### PR TITLE
addons: update Tetrate Istio Distribution addon

### DIFF
--- a/modules/kubernetes-addons/main.tf
+++ b/modules/kubernetes-addons/main.tf
@@ -187,7 +187,7 @@ module "spark_k8s_operator" {
 module "tetrate_istio" {
   count                = var.enable_tetrate_istio ? 1 : 0
   source               = "tetratelabs/tetrate-istio-addon/eksblueprints"
-  version              = "0.0.6"
+  version              = "0.0.7"
   distribution         = var.tetrate_istio_distribution
   distribution_version = var.tetrate_istio_version
   install_base         = var.tetrate_istio_install_base


### PR DESCRIPTION
Signed-off-by: Yaroslav Skopets <yaroslav@tetrate.io>


### What does this PR do?

Bump version of [github.com/tetratelabs/terraform-eksblueprints-tetrate-istio-addon](https://github.com/tetratelabs/terraform-eksblueprints-tetrate-istio-addon).

### Motivation

Update any terraform module references to us [github.com/aws-ia/terraform-aws-eks-blueprints](http://github.com/aws-ia/terraform-aws-eks-blueprints) instead of [github.com/aws-samples/aws-eks-accelerator-for-terraform](http://github.com/aws-samples/aws-eks-accelerator-for-terraform)

### More

- [ ] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-samples/aws-eks-accelerator-for-terraform/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/ssp-eks-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-samples/aws-eks-accelerator-for-terraform/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->

Since new AWS repo [github.com/aws-ia/terraform-aws-eks-blueprints](http://github.com/aws-ia/terraform-aws-eks-blueprints) is not visible to me, I couldn't test the change.