### PR TITLE
Freeze eks_key admin ARNs order

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -84,13 +84,13 @@ data "aws_iam_policy_document" "eks_key" {
 
     principals {
       type = "AWS"
-      identifiers = concat(
+      identifiers = tolist(toset(concat(
         var.cluster_kms_key_additional_admin_arns,
         [
           "arn:${local.context.aws_partition_id}:iam::${local.context.aws_caller_identity_account_id}:role/${local.cluster_iam_role_name}",
           data.aws_iam_session_context.current.issuer_arn
         ]
-      )
+      )))
     }
   }
 


### PR DESCRIPTION
The last element of ARNs list in "Allow access for Key Administrators" statement in `aws_iam_policy_document.eks_key` depends on who is running the `terraform apply`, and it causes updating of this policy on each run by different user.


### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->


### Motivation

<!-- What inspired you to submit this pull request? -->


### More

- [ ] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
