### PR TITLE
docs: Add GitHub action to run checks on Markdown content during pull-request

### DIFF
--- a/.github/.markdownlint.yaml
+++ b/.github/.markdownlint.yaml
@@ -1,0 +1,3 @@
+# https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md#rules
+MD013:
+  line_length: 120

--- a/.github/workflows/markdown-lint.yaml
+++ b/.github/workflows/markdown-lint.yaml
@@ -1,0 +1,20 @@
+name: markdown-lint
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  lint-changelog:
+    name: Markdown lint
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Markdown linter
+      uses: avto-dev/markdown-lint@v1
+      with:
+        config: '.github/.markdownlint.yaml'
+        args: '**/*.md'


### PR DESCRIPTION
### What does this PR do?
- Add GitHub action to run checks on Markdown content during pull-request
	- You can see it in action here https://github.com/bryantbiggs/boop/pull/1 (after merge I can follow up with a PR to resolve the linting issues its caught)

### Motivation
- Keep things in check to avoid changes with lots of whitespace noise due to formatting (https://github.com/aws-ia/terraform-aws-eks-blueprints/pull/424)

### More

- [ ] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR

**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
