### PR TITLE
Block concurrent executions for terratest e2e

### DIFF
--- a/.github/workflows/e2e-terratest.yml
+++ b/.github/workflows/e2e-terratest.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   test:
+    timeout-minutes: 60 # Wait for upto 60 mins before the next jobs runs
     name: Run E2E Terratest
     runs-on: ubuntu-latest
 
@@ -19,6 +20,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+
+      - name: Block concurrent executions
+        uses: softprops/turnstyle@v1
+        with:
+          poll-interval-seconds: 180
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/setup-go@v2
         with:


### PR DESCRIPTION
### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
- Block concurrent executions for terratest e2e github workflows

### Motivation

<!-- What inspired you to submit this pull request? -->


### More

- [ ] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
