### PR TITLE
fix: re-add lb controller nginx example

### DIFF
--- a/examples/ingress-controllers/nginx/README.md
+++ b/examples/ingress-controllers/nginx/README.md
@@ -117,9 +117,11 @@ terraform destroy -target="module.aws_vpc" -auto-approve
 
 | Name | Source | Version |
 |------|--------|---------|
+| <a name="module_aws_load_balancer_controller"></a> [aws\_load\_balancer\_controller](#module\_aws\_load\_balancer\_controller) | ../../../modules/kubernetes-addons | n/a |
 | <a name="module_aws_vpc"></a> [aws\_vpc](#module\_aws\_vpc) | terraform-aws-modules/vpc/aws | v3.2.0 |
 | <a name="module_eks-blueprints"></a> [eks-blueprints](#module\_eks-blueprints) | ../../.. | n/a |
 | <a name="module_eks-blueprints-kubernetes-addons"></a> [eks-blueprints-kubernetes-addons](#module\_eks-blueprints-kubernetes-addons) | ../../../modules/kubernetes-addons | n/a |
+| <a name="module_ingress_nginx"></a> [ingress\_nginx](#module\_ingress\_nginx) | ../../../modules/kubernetes-addons | n/a |
 
 ## Resources
 

--- a/examples/ingress-controllers/nginx/README.md
+++ b/examples/ingress-controllers/nginx/README.md
@@ -90,11 +90,11 @@ The following command destroys the resources created by `terraform apply`
 
 ```shell script
 cd examples/ingress-controllers/nginx
-terraform apply -target="module.module.ingress_nginx" -auto-approve
-terraform apply -target="module.module.aws_load_balancer_controller" -auto-approve
-terraform apply -target="module.module.eks-blueprints-kubernetes-addons" -auto-approve
-terraform apply -target="module.module.eks-blueprints" -auto-approve
-terraform apply -target="module.aws_vpc" -auto-approve
+terraform destroy -target="module.module.ingress_nginx" -auto-approve
+terraform destroy -target="module.module.aws_load_balancer_controller" -auto-approve
+terraform destroy -target="module.module.eks-blueprints-kubernetes-addons" -auto-approve
+terraform destroy -target="module.module.eks-blueprints" -auto-approve
+terraform destroy -target="module.aws_vpc" -auto-approve
 ```
 
 <!--- BEGIN_TF_DOCS --->

--- a/examples/ingress-controllers/nginx/main.tf
+++ b/examples/ingress-controllers/nginx/main.tf
@@ -136,6 +136,18 @@ module "eks-blueprints-kubernetes-addons" {
   #K8s Add-ons
   enable_metrics_server     = true
   enable_cluster_autoscaler = true
+}
+
+module "aws_load_balancer_controller" {
+  source         = "../../../modules/kubernetes-addons"
+  eks_cluster_id = module.eks-blueprints.eks_cluster_id
+
+  enable_aws_load_balancer_controller = true
+}
+
+module "ingress_nginx" {
+  source         = "../../../modules/kubernetes-addons"
+  eks_cluster_id = module.eks-blueprints.eks_cluster_id
 
   enable_ingress_nginx = true
   ingress_nginx_helm_config = {


### PR DESCRIPTION
### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
- re-adds AWS lb controller to the nginx example 
- fix nginx example README to use correct cli command for TF destroy
- 
### Motivation

<!-- What inspired you to submit this pull request? -->
- part of PR and commit in https://github.com/aws-ia/terraform-aws-eks-blueprints/commit/bdeef58bb58b49ea18ffbba742ad6c8eeabe050f#diff-fcdd8d00f7a7978adb63eea56e712bf41b4ddf153bf7b76d1c68d82e80dcd895L139-L150 was done by a mistake and should be reverted.

### More

- [ ] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
