### PR TITLE
[teams] Makes quotas and labels optionals

### DIFF
--- a/modules/aws-eks-teams/locals.tf
+++ b/modules/aws-eks-teams/locals.tf
@@ -10,4 +10,17 @@ locals {
     try(fileset(path.root, "${team_data.manifests_dir}/*"), [])
   ])
 
+  compute_hard_quota_list = ["requests.cpu", "requests.memory", "limits.cpu", "limits.memory"]
+  team_compute_hard_quotas = {
+    for team_name, team_data in var.application_teams : team_name => {
+      for quota_name in setintersection(local.compute_hard_quota_list, keys(team_data.quota)) : quota_name => team_data.quota[quota_name]
+    } if length(setintersection(local.compute_hard_quota_list, keys(try(team_data.quota, {})))) > 0
+  }
+
+  object_hard_quota_list = ["pods", "secrets", "services"]
+  team_object_hard_quotas = {
+    for team_name, team_data in var.application_teams : team_name => {
+      for quota_name in setintersection(local.object_hard_quota_list, keys(team_data.quota)) : quota_name => team_data.quota[quota_name]
+    } if length(setintersection(local.object_hard_quota_list, keys(try(team_data.quota, {})))) > 0
+  }
 }

--- a/modules/aws-eks-teams/main.tf
+++ b/modules/aws-eks-teams/main.tf
@@ -5,7 +5,7 @@ resource "kubernetes_namespace" "team" {
   for_each = var.application_teams
   metadata {
     name   = each.key
-    labels = each.value["labels"]
+    labels = lookup(each.value, "labels", {})
   }
 }
 
@@ -13,33 +13,24 @@ resource "kubernetes_namespace" "team" {
 # Quotas
 # ---------------------------------------------------------------------------------------------------------------------
 resource "kubernetes_resource_quota" "team_compute_quota" {
-  for_each = var.application_teams
+  for_each = local.team_compute_hard_quotas
   metadata {
     name      = "compute-quota"
     namespace = kubernetes_namespace.team[each.key].metadata[0].name
   }
   spec {
-    hard = {
-      "requests.cpu"    = each.value["quota"]["requests.cpu"]
-      "requests.memory" = each.value["quota"]["requests.memory"]
-      "limits.cpu"      = each.value["quota"]["limits.cpu"]
-      "limits.memory"   = each.value["quota"]["limits.memory"]
-    }
+    hard = each.value
   }
 }
 
 resource "kubernetes_resource_quota" "team_object_quota" {
-  for_each = var.application_teams
+  for_each = local.team_object_hard_quotas
   metadata {
     name      = "object-quota"
     namespace = kubernetes_namespace.team[each.key].metadata[0].name
   }
   spec {
-    hard = {
-      "pods"     = each.value["quota"]["pods"]
-      "secrets"  = each.value["quota"]["secrets"]
-      "services" = each.value["quota"]["services"]
-    }
+    hard = each.value
   }
 }
 


### PR DESCRIPTION
### What does this PR do?

Makes the quotas and labels fields in the team definition object optional, as they should not be required in most of the cases.


### Motivation

When creating the namespace for a specific team, if the `application_teams.*.label` object input field is not set, the terraform apply fails as the `labels` input of the resource expects that field to exist.

The same happens with the defined `kubernetes_resource_quota.team_compute_quota` and `kubernetes_resource_quota.team_object_quota ` resources, as they are not prepared for supporting empty or partial defined `application_teams.*.quota` inputs, and if any of them doesn't exist, the kubernetes provider fails with a go panic error due to the `kubernetes_resource_quota`'s `spec` resource field emptiness.

The changes in this PR filter and create two different quota maps for being applied in the respective namespace classifying each team's kubernetes namespace quotas on compute quotas or object quotas.

Maybe there are more efficient or clearer ways for doing that maintaining back-compatibility with the existing quota definition int the application_teams input, any suggestion for improving this will be welcome 👍

### More

- [ ] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes) -> I wasn't able to execute the repository tests locally as I don't have the adequate infrastructure available, I manually tested the changes over an already created cluster with this module.
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

Manual testing inputs:
```
application_teams = {
    test-team = {
      users = [ //OBFUSCATED ]
    },
    test-team2 = {
      labels = {
        "test2" = "test2"
      }
      quota = {
        "requests.cpu"    = "3000m",
        "requests.memory" = "1Gi",
        "secrets"         = "20",
        "services"        = "20"
      },
      users = [ //OBFUSCATED  ]
    }
  }
```

result after apply:

```
❯ k describe ns test-team
Name:         test-team
Labels:       kubernetes.io/metadata.name=test-team
Annotations:  <none>
Status:       Active

No resource quota.

No LimitRange resource.

---

❯ k describe ns test-team2
Name:         test-team2
Labels:       kubernetes.io/metadata.name=test-team2
              test2=test2
Annotations:  <none>
Status:       Active

Resource Quotas
  Name:            compute-quota
  Resource         Used  Hard
  --------         ---   ---
  requests.cpu     0     3
  requests.memory  0     1Gi
  Name:            object-quota
  Resource         Used  Hard
  --------         ---   ---
  secrets          2     20
  services         0     20

No LimitRange resource.
```
