### PR TITLE
Fix/ running ArgoCd example on GovCloud

### DIFF
--- a/docs/add-ons/nginx.md
+++ b/docs/add-ons/nginx.md
@@ -20,7 +20,7 @@ NAME                                                              READY   STATUS
 eks-blueprints-addon-ingress-nginx-78b8567p4q6   1/1     Running   0          4d10h
 ```
 
-Note that the ingress controller is deployed in the `nginx` namespace.
+Note that the ingress controller is deployed in the `ingress-nginx` namespace.
 
 You can optionally customize the Helm chart that deploys `nginx` via the following configuration.
 

--- a/examples/gitops/argocd/main.tf
+++ b/examples/gitops/argocd/main.tf
@@ -175,7 +175,7 @@ module "eks-blueprints-kubernetes-addons" {
   #---------------------------------------------------------------
 
   enable_aws_for_fluentbit            = true
-  enable_aws_load_balancer_controller = false
+  enable_aws_load_balancer_controller = true
   enable_cert_manager                 = true
   enable_cluster_autoscaler           = true
   enable_ingress_nginx                = true

--- a/examples/gitops/argocd/main.tf
+++ b/examples/gitops/argocd/main.tf
@@ -34,7 +34,7 @@ data "aws_eks_cluster_auth" "cluster" {
 }
 
 provider "aws" {
-  region = "us-west-2"
+  region = var.region
   alias  = "default"
 }
 
@@ -175,7 +175,7 @@ module "eks-blueprints-kubernetes-addons" {
   #---------------------------------------------------------------
 
   enable_aws_for_fluentbit            = true
-  enable_aws_load_balancer_controller = true
+  enable_aws_load_balancer_controller = false
   enable_cert_manager                 = true
   enable_cluster_autoscaler           = true
   enable_ingress_nginx                = true

--- a/examples/gitops/argocd/variables.tf
+++ b/examples/gitops/argocd/variables.tf
@@ -21,3 +21,9 @@ variable "zone" {
   description = "zone, e.g. dev or qa or load or ops etc..."
   default     = "dev"
 }
+
+variable "region" {
+  type        = string
+  description = "region in which to deploy the cluster"
+  default     = "us-west-2"
+}

--- a/examples/gitops/argocd/variables.tf
+++ b/examples/gitops/argocd/variables.tf
@@ -18,12 +18,12 @@ variable "environment" {
 
 variable "zone" {
   type        = string
-  description = "zone, e.g. dev or qa or load or ops etc..."
+  description = "Zone, e.g. dev or qa or load or ops etc..."
   default     = "dev"
 }
 
 variable "region" {
   type        = string
-  description = "region in which to deploy the cluster"
+  description = "Region in which to deploy the cluster"
   default     = "us-west-2"
 }

--- a/modules/kubernetes-addons/ingress-nginx/locals.tf
+++ b/modules/kubernetes-addons/ingress-nginx/locals.tf
@@ -1,12 +1,13 @@
 locals {
   name = "ingress-nginx"
+  namespace = "nginx"
 
   default_helm_config = {
     name             = local.name
     chart            = local.name
     repository       = "https://kubernetes.github.io/ingress-nginx"
     version          = "4.0.17"
-    namespace        = local.name
+    namespace        = local.namespace
     create_namespace = false
     values           = local.default_helm_values
     set              = []

--- a/modules/kubernetes-addons/ingress-nginx/locals.tf
+++ b/modules/kubernetes-addons/ingress-nginx/locals.tf
@@ -1,13 +1,12 @@
 locals {
   name = "ingress-nginx"
-  namespace = "nginx"
 
   default_helm_config = {
     name             = local.name
     chart            = local.name
     repository       = "https://kubernetes.github.io/ingress-nginx"
     version          = "4.0.17"
-    namespace        = local.namespace
+    namespace        = local.name
     create_namespace = false
     values           = local.default_helm_values
     set              = []


### PR DESCRIPTION
### What does this PR do?

PR has two changes to enhance the experience of running the [argocd example](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples/gitops/argocd) in govCloud:

- Remove hardcoded region and move it into a variable that can more easily overridden 
- Update the Nginx module to create the `nginx namespace` instead of the `ingress-nginx namespace`. With the old namespace nothing would get created for Nginx beyond an empty namespace and the following error could be seen on Argo cd: 
`Failed sync attempt to c0d70e7b110803dd967c91fec4cba9bd9622bcab: one or more objects failed to apply, reason: namespaces "nginx" not found (retried 1 times).`
Once the correct namespace is created, everything syncs properly and all appropriate resources are created

### Motivation

Testing the ArgoCd example in govcloud to see if gitops would work as expected.


### Additional Notes

For the ArgoCD example to be fully functional, it requires that [PR 381](https://github.com/aws-ia/terraform-aws-eks-blueprints/pull/381) is passed as well to work properly, without that PR the load balancer will fail to deploy.
