### PR TITLE
Adding github workflow concurrency to terratest

### DIFF
--- a/.github/workflows/e2e-terratest.yml
+++ b/.github/workflows/e2e-terratest.yml
@@ -6,9 +6,10 @@ on:
       - main
   workflow_dispatch:
 
+concurrency: e2e-terratest
+
 jobs:
   test:
-    timeout-minutes: 60 # Wait for upto 60 mins before the next jobs runs
     name: Run E2E Terratest
     runs-on: ubuntu-latest
 
@@ -20,13 +21,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-
-      - name: Block concurrent executions
-        uses: softprops/turnstyle@v1
-        with:
-          poll-interval-seconds: 180
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/setup-go@v2
         with:


### PR DESCRIPTION
### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
- Adding Github Workflow Concurrency to e2e-terratest. Checkout this link for more details https://github.blog/changelog/2021-04-19-github-actions-limit-workflow-run-or-job-concurrency/#:~:text=GitHub%20Actions%20now%20supports%20a,running%20at%20any%20given%20time.
- 

### Motivation

<!-- What inspired you to submit this pull request? -->


### More

- [ ] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
