### PR TITLE
ci: Fix repository check to avoid failed plans on contributor forks

### DIFF
--- a/.github/workflows/plan-examples.yml
+++ b/.github/workflows/plan-examples.yml
@@ -14,7 +14,7 @@ jobs:
     name: Get example directories
     runs-on: ubuntu-latest
     # Skip running on forks since it won't have access to secrets
-    if: github.repository_owner == 'aws-ia'
+    if: github.repository == 'aws-ia/terraform-aws-eks-blueprints'
     outputs:
       directories: ${{ steps.dirs.outputs.directories }}
     steps:
@@ -32,7 +32,7 @@ jobs:
     needs: getExampleDirectories
     runs-on: ubuntu-latest
     # Skip running on forks since it won't have access to secrets
-    if: github.repository_owner == 'aws-ia'
+    if: github.repository == 'aws-ia/terraform-aws-eks-blueprints'
 
     # These permissions are needed to interact with GitHub's OIDC Token endpoint.
     permissions:


### PR DESCRIPTION
### What does this PR do?
- Fix repository check to avoid failed plans on contributor forks


### Motivation
- External contributors do not have access to the secrets used to run plans, which results in a number of failed checks that are not actionable for them. I thought the previous check for forks solved this but it does not appear to be working as intended - using solution posted here https://github.com/actions/runner/issues/859

### More

- [ ] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
