### PR TITLE
Adds support for HashiCorp Vault

### DIFF
--- a/docs/add-ons/vault.md
+++ b/docs/add-ons/vault.md
@@ -16,11 +16,22 @@ This step deploys the [HashiCorp Vault](https://www.vaultproject.io) with defaul
   enable_vault = true
 ```
 
-Alternatively, you can override the helm values by using the code snippet below
+Alternatively, you can override the helm values by using the code snippet below:
 
 ```hcl
   enable_vault = true
+
+  vault_helm_config = {
+    name       = "vault"                                          # (Required) Release name.
+    chart      = "vault"                                          # (Required) Chart name to be installed.
+    repository = "https://helm.releases.hashicorp.com"            # (Optional) Repository URL where to locate the requested chart.
+    version    = "v0.19.0"                                        # (Optional) Specify the exact chart version to install.
+
+    ...
+  }
 ```
+
+The above snippet does not contain _all_ available options that can be set as part of `vault_helm_config`. For a complete listing, see The [`hashicorp-vault-eks-blueprints-addon` repository](https://github.com/hashicorp/hashicorp-vault-eks-blueprints-addon/blob/main/locals.tf).
 
 ### GitOps Configuration
 

--- a/docs/add-ons/vault.md
+++ b/docs/add-ons/vault.md
@@ -16,7 +16,7 @@ This step deploys the [HashiCorp Vault](https://www.vaultproject.io) with defaul
   enable_vault = true
 ```
 
-Alternatively, you can override the helm values by using the code snippet below:
+Alternatively, you can override the Helm Values by setting the `vault_helm_config` object, like shown in the code snippet below:
 
 ```hcl
   enable_vault = true
@@ -27,11 +27,11 @@ Alternatively, you can override the helm values by using the code snippet below:
     repository = "https://helm.releases.hashicorp.com"            # (Optional) Repository URL where to locate the requested chart.
     version    = "v0.19.0"                                        # (Optional) Specify the exact chart version to install.
 
-    ...
+    # ...
   }
 ```
 
-The above snippet does not contain _all_ available options that can be set as part of `vault_helm_config`. For a complete listing, see The [`hashicorp-vault-eks-blueprints-addon` repository](https://github.com/hashicorp/hashicorp-vault-eks-blueprints-addon/blob/main/locals.tf).
+This snippet does not contain _all_ available options that can be set as part of `vault_helm_config`. For the complete listing, see the [`hashicorp-vault-eks-blueprints-addon` repository](https://github.com/hashicorp/hashicorp-vault-eks-blueprints-addon/blob/main/locals.tf).
 
 ### GitOps Configuration
 

--- a/docs/add-ons/vault.md
+++ b/docs/add-ons/vault.md
@@ -2,11 +2,11 @@
 
 [HashiCorp Vault](https://www.vaultproject.io) brokers and deeply integrates with trusted identities to automate access to secrets, data, and systems.
 
-This add-on is implemented as an external add-on. For detailed documentation and usage of the add-on please refer to the add-on [repository](https://github.com/hashicorp/hashicorp-vault-eks-blueprints-addon).
+This add-on is implemented as an external add-on. For detailed documentation and usage of the add-on please refer to the add-on [repository](https://github.com/hashicorp/terraform-aws-hashicorp-vault-eks-addon).
 
 ## Example
 
-Checkout the full [example](https://github.com/hashicorp/hashicorp-vault-eks-blueprints-addon/tree/main/blueprints/getting-started).
+Checkout the full [example](https://github.com/hashicorp/terraform-aws-hashicorp-vault-eks-addon/tree/main/blueprints/getting-started).
 
 ## Usage
 
@@ -31,4 +31,4 @@ Alternatively, you can override the Helm Values by setting the `vault_helm_confi
   }
 ```
 
-This snippet does not contain _all_ available options that can be set as part of `vault_helm_config`. For the complete listing, see the [`hashicorp-vault-eks-blueprints-addon` repository](https://github.com/hashicorp/hashicorp-vault-eks-blueprints-addon/blob/main/locals.tf).
+This snippet does not contain _all_ available options that can be set as part of `vault_helm_config`. For the complete listing, see the [`hashicorp-vault-eks-blueprints-addon` repository](https://github.com/hashicorp/terraform-aws-hashicorp-vault-eks-addon/blob/main/locals.tf).

--- a/docs/add-ons/vault.md
+++ b/docs/add-ons/vault.md
@@ -1,0 +1,33 @@
+# HashiCorp Vault
+
+[HashiCorp Vault](https://www.vaultproject.io) brokers and deeply integrates with trusted identities to automate access to secrets, data, and systems.
+
+This add-on is implemented as an external add-on. For detailed documentation and usage of the add-on please refer to the add-on [repository](https://github.com/hashicorp/hashicorp-vault-eks-blueprints-addon).
+
+## Example
+
+Checkout the full [example](https://github.com/hashicorp/hashicorp-vault-eks-blueprints-addon/tree/main/blueprints/getting-started).
+
+## Usage
+
+This step deploys the [HashiCorp Vault](https://www.vaultproject.io) with default Helm Chart config
+
+```hcl
+  enable_vault = true
+```
+
+Alternatively, you can override the helm values by using the code snippet below
+
+```hcl
+  enable_vault = true
+```
+
+### GitOps Configuration
+
+The following properties are made available for use when managing the add-on via GitOps
+
+```hcl
+vault = {
+  enable = true
+}
+```

--- a/docs/add-ons/vault.md
+++ b/docs/add-ons/vault.md
@@ -32,13 +32,3 @@ Alternatively, you can override the Helm Values by setting the `vault_helm_confi
 ```
 
 This snippet does not contain _all_ available options that can be set as part of `vault_helm_config`. For the complete listing, see the [`hashicorp-vault-eks-blueprints-addon` repository](https://github.com/hashicorp/hashicorp-vault-eks-blueprints-addon/blob/main/locals.tf).
-
-### GitOps Configuration
-
-The following properties are made available for use when managing the add-on via GitOps
-
-```hcl
-vault = {
-  enable = true
-}
-```

--- a/modules/kubernetes-addons/locals.tf
+++ b/modules/kubernetes-addons/locals.tf
@@ -14,6 +14,7 @@ locals {
     sparkOperator             = var.enable_spark_k8s_operator ? module.spark_k8s_operator[0].argocd_gitops_config : null
     tetrateIstio              = var.enable_tetrate_istio ? module.tetrate_istio[0].argocd_gitops_config : null
     traefik                   = var.enable_traefik ? module.traefik[0].argocd_gitops_config : null
+    vault                     = var.enable_vault ? module.vault[0].argocd_gitops_config : null
     vpa                       = var.enable_vpa ? module.vpa[0].argocd_gitops_config : null
     yunikorn                  = var.enable_yunikorn ? module.yunikorn[0].argocd_gitops_config : null
     argoRollouts              = var.enable_argo_rollouts ? module.argo_rollouts[0].argocd_gitops_config : null

--- a/modules/kubernetes-addons/main.tf
+++ b/modules/kubernetes-addons/main.tf
@@ -234,8 +234,9 @@ module "traefik" {
 }
 
 module "vault" {
-  source  = "hashicorp/hashicorp-vault-eks-blueprints-addon/aws"
   count = var.enable_vault ? 1 : 0
+
+  source  = "hashicorp/hashicorp-vault-eks-addon/aws"
   helm_config       = var.vault_helm_config
   manage_via_gitops = var.argocd_manage_add_ons
   addon_context     = local.addon_context

--- a/modules/kubernetes-addons/main.tf
+++ b/modules/kubernetes-addons/main.tf
@@ -235,6 +235,7 @@ module "traefik" {
 
 module "vault" {
   count  = var.enable_vault ? 1 : 0
+  source  = "hashicorp/hashicorp-vault-eks-blueprints-addon/aws"
   helm_config       = var.vault_helm_config
   manage_via_gitops = var.argocd_manage_add_ons
   addon_context     = local.addon_context

--- a/modules/kubernetes-addons/main.tf
+++ b/modules/kubernetes-addons/main.tf
@@ -236,7 +236,10 @@ module "traefik" {
 module "vault" {
   count = var.enable_vault ? 1 : 0
 
+  # See https://registry.terraform.io/modules/hashicorp/hashicorp-vault-eks-addon/aws/
   source  = "hashicorp/hashicorp-vault-eks-addon/aws"
+  version = "0.9.0"
+
   helm_config       = var.vault_helm_config
   manage_via_gitops = var.argocd_manage_add_ons
   addon_context     = local.addon_context

--- a/modules/kubernetes-addons/main.tf
+++ b/modules/kubernetes-addons/main.tf
@@ -233,6 +233,13 @@ module "traefik" {
   addon_context     = local.addon_context
 }
 
+module "vault" {
+  count  = var.enable_vault ? 1 : 0
+  helm_config       = var.vault_helm_config
+  manage_via_gitops = var.argocd_manage_add_ons
+  addon_context     = local.addon_context
+}
+
 module "vpa" {
   count             = var.enable_vpa ? 1 : 0
   source            = "./vpa"

--- a/modules/kubernetes-addons/main.tf
+++ b/modules/kubernetes-addons/main.tf
@@ -234,8 +234,8 @@ module "traefik" {
 }
 
 module "vault" {
-  count  = var.enable_vault ? 1 : 0
   source  = "hashicorp/hashicorp-vault-eks-blueprints-addon/aws"
+  count = var.enable_vault ? 1 : 0
   helm_config       = var.vault_helm_config
   manage_via_gitops = var.argocd_manage_add_ons
   addon_context     = local.addon_context

--- a/modules/kubernetes-addons/variables.tf
+++ b/modules/kubernetes-addons/variables.tf
@@ -547,6 +547,12 @@ variable "keda_irsa_permissions_boundary" {
   description = "IAM Policy ARN for IRSA IAM role permissions boundary"
 }
 
+#-----------HashiCorp Vault-------------
+variable "enable_vault" {
+  type        = bool
+  default     = false
+  description = "Enable HashiCorp Vault add-on"
+}
 #------Vertical Pod Autoscaler(VPA) ADDON--------
 variable "enable_vpa" {
   type        = bool

--- a/modules/kubernetes-addons/variables.tf
+++ b/modules/kubernetes-addons/variables.tf
@@ -553,6 +553,13 @@ variable "enable_vault" {
   default     = false
   description = "Enable HashiCorp Vault add-on"
 }
+
+variable "vault_helm_config" {
+  type        = any
+  default     = null
+  description = "HashiCorp Vault Helm Chart config"
+}
+
 #------Vertical Pod Autoscaler(VPA) ADDON--------
 variable "enable_vpa" {
   type        = bool


### PR DESCRIPTION
Hello maintainers 👋🏼 - adding this as draft while we get the final bits and pieces in places.

---

### What does this PR do?

This PR adds a reference to the HashiCorp Vault blueprint. 

### Motivation

We love EKS and believe we should make it easier to manage and protect secrets (and sensitive data, in general) in an EKS workflow.

### More

- [X] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [X] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR

> As we are adding an external add-on, our example code lives in the external repository.

- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)

> Not applicable.

- [X] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [X] Yes, I ran `pre-commit run -a` with this PR

**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
