### PR TITLE
fix: data eks readiness variable, increase timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ If you are interested in contributing to EKS Blueprints, see the [Contribution g
 | <a name="input_create_eks"></a> [create\_eks](#input\_create\_eks) | Create EKS cluster | `bool` | `true` | no |
 | <a name="input_create_node_security_group"></a> [create\_node\_security\_group](#input\_create\_node\_security\_group) | Determines whether to create a security group for the node groups or use the existing `node_security_group_id` | `bool` | `true` | no |
 | <a name="input_custom_oidc_thumbprints"></a> [custom\_oidc\_thumbprints](#input\_custom\_oidc\_thumbprints) | Additional list of server certificate thumbprints for the OpenID Connect (OIDC) identity provider's server certificate(s) | `list(string)` | `[]` | no |
+| <a name="input_eks_readiness_timeout"></a> [eks\_readiness\_timeout](#input\_eks\_readiness\_timeout) | The maximum time (in seconds) to wait for EKS API server endpoint to become healthy | `number` | `"600"` | no |
 | <a name="input_emr_on_eks_teams"></a> [emr\_on\_eks\_teams](#input\_emr\_on\_eks\_teams) | EMR on EKS Teams config | `any` | `{}` | no |
 | <a name="input_enable_amazon_prometheus"></a> [enable\_amazon\_prometheus](#input\_enable\_amazon\_prometheus) | Enable AWS Managed Prometheus service | `bool` | `false` | no |
 | <a name="input_enable_emr_on_eks"></a> [enable\_emr\_on\_eks](#input\_enable\_emr\_on\_eks) | Enable EMR on EKS | `bool` | `false` | no |

--- a/data.tf
+++ b/data.tf
@@ -14,7 +14,7 @@ data "http" "eks_cluster_readiness" {
 
   url            = join("/", [data.aws_eks_cluster.cluster[0].endpoint, "healthz"])
   ca_certificate = base64decode(data.aws_eks_cluster.cluster[0].certificate_authority[0].data)
-  timeout        = 300
+  timeout        = var.eks_readiness_timeout
 }
 
 data "aws_iam_session_context" "current" {

--- a/variables.tf
+++ b/variables.tf
@@ -335,6 +335,12 @@ variable "aws_auth_additional_labels" {
   type        = map(string)
 }
 
+variable "eks_readiness_timeout" {
+  description = "The maximum time (in seconds) to wait for EKS API server endpoint to become healthy"
+  type        = number
+  default     = "600"
+}
+
 #-------------------------------
 # Amazon Managed Prometheus
 #-------------------------------


### PR DESCRIPTION
### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
- timeout of eks readiness as TF variable instead of hard coded. 
- increase default timeout to 10 minutes instead of 5 minutes. 

### Motivation

<!-- What inspired you to submit this pull request? -->
- Closes #449

### More

- [ ] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
