### PR TITLE
chore: nginx example to leverage aws load balancer controller

### DIFF
--- a/.github/workflows/e2e-parallel-destroy.yml
+++ b/.github/workflows/e2e-parallel-destroy.yml
@@ -49,6 +49,14 @@ jobs:
             tenant_name: "agones"
           - example_path: examples/ingress-controllers/nginx
             tenant_name: "nginx"
+            deployment_order:
+              [
+                "module.e2e-test.module.aws_vpc",
+                "module.e2e-test.module.eks-blueprints",
+                "module.e2e-test.module.eks-blueprints-kubernetes-addons",
+                "module.e2e-test.module.aws_load_balancer_controller",
+                "module.e2e-test.module.ingress_nginx",
+              ]
           - example_path: examples/karpenter
             tenant_name: "karpenter"
           - example_path: examples/node-groups/managed-node-groups

--- a/.github/workflows/e2e-parallel-full.yml
+++ b/.github/workflows/e2e-parallel-full.yml
@@ -53,6 +53,14 @@ jobs:
             tenant_name: "agones"
           - example_path: examples/ingress-controllers/nginx
             tenant_name: "nginx"
+            deployment_order:
+              [
+                "module.e2e-test.module.aws_vpc",
+                "module.e2e-test.module.eks-blueprints",
+                "module.e2e-test.module.eks-blueprints-kubernetes-addons",
+                "module.e2e-test.module.aws_load_balancer_controller",
+                "module.e2e-test.module.ingress_nginx",
+              ]
           - example_path: examples/karpenter
             tenant_name: "karpenter"
           - example_path: examples/node-groups/managed-node-groups

--- a/examples/ingress-controllers/nginx/README.md
+++ b/examples/ingress-controllers/nginx/README.md
@@ -51,10 +51,10 @@ to create resources
 
 ```shell script
 terraform apply -target="module.aws_vpc"
-terraform apply -target="module.module.eks-blueprints"
-terraform apply -target="module.module.eks-blueprints-kubernetes-addons"
-terraform apply -target="module.module.aws_load_balancer_controller" 
-terraform apply -target="module.module.ingress_nginx" 
+terraform apply -target="module.eks-blueprints"
+terraform apply -target="module.eks-blueprints-kubernetes-addons"
+terraform apply -target="module.aws_load_balancer_controller" 
+terraform apply -target="module.ingress_nginx" 
 ```
 
 Enter `yes` for each apply

--- a/examples/ingress-controllers/nginx/README.md
+++ b/examples/ingress-controllers/nginx/README.md
@@ -117,9 +117,11 @@ terraform apply -target="module.aws_vpc" -auto-approve
 
 | Name | Source | Version |
 |------|--------|---------|
+| <a name="module_aws_load_balancer_controller"></a> [aws\_load\_balancer\_controller](#module\_aws\_load\_balancer\_controller) | ../../../modules/kubernetes-addons | n/a |
 | <a name="module_aws_vpc"></a> [aws\_vpc](#module\_aws\_vpc) | terraform-aws-modules/vpc/aws | v3.2.0 |
 | <a name="module_eks-blueprints"></a> [eks-blueprints](#module\_eks-blueprints) | ../../.. | n/a |
 | <a name="module_eks-blueprints-kubernetes-addons"></a> [eks-blueprints-kubernetes-addons](#module\_eks-blueprints-kubernetes-addons) | ../../../modules/kubernetes-addons | n/a |
+| <a name="module_ingress_nginx"></a> [ingress\_nginx](#module\_ingress\_nginx) | ../../../modules/kubernetes-addons | n/a |
 
 ## Resources
 

--- a/examples/ingress-controllers/nginx/README.md
+++ b/examples/ingress-controllers/nginx/README.md
@@ -1,12 +1,13 @@
 # EKS Cluster Deployment with the nginx add-on enabled
 
-This example deploys the following Basic EKS Cluster with VPC. In AWS we use a Network load balancer (NLB) to expose the NGINX Ingress controller behind a Service of _Type=LoadBalancer_.
+This example deploys the following Basic EKS Cluster with VPC. In AWS we use a Network load balancer (NLB) to expose the NGINX Ingress controller behind a Service of _Type=LoadBalancer_ leveraging AWS Load Balancer Controller (LBC).
 
 - Creates a new sample VPC, 3 Private Subnets and 3 Public Subnets
 - Creates Internet gateway for Public Subnets and NAT Gateway for Private Subnets
 - Creates EKS Cluster Control plane with managed nodes
 - Creates the nginx controller resources; such as an internet facing AWS Network Load Balancer, AWS IAM role and policy
   for the nginx service account, etc.
+  - Nginx controller service is using the LBC annotations to manage the NLB.
 
 ## How to Deploy
 
@@ -49,10 +50,14 @@ terraform plan
 to create resources
 
 ```shell script
-terraform apply
+terraform apply -target="module.aws_vpc"
+terraform apply -target="module.module.eks-blueprints"
+terraform apply -target="module.module.eks-blueprints-kubernetes-addons"
+terraform apply -target="module.module.aws_load_balancer_controller" 
+terraform apply -target="module.module.ingress_nginx" 
 ```
 
-Enter `yes` to apply
+Enter `yes` for each apply
 
 ### Configure `kubectl` and test cluster
 
@@ -85,7 +90,11 @@ The following command destroys the resources created by `terraform apply`
 
 ```shell script
 cd examples/ingress-controllers/nginx
-terraform destroy --auto-approve
+terraform apply -target="module.module.ingress_nginx" -auto-approve
+terraform apply -target="module.module.aws_load_balancer_controller" -auto-approve
+terraform apply -target="module.module.eks-blueprints-kubernetes-addons" -auto-approve
+terraform apply -target="module.module.eks-blueprints" -auto-approve
+terraform apply -target="module.aws_vpc" -auto-approve
 ```
 
 <!--- BEGIN_TF_DOCS --->
@@ -140,4 +149,4 @@ terraform destroy --auto-approve
 
 ## Learn more
 
-Read this blog, [Using a Network Load Balancer with the NGINX Ingress Controller on Amazon EKS](https://aws.amazon.com/blogs/opensource/network-load-balancer-nginx-ingress-controller-eks/).
+Read more about using NLB to expose the NGINX ingress controller using AWS Load Balancer Controller [here](https://kubernetes.github.io/ingress-nginx/deploy/#aws).

--- a/examples/ingress-controllers/nginx/main.tf
+++ b/examples/ingress-controllers/nginx/main.tf
@@ -136,9 +136,23 @@ module "eks-blueprints-kubernetes-addons" {
   #K8s Add-ons
   enable_metrics_server     = true
   enable_cluster_autoscaler = true
-  enable_ingress_nginx      = true
+}
+
+module "aws_load_balancer_controller" {
+  source         = "../../../modules/kubernetes-addons"
+  eks_cluster_id = module.eks-blueprints.eks_cluster_id
+
+  enable_aws_load_balancer_controller = true
+}
+
+module "ingress_nginx" {
+  source         = "../../../modules/kubernetes-addons"
+  eks_cluster_id = module.eks-blueprints.eks_cluster_id
+
+  enable_ingress_nginx = true
 
   ingress_nginx_helm_config = {
     version = "4.0.17"
+    values  = [templatefile("${path.module}/nginx_values.yaml", {})]
   }
 }

--- a/examples/ingress-controllers/nginx/main.tf
+++ b/examples/ingress-controllers/nginx/main.tf
@@ -140,6 +140,6 @@ module "eks-blueprints-kubernetes-addons" {
 
   ingress_nginx_helm_config = {
     version = "4.0.17"
-    values     = [templatefile("${path.module}/values.yaml", {})]
+    values  = [templatefile("${path.module}/values.yaml", {})]
   }
 }

--- a/examples/ingress-controllers/nginx/main.tf
+++ b/examples/ingress-controllers/nginx/main.tf
@@ -140,5 +140,6 @@ module "eks-blueprints-kubernetes-addons" {
 
   ingress_nginx_helm_config = {
     version = "4.0.17"
+    values     = [templatefile("${path.module}/values.yaml", {})]
   }
 }

--- a/examples/ingress-controllers/nginx/main.tf
+++ b/examples/ingress-controllers/nginx/main.tf
@@ -140,6 +140,5 @@ module "eks-blueprints-kubernetes-addons" {
 
   ingress_nginx_helm_config = {
     version = "4.0.17"
-    values  = [templatefile("${path.module}/values.yaml", {})]
   }
 }

--- a/examples/ingress-controllers/nginx/nginx_values.yaml
+++ b/examples/ingress-controllers/nginx/nginx_values.yaml
@@ -1,0 +1,11 @@
+controller:
+  service:
+    externalTrafficPolicy: "Local"
+    annotations:
+      # AWS Load Balancer Controller Annotations
+      service.beta.kubernetes.io/aws-load-balancer-backend-protocol: tcp # or 'ssl'
+      service.beta.kubernetes.io/aws-load-balancer-attributes: load_balancing.cross_zone.enabled=true
+      service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: '60'
+      service.beta.kubernetes.io/aws-load-balancer-type: 'external'
+      service.beta.kubernetes.io/aws-load-balancer-scheme: 'internet-facing' # or 'internal'
+      service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: 'ip'

--- a/examples/ingress-controllers/nginx/values.yaml
+++ b/examples/ingress-controllers/nginx/values.yaml
@@ -1,9 +1,0 @@
-controller:
-  service:
-    externalTrafficPolicy: "Local"
-    annotations:
-      service.beta.kubernetes.io/aws-load-balancer-backend-protocol: tcp
-      service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: '60'
-      service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: 'true'
-      service.beta.kubernetes.io/aws-load-balancer-internal: "false"
-      service.beta.kubernetes.io/aws-load-balancer-type: "nlb"

--- a/examples/ingress-controllers/nginx/values.yaml
+++ b/examples/ingress-controllers/nginx/values.yaml
@@ -1,0 +1,9 @@
+controller:
+  service:
+    externalTrafficPolicy: "Local"
+    annotations:
+      service.beta.kubernetes.io/aws-load-balancer-backend-protocol: tcp
+      service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: '60'
+      service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: 'true'
+      service.beta.kubernetes.io/aws-load-balancer-internal: "false"
+      service.beta.kubernetes.io/aws-load-balancer-type: "nlb"

--- a/modules/kubernetes-addons/ingress-nginx/values.yaml
+++ b/modules/kubernetes-addons/ingress-nginx/values.yaml
@@ -2,10 +2,8 @@ controller:
   service:
     externalTrafficPolicy: "Local"
     annotations:
-      # AWS Load Balancer Controller Annotations
-      service.beta.kubernetes.io/aws-load-balancer-backend-protocol: tcp # or 'ssl'
-      service.beta.kubernetes.io/aws-load-balancer-attributes: load_balancing.cross_zone.enabled=true
+      service.beta.kubernetes.io/aws-load-balancer-backend-protocol: tcp
       service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: '60'
-      service.beta.kubernetes.io/aws-load-balancer-type: 'external'
-      service.beta.kubernetes.io/aws-load-balancer-scheme: 'internet-facing' # or 'internal'
-      service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: 'ip'
+      service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: 'true'
+      service.beta.kubernetes.io/aws-load-balancer-internal: "false"
+      service.beta.kubernetes.io/aws-load-balancer-type: "nlb"

--- a/modules/kubernetes-addons/ingress-nginx/values.yaml
+++ b/modules/kubernetes-addons/ingress-nginx/values.yaml
@@ -1,9 +1,0 @@
-controller:
-  service:
-    externalTrafficPolicy: "Local"
-    annotations:
-      service.beta.kubernetes.io/aws-load-balancer-backend-protocol: tcp
-      service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: '60'
-      service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: 'true'
-      service.beta.kubernetes.io/aws-load-balancer-internal: "false"
-      service.beta.kubernetes.io/aws-load-balancer-type: "nlb"


### PR DESCRIPTION
### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
- remove default values from nginx addon module
- enable AWS load balancer controller (LBC) in nginx example
- LBC to be deployed before nginx, and to be destroyed after nginx to avoid issues that resources are left behind and nginx can't delete namespace properly - see https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/1629
- Adjust example's README 

### Motivation

<!-- What inspired you to submit this pull request? -->
- nginx example failing right now using default annotations of LBC while LBC not being deployed
- Show correct order of deployments instead of single TF apply/destroy to avoid issues where VPC resources deleted before addons/cluster, and for nginx to be deleted before LBC for this example.

### More

- [ ] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
