### PR TITLE
Use the local.name instead of hardcoded name for external-dns

### DIFF
--- a/modules/kubernetes-addons/external-dns/locals.tf
+++ b/modules/kubernetes-addons/external-dns/locals.tf
@@ -1,5 +1,5 @@
 locals {
-  name                 = "external-dns"
+  name                 = local.name
   service_account_name = "${local.name}-sa"
   zone_filter_ids      = jsonencode([data.aws_route53_zone.selected.zone_id])
 


### PR DESCRIPTION
In case of multiple deployments it may be beneficial to customize this name instead of having it hardcoded.


### What does this PR do?

Uses the local.name instead of hardcoded name for external-dns

### Motivation

<!-- What inspired you to submit this pull request? -->

We may need multiple deployments of external-dns, existing setup disallows that by hardcoding the name to external-dns instead of customizable local.name.

### More

- [ ] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
