### PR TITLE
Allow TF plan checks to run on forks PRs, add concurrency to parallel E2Es 

### DIFF
--- a/.github/workflows/e2e-parallel-destroy.yml
+++ b/.github/workflows/e2e-parallel-destroy.yml
@@ -11,6 +11,8 @@ on:
 env:
   DEFAULT_DEPLOY_ORDER: 'module.e2e_test.module.aws_vpc,module.e2e_test.module.eks_blueprints,module.e2e_test.module.eks_blueprints_kubernetes_addons'
 
+concurrency: e2e-parallel-destroy
+
 jobs:
   deploy:
     name: Run e2e test

--- a/.github/workflows/e2e-parallel-full.yml
+++ b/.github/workflows/e2e-parallel-full.yml
@@ -10,6 +10,8 @@ on:
 env:
   DEFAULT_DEPLOY_ORDER: 'module.e2e_test.module.aws_vpc,module.e2e_test.module.eks_blueprints,module.e2e_test.module.eks_blueprints_kubernetes_addons'
 
+concurrency: e2e-parallel-full
+
 jobs:
   deploy:
     name: Run e2e test

--- a/.github/workflows/plan-examples.yml
+++ b/.github/workflows/plan-examples.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  # Review https://securitylab.github.com/research/github-actions-preventing-pwn-requests/ and better understand the risks of using pull_request_target before making major changes to this workflow.
   pull_request_target:
     branches:
       - main

--- a/.github/workflows/plan-examples.yml
+++ b/.github/workflows/plan-examples.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-  pull_request:
+  pull_request_target:
     branches:
       - main
   workflow_dispatch:
@@ -13,6 +13,7 @@ jobs:
   getExampleDirectories:
     name: Get example directories
     runs-on: ubuntu-latest
+    environment: EKS Blueprints Test
     # Skip running on forks since it won't have access to secrets
     if: github.repository == 'aws-ia/terraform-aws-eks-blueprints'
     outputs:


### PR DESCRIPTION
### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
- Adds concurrency to E2Es workflows (parallel apply & destroy)
- Sets TF plan to use pull_request_target and use GitHub environment.

### Motivation

<!-- What inspired you to submit this pull request? -->

- concurrency to prevent from multiple TF apply/destroy run on the same time as the state is the same - https://docs.github.com/en/actions/using-jobs/using-concurrency

- Allows PRs from forks to run against TF plan checks by allowing `pull_request_target` to be used while utilizing [GitHub Environment](https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment) to prevent ["pwn request"](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/), allowing humans (repo code owners) to review the PRs and deploy relevant checks when it's safe to do so.

### More

- [ ] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR




**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
