### PR TITLE
[examples/karpenter] karpenter provisioner: use eks-vpc_name in subnetSelector to prevent subnet conflicts with other VPCs

### DIFF
--- a/examples/karpenter/main.tf
+++ b/examples/karpenter/main.tf
@@ -206,6 +206,7 @@ data "kubectl_path_documents" "karpenter_provisioners" {
     azs                     = join(",", local.azs)
     iam-instance-profile-id = format("%s-%s", local.cluster_name, local.node_group_name)
     eks-cluster-id          = local.cluster_name
+    eks-vpc_name            = local.vpc_name
   }
 }
 

--- a/examples/karpenter/provisioners/default_provisioner.yaml
+++ b/examples/karpenter/provisioners/default_provisioner.yaml
@@ -16,7 +16,7 @@ spec:
   provider:
     instanceProfile: ${iam-instance-profile-id}
     subnetSelector:
-      Name: "*private*"
+      Name: "${eks-vpc_name}-private*"
     securityGroupSelector:
       kubernetes.io/cluster/${eks-cluster-id}: 'owned'
   ttlSecondsAfterEmpty: 120

--- a/examples/karpenter/provisioners/default_provisioner_with_launch_templates.yaml
+++ b/examples/karpenter/provisioners/default_provisioner_with_launch_templates.yaml
@@ -22,7 +22,7 @@ spec:
   provider:
     launchTemplate: "karpenter-aws001-preprod-dev-eks"     # Used by Karpenter Nodes
     subnetSelector:
-      Name: "*private*"
+      Name: "${eks-vpc_name}-private*"
     securityGroupSelector:
       kubernetes.io/cluster/aws-dev-spark-eks: owned
   ttlSecondsAfterEmpty: 120


### PR DESCRIPTION
### What does this PR do?

This PR fixes subnetSelector in karpenter provisioner by using VPC name e.g. `${eks-vpc_name}-private*` => `aws001-preprod-dev-vpc-private*`


### Motivation

If we already have a non-default VPC in account then `*private*` subnet selecter will select private subnets from all available VPCs as shown in this image.

![image](https://user-images.githubusercontent.com/3725386/168427298-bf4ac4fa-03e1-484f-8b23-d31eb168760c.png)

Karpenter will then discover all private subnets (from all VPCs) and will try to launch nodes in a different VPC and we will get this error.

Error log:
```
2022-05-14T12:58:21.515Z	ERROR	controller.provisioning	Could not launch node, launching instances, with fleet error(s), InvalidParameter: Security group sg-08772d703d36e84ab and subnet subnet-06ab25f078c0630e5 belong to different networks.; InvalidParameter: Security group sg-08772d703d36e84ab and subnet subnet-04adc26d50a7c8249 belong to different networks.; InvalidParameter: Security group sg-08772d703d36e84ab and subnet subnet-09ef75c0d1cf0d92e belong to different networks.; UnfulfillableCapacity: Unable to fulfill capacity due to your request configuration. Please adjust your request and try again.	{"commit": "7b5afee", "provisioner": "default"}
```



### More

- [X] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

`terraform plan` with my branch. I have also tested this using `terraform apply` with `default_provisioner.yaml`
![image](https://user-images.githubusercontent.com/3725386/168427580-5d5317f5-a00e-486c-8aa9-0f5fb3439fa3.png)

you can also see that `aws001-preprod-dev-vpc-private*` filter only selects relevant subnets 
![image](https://user-images.githubusercontent.com/3725386/168427641-2b2bf07c-e9f4-45ed-bccb-0058faed626b.png)

