### PR TITLE
Update getting-started.md

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -139,11 +139,11 @@ terraform destroy -target="module.eks_blueprints_kubernetes_addons"
 Destroy the EKS cluster. 
 
 ```
-terraform apply -target="module.eks_blueprints"
+terraform destroy -target="module.eks_blueprints"
 ```
 
 Destroy the VPC.
 
 ```
-terraform apply -target="module.aws_vpc"
+terraform destroy -target="module.aws_vpc"
 ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -73,7 +73,7 @@ terraform apply -target="module.eks_blueprints_kubernetes_addons"
 
 ## Configure kubectl
 
-Terraform output will display a command in your consolde that you can use to bootstrap your local `kubeconfig`. 
+Terraform output will display a command in your console that you can use to bootstrap your local `kubeconfig`. 
 
 ```
 configure_kubectl = "aws eks --region <region> update-kubeconfig --name <cluster-name>"


### PR DESCRIPTION
Removing typos 
- name from consolde to console
- CleanUp commands for EKS cluster and VPC should have terraform destroy in place of terraform apply

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
Making changes in the Docs. The getting started had a small typo. Just changed it and made a pull request.

### Motivation

<!-- What inspired you to submit this pull request? -->


### More

- [ ] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ yes] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
