### PR TITLE
Add stale workflow

### DIFF
--- a/.github/workflows/stale_issue_pr.yaml
+++ b/.github/workflows/stale_issue_pr.yaml
@@ -1,0 +1,27 @@
+name: 'Stale issue & PR handler'
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@main
+        id: stale
+        with:
+          ascending: true
+          close-issue-message: 'Issue closed due to inactivity.'
+          close-pr-message: 'Pull request closed due to inactivity.'
+          days-before-close: 14
+          days-before-stale: 60
+          exempt-issue-labels: 'triage-pending,review-pending'
+          operations-per-run: 100
+          stale-issue-message: 'This issue is stale because it has been open 60 days with no activity. Remove stale label or comment or this will be closed in 14 days'
+          stale-pr-message: 'This pull request is stale because it has been open 60 days with no activity. Remove stale label or comment or this will be closed in 14 days'
+      - name: Print outputs
+        run: echo ${{ join(steps.stale.outputs.*, ',') }}

--- a/.github/workflows/stale_issue_pr.yaml
+++ b/.github/workflows/stale_issue_pr.yaml
@@ -22,8 +22,8 @@ jobs:
           stale-issue-label: stale
           stale-pr-label: stale
           # Not stale if have this labels
-          exempt-issue-labels: 'bug'
-          exempt-pr-labels: 'bug'
+          exempt-issue-labels: 'bug,enhancement'
+          exempt-pr-labels: 'bug,enhancement'
           operations-per-run: 100
           stale-issue-message: |
             This issue has been automatically marked as stale because it has been open 30 days

--- a/.github/workflows/stale_issue_pr.yaml
+++ b/.github/workflows/stale_issue_pr.yaml
@@ -17,11 +17,19 @@ jobs:
           ascending: true
           close-issue-message: 'Issue closed due to inactivity.'
           close-pr-message: 'Pull request closed due to inactivity.'
-          days-before-close: 14
-          days-before-stale: 60
-          exempt-issue-labels: 'triage-pending,review-pending'
+          days-before-close: 10
+          days-before-stale: 30
+          stale-issue-label: stale
+          stale-pr-label: stale
+          # Not stale if have this labels 
+          exempt-issue-labels: 'bug'
+          exempt-pr-labels: 'bug'
           operations-per-run: 100
-          stale-issue-message: 'This issue is stale because it has been open 60 days with no activity. Remove stale label or comment or this will be closed in 14 days'
-          stale-pr-message: 'This pull request is stale because it has been open 60 days with no activity. Remove stale label or comment or this will be closed in 14 days'
+          stale-issue-message: |
+            This issue has been automatically marked as stale because it has been open 30 days
+            with no activity. Remove stale label or comment or this issue will be closed in 10 days
+          stale-pr-message: |
+            This PR has been automatically marked as stale because it has been open 30 days
+            with no activity. Remove stale label or comment or this PR will be closed in 10 days
       - name: Print outputs
         run: echo ${{ join(steps.stale.outputs.*, ',') }}

--- a/.github/workflows/stale_issue_pr.yaml
+++ b/.github/workflows/stale_issue_pr.yaml
@@ -21,7 +21,7 @@ jobs:
           days-before-stale: 30
           stale-issue-label: stale
           stale-pr-label: stale
-          # Not stale if have this labels 
+          # Not stale if have this labels
           exempt-issue-labels: 'bug'
           exempt-pr-labels: 'bug'
           operations-per-run: 100

--- a/.github/workflows/stale_issue_pr.yaml
+++ b/.github/workflows/stale_issue_pr.yaml
@@ -31,5 +31,3 @@ jobs:
           stale-pr-message: |
             This PR has been automatically marked as stale because it has been open 30 days
             with no activity. Remove stale label or comment or this PR will be closed in 10 days
-      - name: Print outputs
-        run: echo ${{ join(steps.stale.outputs.*, ',') }}


### PR DESCRIPTION
### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
- add stale workflow for Issues and PRs

### Motivation
- healthy practice as project keeps growing and we need to keep track of things.
- inspired by https://github.com/terraform-aws-modules/terraform-aws-eks/blob/master/.github/workflows/stale-actions.yaml and https://github.com/aws/amazon-vpc-cni-k8s/blob/master/.github/workflows/stale_issue_pr.yaml configs
<!-- What inspired you to submit this pull request? -->


### More

- [ ] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
