### PR TITLE
Add preserve for EKS Managed Addons

### DIFF
--- a/docs/add-ons/managed-add-ons.md
+++ b/docs/add-ons/managed-add-ons.md
@@ -71,7 +71,7 @@ Checkout this [doc](https://docs.aws.amazon.com/eks/latest/userguide/managing-vp
     addon_version            = "v1.4.0-eksbuild.preview"
     service_account          = "ebs-csi-controller-sa"
     resolve_conflicts        = "OVERWRITE"
-    namespace                = "kube-system"       
+    namespace                = "kube-system"
     additional_iam_policies  = []
     service_account_role_arn = ""
     tags                     = {}

--- a/docs/add-ons/managed-add-ons.md
+++ b/docs/add-ons/managed-add-ons.md
@@ -23,8 +23,9 @@ EKS managed add-ons can be enabled via the following.
     service_account          = "aws-node"
     resolve_conflicts        = "OVERWRITE"
     namespace                = "kube-system"
-    additional_iam_policies  = []
     service_account_role_arn = ""
+    preserve                 = true # This option makes the add-on a self-managed add-on, rather than an Amazon EKS add-on. There is no downtime for the add-on.
+    additional_iam_policies  = []
     tags                     = {}
   }
 
@@ -37,6 +38,7 @@ EKS managed add-ons can be enabled via the following.
     resolve_conflicts        = "OVERWRITE"
     namespace                = "kube-system"
     service_account_role_arn = ""
+    preserve                 = true # This option makes the add-on a self-managed add-on, rather than an Amazon EKS add-on. There is no downtime for the add-on.
     additional_iam_policies  = []
     tags                     = {}
   }
@@ -49,8 +51,9 @@ EKS managed add-ons can be enabled via the following.
     service_account          = "kube-proxy"
     resolve_conflicts        = "OVERWRITE"
     namespace                = "kube-system"
-    additional_iam_policies  = []
     service_account_role_arn = ""
+    preserve                 = true # This option makes the add-on a self-managed add-on, rather than an Amazon EKS add-on. There is no downtime for the add-on.
+    additional_iam_policies  = []
     tags                     = {}
   }
 

--- a/docs/add-ons/managed-add-ons.md
+++ b/docs/add-ons/managed-add-ons.md
@@ -11,7 +11,14 @@ EKS currently provides support for the following managed add-ons.
 | [kube-proxy](https://docs.aws.amazon.com/eks/latest/userguide/managing-kube-proxy.html) | Enables network communication to your pods. |
 | [Amazon EBS CSI](https://docs.aws.amazon.com/eks/latest/userguide/managing-ebs-csi.html) | Manage the Amazon EBS CSI driver as an Amazon EKS add-on. |
 
-EKS managed add-ons can be enabled via the following.
+EKS managed add-ons can be enabled via the following. 
+
+Note: EKS managed Add-ons can be converted to self-managed add-on with `preserve` field.
+`preserve=true` option removes Amazon EKS management of any settings and the ability for Amazon EKS to notify you of updates and automatically update the Amazon EKS add-on after you initiate an update, but preserves the add-on's software on your cluster. 
+This option makes the add-on a self-managed add-on, rather than an Amazon EKS add-on. 
+There is no downtime while deleting EKS managed Add-ons when `preserve=true`. This is a default option for `enable_amazon_eks_vpc_cni` , `enable_amazon_eks_coredns` and `enable_amazon_eks_kube_proxy`.
+
+Checkout this [doc](https://docs.aws.amazon.com/eks/latest/userguide/managing-vpc-cni.html#updating-vpc-cni-eks-add-on) for more details.
 
 ```
 # EKS Addons
@@ -24,7 +31,7 @@ EKS managed add-ons can be enabled via the following.
     resolve_conflicts        = "OVERWRITE"
     namespace                = "kube-system"
     service_account_role_arn = ""
-    preserve                 = true # This option makes the add-on a self-managed add-on, rather than an Amazon EKS add-on. There is no downtime for the add-on.
+    preserve                 = true
     additional_iam_policies  = []
     tags                     = {}
   }
@@ -38,7 +45,7 @@ EKS managed add-ons can be enabled via the following.
     resolve_conflicts        = "OVERWRITE"
     namespace                = "kube-system"
     service_account_role_arn = ""
-    preserve                 = true # This option makes the add-on a self-managed add-on, rather than an Amazon EKS add-on. There is no downtime for the add-on.
+    preserve                 = true
     additional_iam_policies  = []
     tags                     = {}
   }
@@ -52,7 +59,7 @@ EKS managed add-ons can be enabled via the following.
     resolve_conflicts        = "OVERWRITE"
     namespace                = "kube-system"
     service_account_role_arn = ""
-    preserve                 = true # This option makes the add-on a self-managed add-on, rather than an Amazon EKS add-on. There is no downtime for the add-on.
+    preserve                 = true
     additional_iam_policies  = []
     tags                     = {}
   }
@@ -64,7 +71,7 @@ EKS managed add-ons can be enabled via the following.
     addon_version            = "v1.4.0-eksbuild.preview"
     service_account          = "ebs-csi-controller-sa"
     resolve_conflicts        = "OVERWRITE"
-    namespace                = "kube-system"
+    namespace                = "kube-system"       
     additional_iam_policies  = []
     service_account_role_arn = ""
     tags                     = {}

--- a/examples/eks-cluster-with-new-vpc/main.tf
+++ b/examples/eks-cluster-with-new-vpc/main.tf
@@ -101,6 +101,7 @@ module "eks_blueprints_kubernetes_addons" {
   eks_cluster_id = module.eks_blueprints.eks_cluster_id
 
   # EKS Managed Add-ons
+  enable_amazon_eks_vpc_cni    = true
   enable_amazon_eks_coredns    = true
   enable_amazon_eks_kube_proxy = true
 

--- a/modules/kubernetes-addons/aws-coredns/locals.tf
+++ b/modules/kubernetes-addons/aws-coredns/locals.tf
@@ -8,6 +8,7 @@ locals {
     namespace                = "kube-system"
     service_account_role_arn = ""
     additional_iam_policies  = []
+    preserve                 = true
     tags                     = {}
   }
 

--- a/modules/kubernetes-addons/aws-coredns/main.tf
+++ b/modules/kubernetes-addons/aws-coredns/main.tf
@@ -4,6 +4,7 @@ resource "aws_eks_addon" "coredns" {
   addon_version            = local.addon_config["addon_version"]
   resolve_conflicts        = local.addon_config["resolve_conflicts"]
   service_account_role_arn = local.addon_config["service_account_role_arn"]
+  preserve                 = local.addon_config["preserve"]
 
   tags = merge(
     var.addon_context.tags, local.addon_config["tags"],

--- a/modules/kubernetes-addons/aws-kube-proxy/locals.tf
+++ b/modules/kubernetes-addons/aws-kube-proxy/locals.tf
@@ -8,6 +8,7 @@ locals {
     namespace                = "kube-system"
     additional_iam_policies  = []
     service_account_role_arn = ""
+    preserve                 = true
     tags                     = {}
   }
 

--- a/modules/kubernetes-addons/aws-kube-proxy/main.tf
+++ b/modules/kubernetes-addons/aws-kube-proxy/main.tf
@@ -4,6 +4,7 @@ resource "aws_eks_addon" "kube_proxy" {
   addon_version            = local.addon_config["addon_version"]
   resolve_conflicts        = local.addon_config["resolve_conflicts"]
   service_account_role_arn = local.addon_config["service_account_role_arn"]
+  preserve                 = local.addon_config["preserve"]
   tags = merge(
     var.addon_context.tags, local.addon_config["tags"],
     { "eks_addon" = "kube-proxy" }

--- a/modules/kubernetes-addons/aws-vpc-cni/locals.tf
+++ b/modules/kubernetes-addons/aws-vpc-cni/locals.tf
@@ -7,6 +7,7 @@ locals {
     namespace                = "kube-system"
     additional_iam_policies  = []
     service_account_role_arn = ""
+    preserve                 = true
     tags                     = {}
   }
 

--- a/modules/kubernetes-addons/aws-vpc-cni/main.tf
+++ b/modules/kubernetes-addons/aws-vpc-cni/main.tf
@@ -4,6 +4,7 @@ resource "aws_eks_addon" "vpc_cni" {
   addon_version            = local.addon_config["addon_version"]
   resolve_conflicts        = local.addon_config["resolve_conflicts"]
   service_account_role_arn = local.addon_config["service_account_role_arn"] == "" ? module.irsa_addon.irsa_iam_role_arn : local.addon_config["service_account_role_arn"]
+  preserve                 = local.addon_config["preserve"]
   tags = merge(
     var.addon_context.tags, local.addon_config["tags"],
     { "eks_addon" = "vpc-cni" }

--- a/outputs.tf
+++ b/outputs.tf
@@ -37,7 +37,7 @@ output "configure_kubectl" {
 }
 
 output "eks_cluster_status" {
-  description = "Amazon EKS Cluster Name"
+  description = "Amazon EKS Cluster Status"
   value       = module.aws_eks.cluster_status
 }
 


### PR DESCRIPTION
### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->

- Currently EKS Add-ons are controlled by the `kubernetes-addon`  sub module. VPC CNI add-on is getting deleted when we destroy kubernetes-addon before the cluster and node groups. 
- This feature will cleanup the EKS managed add-ons as and preserve the add-on as self-managed addon. This will ensure cirtical add-ons are running even after the add-ons and node groups are deleted
- Preserved self-managed addons will be deleted automatically when you delete the cluster
- This is added only for critical addons vpc-cni, coredns and kube-proxy. We will revise if its required for other managed add-ons
- If this users wanted to delete the add-on completely then can always pass `preserve=false`
- #510 - fixes the description issue

### Motivation

<!-- What inspired you to submit this pull request? -->


### More

- [ ] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
