### PR TITLE
bug(addon): typo in gitops config for external-dns

### DIFF
--- a/modules/kubernetes-addons/external-dns/locals.tf
+++ b/modules/kubernetes-addons/external-dns/locals.tf
@@ -43,8 +43,8 @@ locals {
   }
 
   argocd_gitops_config = {
-    enable            = true
-    zoneFilterIds     = local.zone_filter_ids
-    serviceAccontName = local.service_account_name
+    enable             = true
+    zoneFilterIds      = local.zone_filter_ids
+    serviceAccountName = local.service_account_name
   }
 }


### PR DESCRIPTION
### What does this PR do?

Typo in argocd config for external-dns.


### Motivation

<!-- What inspired you to submit this pull request? -->


### More

- [ ] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
