### PR TITLE
Comment out harcoded region names in windows node group example

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 Welcome to Amazon EKS Blueprints for Terraform!
 
-This repository contains a collection of Terraform modules that aim to make it easier and faster for customers to adopt [Amazon EKS](https://aws.amazon.com/eks/). It can be used by AWS customers, partners, and internal AWS teams to configure and manage complete EKS clusters that are fully bootstrapped with the operational software that is needed to deploy and operate workloads. 
+This repository contains a collection of Terraform modules that aim to make it easier and faster for customers to adopt [Amazon EKS](https://aws.amazon.com/eks/). It can be used by AWS customers, partners, and internal AWS teams to configure and manage complete EKS clusters that are fully bootstrapped with the operational software that is needed to deploy and operate workloads.
 
 This project leverages the community [terraform-aws-eks](https://github.com/terraform-aws-modules/terraform-aws-eks) modules for deploying EKS Clusters.
 
@@ -90,13 +90,13 @@ This includes Amazon Managed Prometheus and EMR on EKS. For complete documentati
 
 ## Motivation
 
-Kubernetes is a powerful and extensible container orchestration technology that allows you to deploy and manage containerized applications at scale. The extensible nature of Kubernetes also allows you to use a wide range of popular open-source tools, commonly referred to as add-ons, in Kubernetes clusters. With such a large number of tooling and design choices available however, building a tailored EKS cluster that meets your application’s specific needs can take a significant amount of time. It involves integrating a wide range of open-source tools and AWS services and requires deep expertise in AWS and Kubernetes. 
+Kubernetes is a powerful and extensible container orchestration technology that allows you to deploy and manage containerized applications at scale. The extensible nature of Kubernetes also allows you to use a wide range of popular open-source tools, commonly referred to as add-ons, in Kubernetes clusters. With such a large number of tooling and design choices available however, building a tailored EKS cluster that meets your application’s specific needs can take a significant amount of time. It involves integrating a wide range of open-source tools and AWS services and requires deep expertise in AWS and Kubernetes.
 
 AWS customers have asked for examples that demonstrate how to integrate the landscape of Kubernetes tools and make it easy for them to provision complete, opinionated EKS clusters that meet specific application requirements. Customers can use EKS Blueprints to configure and deploy purpose built EKS clusters, and start onboarding workloads in days, rather than months.
 
 ## Support & Feedback
 
-EKS Blueprints for Terraform is maintained by AWS Solution Architects. It is not part of an AWS service and support is provided best-effort by the EKS Blueprints community. 
+EKS Blueprints for Terraform is maintained by AWS Solution Architects. It is not part of an AWS service and support is provided best-effort by the EKS Blueprints community.
 
 To post feedback, submit feature ideas, or report bugs, please use the [Issues section](https://github.com/aws-ia/terraform-aws-eks-blueprints/issues) of this GitHub repo.
 

--- a/docs/add-ons/index.md
+++ b/docs/add-ons/index.md
@@ -55,7 +55,7 @@ module "eks_blueprints_kubernetes_addons" {
   cluster_id                    = <EKS-CLUSTER-ID>
 
   # EKS Addons
-  
+
   enable_amazon_eks_aws_ebs_csi_driver  = true
   enable_amazon_eks_coredns             = true
   enable_amazon_eks_kube_proxy          = true

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -51,9 +51,9 @@ terraform plan
 
 ### Terraform APPLY
 
-We will leverage Terraform's [target](https://learn.hashicorp.com/tutorials/terraform/resource-targeting?in=terraform/cli) functionality to deploy a VPC, an EKS Cluster, and Kubernetes add-ons in separate steps. 
+We will leverage Terraform's [target](https://learn.hashicorp.com/tutorials/terraform/resource-targeting?in=terraform/cli) functionality to deploy a VPC, an EKS Cluster, and Kubernetes add-ons in separate steps.
 
-**Deploy the VPC**. This step will take roughly 3 minutes to complete. 
+**Deploy the VPC**. This step will take roughly 3 minutes to complete.
 
 ```
 terraform apply -target="module.aws_vpc"
@@ -73,7 +73,7 @@ terraform apply -target="module.eks_blueprints_kubernetes_addons"
 
 ## Configure kubectl
 
-Terraform output will display a command in your consolde that you can use to bootstrap your local `kubeconfig`. 
+Terraform output will display a command in your consolde that you can use to bootstrap your local `kubeconfig`.
 
 ```
 configure_kubectl = "aws eks --region <region> update-kubeconfig --name <cluster-name>"
@@ -126,17 +126,17 @@ kube-proxy-zl7cj                                            1/1     Running   1 
 metrics-server-694d47d564-hzd8h                             1/1     Running   1          15m
 ```
 
-## Cleanup 
+## Cleanup
 
 To clean up your environment, destroy the Terraform modules in reverse order.
 
-Destroy the add-ons. 
+Destroy the add-ons.
 
 ```
 terraform destroy -target="module.eks_blueprints_kubernetes_addons"
 ```
 
-Destroy the EKS cluster. 
+Destroy the EKS cluster.
 
 ```
 terraform apply -target="module.eks_blueprints"

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -73,7 +73,7 @@ terraform apply -target="module.eks_blueprints_kubernetes_addons"
 
 ## Configure kubectl
 
-Terraform output will display a command in your console that you can use to bootstrap your local `kubeconfig`. 
+Terraform output will display a command in your console that you can use to bootstrap your local `kubeconfig`.
 
 ```
 configure_kubectl = "aws eks --region <region> update-kubeconfig --name <cluster-name>"

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,9 +4,9 @@
 
 Welcome to Amazon EKS Blueprints for Terraform!
 
-This repository contains a collection of Terraform modules that aim to make it easier and faster for customers to adopt [Amazon EKS](https://aws.amazon.com/eks/). 
+This repository contains a collection of Terraform modules that aim to make it easier and faster for customers to adopt [Amazon EKS](https://aws.amazon.com/eks/).
 
-## WHat is EKS Blueprints 
+## WHat is EKS Blueprints
 
 EKS Blueprints helps you compose complete EKS clusters that are fully bootstrapped with the operational software that is needed to deploy and operate workloads. With EKS Blueprints, you describe the configuration for the desired state of your EKS environment, such as the control plane, worker nodes, and Kubernetes add-ons, as an IaC blueprint. Once a blueprint is configured, you can use it to stamp out consistent environments across multiple AWS accounts and Regions using continuous deployment automation.
 
@@ -18,7 +18,7 @@ To view a library of examples for how you can leverage the terraform-eks-bluepri
 
 ## Motivation
 
-Kubernetes is a powerful and extensible container orchestration technology that allows you to deploy and manage containerized applications at scale. The extensible nature of Kubernetes also allows you to use a wide range of popular open-source tools, commonly referred to as add-ons, in Kubernetes clusters. With such a large number of tooling and design choices available however, building a tailored EKS cluster that meets your application’s specific needs can take a significant amount of time. It involves integrating a wide range of open-source tools and AWS services and requires deep expertise in AWS and Kubernetes. 
+Kubernetes is a powerful and extensible container orchestration technology that allows you to deploy and manage containerized applications at scale. The extensible nature of Kubernetes also allows you to use a wide range of popular open-source tools, commonly referred to as add-ons, in Kubernetes clusters. With such a large number of tooling and design choices available however, building a tailored EKS cluster that meets your application’s specific needs can take a significant amount of time. It involves integrating a wide range of open-source tools and AWS services and requires deep expertise in AWS and Kubernetes.
 
 AWS customers have asked for examples that demonstrate how to integrate the landscape of Kubernetes tools and make it easy for them to provision complete, batteries-included EKS clusters that meet specific application requirements. EKS Blueprints was built to address this customer need. You can use EKS Blueprints to configure and deploy purpose built EKS clusters, and start onboarding workloads in days, rather than months.
 

--- a/docs/teams.md
+++ b/docs/teams.md
@@ -14,7 +14,7 @@ To create an `application_team` for your cluster, you will need to supply a team
 
 **NOTE:** When the manifests are applied, namespaces are not checked. Therefore, you are responsible for namespace settings in the yaml files.
 
-> As of today (2020-05-01), resource `kubernetes_manifest` can only be used (`terraform plan/apply...`) only after the cluster has been created and the cluster API can be accessed. Read ["Before you use this resource"](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/manifest#before-you-use-this-resource) section for more information. 
+> As of today (2020-05-01), resource `kubernetes_manifest` can only be used (`terraform plan/apply...`) only after the cluster has been created and the cluster API can be accessed. Read ["Before you use this resource"](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/manifest#before-you-use-this-resource) section for more information.
 
 To overcome this limitation, you can add/enable `manifests_dir` after you applied and created the cluster first. We are working on a better solution for this.
 

--- a/examples/node-groups/windows-node-groups/main.tf
+++ b/examples/node-groups/windows-node-groups/main.tf
@@ -31,10 +31,10 @@ data "aws_availability_zones" "available" {
   # Specify AZs to avoid EKS cluster creation error due to reduced capacity in an AZ.
   # Change the AZ names per capacity available in the region you selected.
   # https://aws.amazon.com/premiumsupport/knowledge-center/eks-cluster-creation-errors/
-  filter {
-    name   = "zone-name"
-    values = ["us-west-2a", "us-west-2b", "us-west-2c"]
-  }
+  # filter {
+  #   name   = "zone-name"
+  #   values = ["us-west-2a", "us-west-2b", "us-west-2c"]
+  # }
 }
 
 data "aws_eks_cluster" "cluster" {


### PR DESCRIPTION
### What does this PR do?

This PR makes the example under `examples/node-group/windows-node-groups` compatible with different regions. It does this by commenting-out the filter statement in the availability zone data source that used hardcoded `us-west-2*` AZs. Otherwise this example fails out of the box in regions other than us-west-2.

The filter statement exists to show how to deal with the issue here: https://aws.amazon.com/premiumsupport/knowledge-center/eks-cluster-creation-errors/ so I opted to comment it out instead of removing it entirely so we don't lose that knowledge.

This PR also includes some formatting updates caught by running pre-commit.

### More

- [x] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

Tested both in us-west-2 and GovCloud.
