### PR TITLE
fix: enable vpc cni for ipv6 example

### DIFF
--- a/examples/ipv6-eks-cluster/README.md
+++ b/examples/ipv6-eks-cluster/README.md
@@ -57,7 +57,7 @@ Enter `yes` to apply
 #### Step 5: Verify EC2 instances running with IPv6 support
 
 ```shell script
-aws ec2 describe-instances --filters "Name=tag:eks:cluster-name,Values=aws-preprod-cplane-eks" --query "Reservations[].Instances[? State.Name == 'running' ][].NetworkInterfaces[].Ipv6Addresses" --output table
+aws ec2 describe-instances --filters "Name=tag:eks:cluster-name,Values=ipv6-preprod-dev-eks" --query "Reservations[].Instances[? State.Name == 'running' ][].NetworkInterfaces[].Ipv6Addresses" --output table
 ```
 
 ### Configure `kubectl` and test cluster

--- a/examples/ipv6-eks-cluster/main.tf
+++ b/examples/ipv6-eks-cluster/main.tf
@@ -119,6 +119,7 @@ module "eks_blueprints_kubernetes_addons" {
   # EKS Managed Add-ons
   enable_amazon_eks_coredns    = true
   enable_amazon_eks_kube_proxy = true
+  enable_amazon_eks_vpc_cni    = true
 
   #K8s Add-ons
   enable_aws_load_balancer_controller = true


### PR DESCRIPTION
### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
- setting `enable_amazon_eks_vpc_cni` to true 
- fixing cluster name value in README

### Motivation
- example is failing to deploy without having `enable_amazon_eks_vpc_cni` set to true as it needs to be set for `enable_ipv6` variable.
- README had incorrect cluster name for the AWS CLI command.
<!-- What inspired you to submit this pull request? -->


### More

- [ ] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
