### PR TITLE
adds DeleteLaunchTemplate to karpenter policy

### DIFF
--- a/modules/kubernetes-addons/karpenter/data.tf
+++ b/modules/kubernetes-addons/karpenter/data.tf
@@ -10,6 +10,7 @@ data "aws_iam_policy_document" "karpenter" {
       "ec2:RunInstances",
       "ec2:CreateTags",
       "iam:PassRole",
+      "ec2:DeleteLaunchTemplate*",
       "ec2:DescribeLaunchTemplates",
       "ec2:DescribeInstances",
       "ec2:DescribeSecurityGroups",

--- a/modules/kubernetes-addons/karpenter/data.tf
+++ b/modules/kubernetes-addons/karpenter/data.tf
@@ -10,7 +10,7 @@ data "aws_iam_policy_document" "karpenter" {
       "ec2:RunInstances",
       "ec2:CreateTags",
       "iam:PassRole",
-      "ec2:DeleteLaunchTemplate*",
+      "ec2:DeleteLaunchTemplate",
       "ec2:DescribeLaunchTemplates",
       "ec2:DescribeInstances",
       "ec2:DescribeSecurityGroups",


### PR DESCRIPTION
Based on a similar issue to https://github.com/aws/karpenter/issues/1706
This policy lacks `"ec2:DeleteLaunchTemplate",` and this ends up with:
`2022-05-12T18:03:24.151Z	ERROR	controller.aws.launchtemplate	Unable to delete launch template, UnauthorizedOperation: You are not authorized to perform this operation. Encoded authorization failure message:`


### What does this PR do?
add `      "ec2:DeleteLaunchTemplate*",`

### Motivation

Fixes `Unable to delete launch template,` error

### More

- [X] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
