### PR TITLE
[bugfix]: #532: Have teams module honor permissions boundary

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -142,11 +142,12 @@ module "aws_eks_teams" {
   count  = length(var.application_teams) > 0 || length(var.platform_teams) > 0 ? 1 : 0
   source = "./modules/aws-eks-teams"
 
-  application_teams = var.application_teams
-  platform_teams    = var.platform_teams
-  environment       = var.environment
-  tenant            = var.tenant
-  zone              = var.zone
-  eks_cluster_id    = module.aws_eks.cluster_id
-  tags              = module.eks_tags.tags
+  application_teams               = var.application_teams
+  platform_teams                  = var.platform_teams
+  environment                     = var.environment
+  tenant                          = var.tenant
+  zone                            = var.zone
+  iam_role_permissions_boundary   = var.iam_role_permissions_boundary
+  eks_cluster_id                  = module.aws_eks.cluster_id
+  tags                            = module.eks_tags.tags
 }

--- a/main.tf
+++ b/main.tf
@@ -142,12 +142,12 @@ module "aws_eks_teams" {
   count  = length(var.application_teams) > 0 || length(var.platform_teams) > 0 ? 1 : 0
   source = "./modules/aws-eks-teams"
 
-  application_teams               = var.application_teams
-  platform_teams                  = var.platform_teams
-  environment                     = var.environment
-  tenant                          = var.tenant
-  zone                            = var.zone
-  iam_role_permissions_boundary   = var.iam_role_permissions_boundary
-  eks_cluster_id                  = module.aws_eks.cluster_id
-  tags                            = module.eks_tags.tags
+  application_teams             = var.application_teams
+  platform_teams                = var.platform_teams
+  environment                   = var.environment
+  tenant                        = var.tenant
+  zone                          = var.zone
+  iam_role_permissions_boundary = var.iam_role_permissions_boundary
+  eks_cluster_id                = module.aws_eks.cluster_id
+  tags                          = module.eks_tags.tags
 }

--- a/modules/aws-eks-teams/README.md
+++ b/modules/aws-eks-teams/README.md
@@ -165,6 +165,7 @@ No modules.
 | <a name="input_application_teams"></a> [application\_teams](#input\_application\_teams) | Map of maps of teams to create | `any` | `{}` | no |
 | <a name="input_eks_cluster_id"></a> [eks\_cluster\_id](#input\_eks\_cluster\_id) | EKS Cluster name | `string` | n/a | yes |
 | <a name="input_environment"></a> [environment](#input\_environment) | Environment area, e.g. prod or preprod | `string` | n/a | yes |
+| <a name="input_iam_role_permissions_boundary"></a> [iam\_role\_permissions\_boundary](#input\_iam\_role\_permissions\_boundary) | ARN of the policy that is used to set the permissions boundary for the IAM role | `string` | `null` | no |
 | <a name="input_platform_teams"></a> [platform\_teams](#input\_platform\_teams) | Map of maps of teams to create | `any` | `{}` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | `{}` | no |
 | <a name="input_tenant"></a> [tenant](#input\_tenant) | Account Name or unique account unique id e.g., apps or management or aws007 | `string` | n/a | yes |

--- a/modules/aws-eks-teams/main.tf
+++ b/modules/aws-eks-teams/main.tf
@@ -48,8 +48,8 @@ resource "kubernetes_resource_quota" "team_object_quota" {
 # ---------------------------------------------------------------------------------------------------------------------
 resource "aws_iam_role" "team_access" {
   permissions_boundary = var.iam_role_permissions_boundary
-  for_each = { for team_name, team_data in var.application_teams : team_name => team_data if lookup(team_data, "users", "") != "" }
-  name     = format("%s-%s-%s", local.role_prefix_name, "${each.key}", "Access")
+  for_each             = { for team_name, team_data in var.application_teams : team_name => team_data if lookup(team_data, "users", "") != "" }
+  name                 = format("%s-%s-%s", local.role_prefix_name, "${each.key}", "Access")
   assume_role_policy = jsonencode({
     "Version" : "2012-10-17",
     "Statement" : [
@@ -134,9 +134,9 @@ resource "kubernetes_role_binding" "team" {
 
 resource "aws_iam_role" "team_sa_irsa" {
   permissions_boundary = var.iam_role_permissions_boundary
-  for_each = var.application_teams
-  name     = format("%s-%s-%s", local.role_prefix_name, "${each.key}", "sa-role")
-  tags     = var.tags
+  for_each             = var.application_teams
+  name                 = format("%s-%s-%s", local.role_prefix_name, "${each.key}", "sa-role")
+  tags                 = var.tags
   assume_role_policy = jsonencode({
     "Version" : "2012-10-17",
     "Statement" : [
@@ -189,10 +189,10 @@ resource "kubectl_manifest" "team" {
 
 resource "aws_iam_role" "platform_team" {
   permissions_boundary = var.iam_role_permissions_boundary
-  for_each            = var.platform_teams
-  name                = format("%s-%s-%s", local.role_prefix_name, "${each.key}", "Access")
-  tags                = var.tags
-  managed_policy_arns = [aws_iam_policy.platform_team_eks_access[0].arn]
+  for_each             = var.platform_teams
+  name                 = format("%s-%s-%s", local.role_prefix_name, "${each.key}", "Access")
+  tags                 = var.tags
+  managed_policy_arns  = [aws_iam_policy.platform_team_eks_access[0].arn]
   assume_role_policy = jsonencode({
     "Version" : "2012-10-17",
     "Statement" : [

--- a/modules/aws-eks-teams/main.tf
+++ b/modules/aws-eks-teams/main.tf
@@ -47,6 +47,7 @@ resource "kubernetes_resource_quota" "team_object_quota" {
 # IAM / RBAC
 # ---------------------------------------------------------------------------------------------------------------------
 resource "aws_iam_role" "team_access" {
+  permissions_boundary = var.iam_role_permissions_boundary
   for_each = { for team_name, team_data in var.application_teams : team_name => team_data if lookup(team_data, "users", "") != "" }
   name     = format("%s-%s-%s", local.role_prefix_name, "${each.key}", "Access")
   assume_role_policy = jsonencode({
@@ -132,6 +133,7 @@ resource "kubernetes_role_binding" "team" {
 }
 
 resource "aws_iam_role" "team_sa_irsa" {
+  permissions_boundary = var.iam_role_permissions_boundary
   for_each = var.application_teams
   name     = format("%s-%s-%s", local.role_prefix_name, "${each.key}", "sa-role")
   tags     = var.tags
@@ -186,6 +188,7 @@ resource "kubectl_manifest" "team" {
 # ---------------------------------------------------------------------------------------------------------------------
 
 resource "aws_iam_role" "platform_team" {
+  permissions_boundary = var.iam_role_permissions_boundary
   for_each            = var.platform_teams
   name                = format("%s-%s-%s", local.role_prefix_name, "${each.key}", "Access")
   tags                = var.tags

--- a/modules/aws-eks-teams/variables.tf
+++ b/modules/aws-eks-teams/variables.tf
@@ -35,3 +35,9 @@ variable "eks_cluster_id" {
   description = "EKS Cluster name"
   type        = string
 }
+
+variable "iam_role_permissions_boundary" {
+  description = "ARN of the policy that is used to set the permissions boundary for the IAM role"
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
### What does this PR do?

This fixes bug #532 , and makes the teams module honor the permissions boundary in the main blueprints module. 


### Motivation

We hit this bug testing blueprints, and thought it was a pretty straightforward fix. 
- Closes #532 

### More

- [ x ] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
