### PR TITLE
Remove enable_amazon_eks_vpc_cni from examples

### DIFF
--- a/examples/aws-efs-csi-driver/main.tf
+++ b/examples/aws-efs-csi-driver/main.tf
@@ -153,7 +153,6 @@ module "eks-blueprints-kubernetes-addons" {
   eks_cluster_id = module.eks-blueprints.eks_cluster_id
 
   # EKS Managed Add-ons
-  enable_amazon_eks_vpc_cni    = true
   enable_amazon_eks_coredns    = true
   enable_amazon_eks_kube_proxy = true
 

--- a/examples/eks-cluster-with-import-vpc/eks/main.tf
+++ b/examples/eks-cluster-with-import-vpc/eks/main.tf
@@ -115,7 +115,6 @@ module "eks-blueprints-kubernetes-addons" {
   eks_worker_security_group_id = module.eks-blueprints.worker_node_security_group_id
 
   # EKS Managed Add-ons
-  enable_amazon_eks_vpc_cni            = true
   enable_amazon_eks_coredns            = true
   enable_amazon_eks_kube_proxy         = true
   enable_amazon_eks_aws_ebs_csi_driver = true

--- a/examples/eks-cluster-with-new-vpc/main.tf
+++ b/examples/eks-cluster-with-new-vpc/main.tf
@@ -127,7 +127,6 @@ module "eks_blueprints_kubernetes_addons" {
   eks_cluster_id = module.eks_blueprints.eks_cluster_id
 
   # EKS Managed Add-ons
-  enable_amazon_eks_vpc_cni    = true
   enable_amazon_eks_coredns    = true
   enable_amazon_eks_kube_proxy = true
 

--- a/examples/ingress-controllers/nginx/main.tf
+++ b/examples/ingress-controllers/nginx/main.tf
@@ -129,7 +129,6 @@ module "eks-blueprints-kubernetes-addons" {
   eks_cluster_id = module.eks-blueprints.eks_cluster_id
 
   # EKS Managed Add-ons
-  enable_amazon_eks_vpc_cni    = true
   enable_amazon_eks_coredns    = true
   enable_amazon_eks_kube_proxy = true
 

--- a/examples/ipv6-eks-cluster/main.tf
+++ b/examples/ipv6-eks-cluster/main.tf
@@ -142,7 +142,6 @@ module "eks-blueprints-kubernetes-addons" {
   enable_ipv6    = true # Enable Ipv6 network. Attaches new VPC CNI policy to the IRSA role
 
   # EKS Managed Add-ons
-  enable_amazon_eks_vpc_cni    = true
   enable_amazon_eks_coredns    = true
   enable_amazon_eks_kube_proxy = true
 

--- a/examples/node-groups/windows-node-groups/main.tf
+++ b/examples/node-groups/windows-node-groups/main.tf
@@ -160,7 +160,6 @@ module "eks-blueprints-kubernetes-addons" {
   eks_cluster_id = module.eks-blueprints.eks_cluster_id
 
   # EKS Managed Add-ons
-  enable_amazon_eks_vpc_cni    = true
   enable_amazon_eks_coredns    = true
   enable_amazon_eks_kube_proxy = true
 


### PR DESCRIPTION
### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
- Removes `enable_amazon_eks_vpc_cni` from most examples

### Motivation
- Assist with the [known issues](https://github.com/aws-ia/terraform-aws-eks-blueprints/blob/main/KNOWN_ISSUES.md#timeouts-on-destroy) around VPC CNI where ENIs are not being deleted, the default behavior when `enable_amazon_eks_vpc_cni` is that EKS will deploy the VPC CNI but customer may not be able to customize it, for most of the default examples this is not required, however if users would like to customize they can follow the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/blob/main/docs/add-ons/managed-add-ons.md).
- When VPC CNI is deployed by default, this allows a smoother experience when TF destroy executed by the user in the correct order, example:
 ```
terraform destroy -target="module.eks-blueprints-kubernetes-addons" -auto-approve
sleep 45
terraform destroy -target="module.eks-blueprints" -auto-approve
terraform destroy -target="module.aws_vpc" -auto-approve
```
### Why adding a delay is recommended?
VPC CNI may not be able to handle all deletion (detach and delete) ENIs in a matter of time user may end up with error messages like:
```
{"level":"debug","ts":"2022-04-26T17:52:52.446Z","caller":"datastore/data_store.go:1048","msg":"ENI eni-XXXXXXXXX cannot be deleted because has IPs in cooling"}
```
the ENIs wont be deleted since the IPs will be in cool down after pods are deleted, can read more about it [here](https://github.com/aws/amazon-vpc-cni-k8s/blob/master/docs/cni-proposal.md#pod-ip-address-cooling-period)


<!-- What inspired you to submit this pull request? -->


### More

- [ ] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
