### PR TITLE
Add dynamic partition to aws-cloudwatch-metrics cloudwatch agent addon policy arn

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ If you are interested in contributing to EKS Blueprints, see the [Contribution g
 | <a name="output_eks_cluster_certificate_authority_data"></a> [eks\_cluster\_certificate\_authority\_data](#output\_eks\_cluster\_certificate\_authority\_data) | Base64 encoded certificate data required to communicate with the cluster |
 | <a name="output_eks_cluster_endpoint"></a> [eks\_cluster\_endpoint](#output\_eks\_cluster\_endpoint) | Endpoint for your Kubernetes API server |
 | <a name="output_eks_cluster_id"></a> [eks\_cluster\_id](#output\_eks\_cluster\_id) | Amazon EKS Cluster Name |
-| <a name="output_eks_cluster_status"></a> [eks\_cluster\_status](#output\_eks\_cluster\_status) | Amazon EKS Cluster Name |
+| <a name="output_eks_cluster_status"></a> [eks\_cluster\_status](#output\_eks\_cluster\_status) | Amazon EKS Cluster Status |
 | <a name="output_eks_oidc_issuer_url"></a> [eks\_oidc\_issuer\_url](#output\_eks\_oidc\_issuer\_url) | The URL on the EKS cluster OIDC Issuer |
 | <a name="output_eks_oidc_provider_arn"></a> [eks\_oidc\_provider\_arn](#output\_eks\_oidc\_provider\_arn) | The ARN of the OIDC Provider if `enable_irsa = true`. |
 | <a name="output_emr_on_eks_role_arn"></a> [emr\_on\_eks\_role\_arn](#output\_emr\_on\_eks\_role\_arn) | IAM execution role ARN for EMR on EKS |

--- a/docs/add-ons/managed-add-ons.md
+++ b/docs/add-ons/managed-add-ons.md
@@ -11,11 +11,11 @@ EKS currently provides support for the following managed add-ons.
 | [kube-proxy](https://docs.aws.amazon.com/eks/latest/userguide/managing-kube-proxy.html) | Enables network communication to your pods. |
 | [Amazon EBS CSI](https://docs.aws.amazon.com/eks/latest/userguide/managing-ebs-csi.html) | Manage the Amazon EBS CSI driver as an Amazon EKS add-on. |
 
-EKS managed add-ons can be enabled via the following. 
+EKS managed add-ons can be enabled via the following.
 
 Note: EKS managed Add-ons can be converted to self-managed add-on with `preserve` field.
-`preserve=true` option removes Amazon EKS management of any settings and the ability for Amazon EKS to notify you of updates and automatically update the Amazon EKS add-on after you initiate an update, but preserves the add-on's software on your cluster. 
-This option makes the add-on a self-managed add-on, rather than an Amazon EKS add-on. 
+`preserve=true` option removes Amazon EKS management of any settings and the ability for Amazon EKS to notify you of updates and automatically update the Amazon EKS add-on after you initiate an update, but preserves the add-on's software on your cluster.
+This option makes the add-on a self-managed add-on, rather than an Amazon EKS add-on.
 There is no downtime while deleting EKS managed Add-ons when `preserve=true`. This is a default option for `enable_amazon_eks_vpc_cni` , `enable_amazon_eks_coredns` and `enable_amazon_eks_kube_proxy`.
 
 Checkout this [doc](https://docs.aws.amazon.com/eks/latest/userguide/managing-vpc-cni.html#updating-vpc-cni-eks-add-on) for more details.

--- a/modules/kubernetes-addons/aws-cloudwatch-metrics/locals.tf
+++ b/modules/kubernetes-addons/aws-cloudwatch-metrics/locals.tf
@@ -38,7 +38,7 @@ locals {
     kubernetes_service_account        = local.service_account_name
     create_kubernetes_namespace       = true
     create_kubernetes_service_account = true
-    irsa_iam_policies                 = concat(["arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"], var.irsa_policies)
+    irsa_iam_policies                 = concat(["arn:${var.addon_context.aws_partition_id}:iam::aws:policy/CloudWatchAgentServerPolicy"], var.irsa_policies)
   }
 
   argocd_gitops_config = {


### PR DESCRIPTION
### What does this PR do?

Replaces a hardcoded `aws` partition in the cloudwatch agent addon policy arn in the aws-cloudwatch-metrics addon with a dynamic partition so it's compatible with GovCloud. Without this, any deployments using the `aws-cloudwatch-metrics` addon in GovCloud will fail.

### More

- [x] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

Tested by applying and destroying `examples/eks-cluster-with-new-vpc` in GovCloud.
