### PR TITLE
Update core-concepts.md: fix link code block

### DIFF
--- a/docs/core-concepts.md
+++ b/docs/core-concepts.md
@@ -34,4 +34,4 @@ See our [`Teams`](./teams) documentation page for detailed information.
 
 `Applications` represent the actual workloads that run within a Kubernetes cluster. The framework leverages a GitOps approach for deploying applications onto clusters.
 
-See our [`Applications](https://aws-ia.github.io/terraform-aws-eks-blueprints/add-ons/argocd/#boostrapping) documentation for detailed information.
+See our [`Applications`](https://aws-ia.github.io/terraform-aws-eks-blueprints/add-ons/argocd/#boostrapping) documentation for detailed information.


### PR DESCRIPTION
### What does this PR do?

Add missing backtick to properly set the code block styling on the link to the "Applications" page.

### Motivation


### More

- [ ] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
