### PR TITLE
[Kubernetes Addons Module] - Use EKS outputs instead of data resources

### DIFF
--- a/examples/analytics/emr-on-eks/main.tf
+++ b/examples/analytics/emr-on-eks/main.tf
@@ -92,7 +92,10 @@ module "eks_blueprints" {
 module "eks_blueprints_kubernetes_addons" {
   source = "../../../modules/kubernetes-addons"
 
-  eks_cluster_id = module.eks_blueprints.eks_cluster_id
+  eks_cluster_id           = module.eks_blueprints.eks_cluster_id
+  aws_eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint
+  eks_oidc_issuer_url      = module.eks_blueprints.eks_oidc_issuer_url
+  eks_cluster_version      = module.eks_blueprints.eks_cluster_version
 
   # Add-ons
   enable_metrics_server     = true

--- a/examples/analytics/emr-on-eks/main.tf
+++ b/examples/analytics/emr-on-eks/main.tf
@@ -94,7 +94,7 @@ module "eks_blueprints_kubernetes_addons" {
 
   eks_cluster_id           = module.eks_blueprints.eks_cluster_id
   aws_eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint
-  eks_oidc_issuer_url      = module.eks_blueprints.eks_oidc_issuer_url
+  eks_oidc_provider        = module.eks_blueprints.oidc_provider
   eks_cluster_version      = module.eks_blueprints.eks_cluster_version
 
   # Add-ons

--- a/examples/analytics/emr-on-eks/main.tf
+++ b/examples/analytics/emr-on-eks/main.tf
@@ -92,10 +92,10 @@ module "eks_blueprints" {
 module "eks_blueprints_kubernetes_addons" {
   source = "../../../modules/kubernetes-addons"
 
-  eks_cluster_id           = module.eks_blueprints.eks_cluster_id
-  aws_eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint
-  eks_oidc_provider        = module.eks_blueprints.oidc_provider
-  eks_cluster_version      = module.eks_blueprints.eks_cluster_version
+  eks_cluster_id       = module.eks_blueprints.eks_cluster_id
+  eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint
+  eks_oidc_provider    = module.eks_blueprints.oidc_provider
+  eks_cluster_version  = module.eks_blueprints.eks_cluster_version
 
   # Add-ons
   enable_metrics_server     = true

--- a/examples/analytics/spark-k8s-operator/main.tf
+++ b/examples/analytics/spark-k8s-operator/main.tf
@@ -111,10 +111,10 @@ module "eks_blueprints" {
 module "eks_blueprints_kubernetes_addons" {
   source = "../../../modules/kubernetes-addons"
 
-  eks_cluster_id           = module.eks_blueprints.eks_cluster_id
-  aws_eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint
-  eks_oidc_provider        = module.eks_blueprints.oidc_provider
-  eks_cluster_version      = module.eks_blueprints.eks_cluster_version
+  eks_cluster_id       = module.eks_blueprints.eks_cluster_id
+  eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint
+  eks_oidc_provider    = module.eks_blueprints.oidc_provider
+  eks_cluster_version  = module.eks_blueprints.eks_cluster_version
   # Add-ons
   enable_metrics_server     = true
   enable_cluster_autoscaler = true

--- a/examples/analytics/spark-k8s-operator/main.tf
+++ b/examples/analytics/spark-k8s-operator/main.tf
@@ -111,8 +111,10 @@ module "eks_blueprints" {
 module "eks_blueprints_kubernetes_addons" {
   source = "../../../modules/kubernetes-addons"
 
-  eks_cluster_id = module.eks_blueprints.eks_cluster_id
-
+  eks_cluster_id           = module.eks_blueprints.eks_cluster_id
+  aws_eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint
+  eks_oidc_issuer_url      = module.eks_blueprints.eks_oidc_issuer_url
+  eks_cluster_version      = module.eks_blueprints.eks_cluster_version
   # Add-ons
   enable_metrics_server     = true
   enable_cluster_autoscaler = true

--- a/examples/analytics/spark-k8s-operator/main.tf
+++ b/examples/analytics/spark-k8s-operator/main.tf
@@ -113,7 +113,7 @@ module "eks_blueprints_kubernetes_addons" {
 
   eks_cluster_id           = module.eks_blueprints.eks_cluster_id
   aws_eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint
-  eks_oidc_issuer_url      = module.eks_blueprints.eks_oidc_issuer_url
+  eks_oidc_provider        = module.eks_blueprints.oidc_provider
   eks_cluster_version      = module.eks_blueprints.eks_cluster_version
   # Add-ons
   enable_metrics_server     = true

--- a/examples/aws-efs-csi-driver/main.tf
+++ b/examples/aws-efs-csi-driver/main.tf
@@ -89,7 +89,10 @@ module "eks_blueprints" {
 module "eks_blueprints_kubernetes_addons" {
   source = "../../modules/kubernetes-addons"
 
-  eks_cluster_id = module.eks_blueprints.eks_cluster_id
+  eks_cluster_id           = module.eks_blueprints.eks_cluster_id
+  aws_eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint
+  eks_oidc_issuer_url      = module.eks_blueprints.eks_oidc_issuer_url
+  eks_cluster_version      = module.eks_blueprints.eks_cluster_version
 
   # EKS Managed Add-ons
   enable_amazon_eks_coredns    = true

--- a/examples/aws-efs-csi-driver/main.tf
+++ b/examples/aws-efs-csi-driver/main.tf
@@ -91,7 +91,7 @@ module "eks_blueprints_kubernetes_addons" {
 
   eks_cluster_id           = module.eks_blueprints.eks_cluster_id
   aws_eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint
-  eks_oidc_issuer_url      = module.eks_blueprints.eks_oidc_issuer_url
+  eks_oidc_provider        = module.eks_blueprints.oidc_provider
   eks_cluster_version      = module.eks_blueprints.eks_cluster_version
 
   # EKS Managed Add-ons

--- a/examples/aws-efs-csi-driver/main.tf
+++ b/examples/aws-efs-csi-driver/main.tf
@@ -89,10 +89,10 @@ module "eks_blueprints" {
 module "eks_blueprints_kubernetes_addons" {
   source = "../../modules/kubernetes-addons"
 
-  eks_cluster_id           = module.eks_blueprints.eks_cluster_id
-  aws_eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint
-  eks_oidc_provider        = module.eks_blueprints.oidc_provider
-  eks_cluster_version      = module.eks_blueprints.eks_cluster_version
+  eks_cluster_id       = module.eks_blueprints.eks_cluster_id
+  eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint
+  eks_oidc_provider    = module.eks_blueprints.oidc_provider
+  eks_cluster_version  = module.eks_blueprints.eks_cluster_version
 
   # EKS Managed Add-ons
   enable_amazon_eks_coredns    = true

--- a/examples/complete-kubernetes-addons/main.tf
+++ b/examples/complete-kubernetes-addons/main.tf
@@ -158,7 +158,7 @@ module "eks_blueprints_kubernetes_addons" {
 
   eks_cluster_id               = module.eks_blueprints.eks_cluster_id
   aws_eks_cluster_endpoint     = module.eks_blueprints.eks_cluster_endpoint
-  eks_oidc_issuer_url          = module.eks_blueprints.eks_oidc_issuer_url
+  eks_oidc_provider            = module.eks_blueprints.oidc_provider
   eks_cluster_version          = module.eks_blueprints.eks_cluster_version
   eks_worker_security_group_id = module.eks_blueprints.worker_node_security_group_id
   auto_scaling_group_names     = module.eks_blueprints.self_managed_node_group_autoscaling_groups

--- a/examples/complete-kubernetes-addons/main.tf
+++ b/examples/complete-kubernetes-addons/main.tf
@@ -157,7 +157,7 @@ module "eks_blueprints_kubernetes_addons" {
   source = "../../modules/kubernetes-addons"
 
   eks_cluster_id               = module.eks_blueprints.eks_cluster_id
-  aws_eks_cluster_endpoint     = module.eks_blueprints.eks_cluster_endpoint
+  eks_cluster_endpoint         = module.eks_blueprints.eks_cluster_endpoint
   eks_oidc_provider            = module.eks_blueprints.oidc_provider
   eks_cluster_version          = module.eks_blueprints.eks_cluster_version
   eks_worker_security_group_id = module.eks_blueprints.worker_node_security_group_id

--- a/examples/complete-kubernetes-addons/main.tf
+++ b/examples/complete-kubernetes-addons/main.tf
@@ -157,6 +157,9 @@ module "eks_blueprints_kubernetes_addons" {
   source = "../../modules/kubernetes-addons"
 
   eks_cluster_id               = module.eks_blueprints.eks_cluster_id
+  aws_eks_cluster_endpoint     = module.eks_blueprints.eks_cluster_endpoint
+  eks_oidc_issuer_url          = module.eks_blueprints.eks_oidc_issuer_url
+  eks_cluster_version          = module.eks_blueprints.eks_cluster_version
   eks_worker_security_group_id = module.eks_blueprints.worker_node_security_group_id
   auto_scaling_group_names     = module.eks_blueprints.self_managed_node_group_autoscaling_groups
 

--- a/examples/crossplane/main.tf
+++ b/examples/crossplane/main.tf
@@ -84,7 +84,10 @@ module "eks_blueprints" {
 module "eks_blueprints_kubernetes_addons" {
   source = "../../modules/kubernetes-addons"
 
-  eks_cluster_id = module.eks_blueprints.eks_cluster_id
+  eks_cluster_id           = module.eks_blueprints.eks_cluster_id
+  aws_eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint
+  eks_oidc_issuer_url      = module.eks_blueprints.eks_oidc_issuer_url
+  eks_cluster_version      = module.eks_blueprints.eks_cluster_version
 
   enable_crossplane = true
 

--- a/examples/crossplane/main.tf
+++ b/examples/crossplane/main.tf
@@ -86,7 +86,7 @@ module "eks_blueprints_kubernetes_addons" {
 
   eks_cluster_id           = module.eks_blueprints.eks_cluster_id
   aws_eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint
-  eks_oidc_issuer_url      = module.eks_blueprints.eks_oidc_issuer_url
+  eks_oidc_provider        = module.eks_blueprints.oidc_provider
   eks_cluster_version      = module.eks_blueprints.eks_cluster_version
 
   enable_crossplane = true

--- a/examples/crossplane/main.tf
+++ b/examples/crossplane/main.tf
@@ -84,10 +84,10 @@ module "eks_blueprints" {
 module "eks_blueprints_kubernetes_addons" {
   source = "../../modules/kubernetes-addons"
 
-  eks_cluster_id           = module.eks_blueprints.eks_cluster_id
-  aws_eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint
-  eks_oidc_provider        = module.eks_blueprints.oidc_provider
-  eks_cluster_version      = module.eks_blueprints.eks_cluster_version
+  eks_cluster_id       = module.eks_blueprints.eks_cluster_id
+  eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint
+  eks_oidc_provider    = module.eks_blueprints.oidc_provider
+  eks_cluster_version  = module.eks_blueprints.eks_cluster_version
 
   enable_crossplane = true
 

--- a/examples/eks-cluster-with-external-dns/main.tf
+++ b/examples/eks-cluster-with-external-dns/main.tf
@@ -77,7 +77,7 @@ module "eks_blueprints_kubernetes_addons" {
 
   eks_cluster_id           = module.eks_blueprints.eks_cluster_id
   aws_eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint
-  eks_oidc_issuer_url      = module.eks_blueprints.eks_oidc_issuer_url
+  eks_oidc_provider        = module.eks_blueprints.oidc_provider
   eks_cluster_version      = module.eks_blueprints.eks_cluster_version
   eks_cluster_domain       = var.eks_cluster_domain
 

--- a/examples/eks-cluster-with-external-dns/main.tf
+++ b/examples/eks-cluster-with-external-dns/main.tf
@@ -75,11 +75,11 @@ module "eks_blueprints" {
 module "eks_blueprints_kubernetes_addons" {
   source = "../../modules/kubernetes-addons"
 
-  eks_cluster_id           = module.eks_blueprints.eks_cluster_id
-  aws_eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint
-  eks_oidc_provider        = module.eks_blueprints.oidc_provider
-  eks_cluster_version      = module.eks_blueprints.eks_cluster_version
-  eks_cluster_domain       = var.eks_cluster_domain
+  eks_cluster_id       = module.eks_blueprints.eks_cluster_id
+  eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint
+  eks_oidc_provider    = module.eks_blueprints.oidc_provider
+  eks_cluster_version  = module.eks_blueprints.eks_cluster_version
+  eks_cluster_domain   = var.eks_cluster_domain
 
   enable_argocd = true
   argocd_applications = {

--- a/examples/eks-cluster-with-external-dns/main.tf
+++ b/examples/eks-cluster-with-external-dns/main.tf
@@ -75,8 +75,11 @@ module "eks_blueprints" {
 module "eks_blueprints_kubernetes_addons" {
   source = "../../modules/kubernetes-addons"
 
-  eks_cluster_id     = module.eks_blueprints.eks_cluster_id
-  eks_cluster_domain = var.eks_cluster_domain
+  eks_cluster_id           = module.eks_blueprints.eks_cluster_id
+  aws_eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint
+  eks_oidc_issuer_url      = module.eks_blueprints.eks_oidc_issuer_url
+  eks_cluster_version      = module.eks_blueprints.eks_cluster_version
+  eks_cluster_domain       = var.eks_cluster_domain
 
   enable_argocd = true
   argocd_applications = {

--- a/examples/eks-cluster-with-new-vpc/main.tf
+++ b/examples/eks-cluster-with-new-vpc/main.tf
@@ -71,7 +71,10 @@ module "eks_blueprints" {
 module "eks_blueprints_kubernetes_addons" {
   source = "../../modules/kubernetes-addons"
 
-  eks_cluster_id = module.eks_blueprints.eks_cluster_id
+  eks_cluster_id           = module.eks_blueprints.eks_cluster_id
+  aws_eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint
+  eks_oidc_issuer_url      = module.eks_blueprints.eks_oidc_issuer_url
+  eks_cluster_version      = module.eks_blueprints.eks_cluster_version
 
   # EKS Managed Add-ons
   enable_amazon_eks_vpc_cni    = true

--- a/examples/eks-cluster-with-new-vpc/main.tf
+++ b/examples/eks-cluster-with-new-vpc/main.tf
@@ -73,7 +73,7 @@ module "eks_blueprints_kubernetes_addons" {
 
   eks_cluster_id           = module.eks_blueprints.eks_cluster_id
   aws_eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint
-  eks_oidc_issuer_url      = module.eks_blueprints.eks_oidc_issuer_url
+  eks_oidc_provider        = module.eks_blueprints.oidc_provider
   eks_cluster_version      = module.eks_blueprints.eks_cluster_version
 
   # EKS Managed Add-ons

--- a/examples/eks-cluster-with-new-vpc/main.tf
+++ b/examples/eks-cluster-with-new-vpc/main.tf
@@ -71,10 +71,10 @@ module "eks_blueprints" {
 module "eks_blueprints_kubernetes_addons" {
   source = "../../modules/kubernetes-addons"
 
-  eks_cluster_id           = module.eks_blueprints.eks_cluster_id
-  aws_eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint
-  eks_oidc_provider        = module.eks_blueprints.oidc_provider
-  eks_cluster_version      = module.eks_blueprints.eks_cluster_version
+  eks_cluster_id       = module.eks_blueprints.eks_cluster_id
+  eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint
+  eks_oidc_provider    = module.eks_blueprints.oidc_provider
+  eks_cluster_version  = module.eks_blueprints.eks_cluster_version
 
   # EKS Managed Add-ons
   enable_amazon_eks_vpc_cni    = true

--- a/examples/fargate-serverless/main.tf
+++ b/examples/fargate-serverless/main.tf
@@ -92,7 +92,7 @@ module "eks_blueprints_kubernetes_addons" {
 
   eks_cluster_id           = module.eks_blueprints.eks_cluster_id
   aws_eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint
-  eks_oidc_issuer_url      = module.eks_blueprints.eks_oidc_issuer_url
+  eks_oidc_provider        = module.eks_blueprints.oidc_provider
   eks_cluster_version      = module.eks_blueprints.eks_cluster_version
 
   enable_amazon_eks_vpc_cni = true

--- a/examples/fargate-serverless/main.tf
+++ b/examples/fargate-serverless/main.tf
@@ -90,10 +90,10 @@ module "eks_blueprints" {
 module "eks_blueprints_kubernetes_addons" {
   source = "../../modules/kubernetes-addons"
 
-  eks_cluster_id           = module.eks_blueprints.eks_cluster_id
-  aws_eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint
-  eks_oidc_provider        = module.eks_blueprints.oidc_provider
-  eks_cluster_version      = module.eks_blueprints.eks_cluster_version
+  eks_cluster_id       = module.eks_blueprints.eks_cluster_id
+  eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint
+  eks_oidc_provider    = module.eks_blueprints.oidc_provider
+  eks_cluster_version  = module.eks_blueprints.eks_cluster_version
 
   enable_amazon_eks_vpc_cni = true
   amazon_eks_vpc_cni_config = {

--- a/examples/fargate-serverless/main.tf
+++ b/examples/fargate-serverless/main.tf
@@ -90,7 +90,10 @@ module "eks_blueprints" {
 module "eks_blueprints_kubernetes_addons" {
   source = "../../modules/kubernetes-addons"
 
-  eks_cluster_id = module.eks_blueprints.eks_cluster_id
+  eks_cluster_id           = module.eks_blueprints.eks_cluster_id
+  aws_eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint
+  eks_oidc_issuer_url      = module.eks_blueprints.eks_oidc_issuer_url
+  eks_cluster_version      = module.eks_blueprints.eks_cluster_version
 
   enable_amazon_eks_vpc_cni = true
   amazon_eks_vpc_cni_config = {

--- a/examples/fully-private-eks-cluster/main.tf
+++ b/examples/fully-private-eks-cluster/main.tf
@@ -44,9 +44,6 @@ module "eks_blueprints" {
   # Step 1. Set cluster API endpoint both private and public
   cluster_endpoint_public_access  = true
   cluster_endpoint_private_access = true
-  aws_eks_cluster_endpoint        = module.eks_blueprints.eks_cluster_endpoint
-  eks_oidc_issuer_url             = module.eks_blueprints.eks_oidc_issuer_url
-  eks_cluster_version             = module.eks_blueprints.eks_cluster_version
 
   # Step 2. Change cluster endpoint to private only, comment out the above lines and uncomment the below lines.
   # cluster_endpoint_public_access  = false

--- a/examples/fully-private-eks-cluster/main.tf
+++ b/examples/fully-private-eks-cluster/main.tf
@@ -44,6 +44,9 @@ module "eks_blueprints" {
   # Step 1. Set cluster API endpoint both private and public
   cluster_endpoint_public_access  = true
   cluster_endpoint_private_access = true
+  aws_eks_cluster_endpoint        = module.eks_blueprints.eks_cluster_endpoint
+  eks_oidc_issuer_url             = module.eks_blueprints.eks_oidc_issuer_url
+  eks_cluster_version             = module.eks_blueprints.eks_cluster_version
 
   # Step 2. Change cluster endpoint to private only, comment out the above lines and uncomment the below lines.
   # cluster_endpoint_public_access  = false

--- a/examples/game-tech/agones-game-controller/main.tf
+++ b/examples/game-tech/agones-game-controller/main.tf
@@ -99,7 +99,7 @@ module "eks_blueprints_kubernetes_addons" {
 
   eks_cluster_id               = module.eks_blueprints.eks_cluster_id
   aws_eks_cluster_endpoint     = module.eks_blueprints.eks_cluster_endpoint
-  eks_oidc_issuer_url          = module.eks_blueprints.eks_oidc_issuer_url
+  eks_oidc_provider            = module.eks_blueprints.oidc_provider
   eks_cluster_version          = module.eks_blueprints.eks_cluster_version
   eks_worker_security_group_id = module.eks_blueprints.worker_node_security_group_id
 

--- a/examples/game-tech/agones-game-controller/main.tf
+++ b/examples/game-tech/agones-game-controller/main.tf
@@ -98,6 +98,9 @@ module "eks_blueprints_kubernetes_addons" {
   source = "../../..//modules/kubernetes-addons"
 
   eks_cluster_id               = module.eks_blueprints.eks_cluster_id
+  aws_eks_cluster_endpoint     = module.eks_blueprints.eks_cluster_endpoint
+  eks_oidc_issuer_url          = module.eks_blueprints.eks_oidc_issuer_url
+  eks_cluster_version          = module.eks_blueprints.eks_cluster_version
   eks_worker_security_group_id = module.eks_blueprints.worker_node_security_group_id
 
   # Add-ons

--- a/examples/game-tech/agones-game-controller/main.tf
+++ b/examples/game-tech/agones-game-controller/main.tf
@@ -98,7 +98,7 @@ module "eks_blueprints_kubernetes_addons" {
   source = "../../..//modules/kubernetes-addons"
 
   eks_cluster_id               = module.eks_blueprints.eks_cluster_id
-  aws_eks_cluster_endpoint     = module.eks_blueprints.eks_cluster_endpoint
+  eks_cluster_endpoint         = module.eks_blueprints.eks_cluster_endpoint
   eks_oidc_provider            = module.eks_blueprints.oidc_provider
   eks_cluster_version          = module.eks_blueprints.eks_cluster_version
   eks_worker_security_group_id = module.eks_blueprints.worker_node_security_group_id

--- a/examples/gitops/argocd/main.tf
+++ b/examples/gitops/argocd/main.tf
@@ -73,10 +73,10 @@ module "eks_blueprints" {
 module "eks_blueprints_kubernetes_addons" {
   source = "../../../modules/kubernetes-addons"
 
-  eks_cluster_id           = module.eks_blueprints.eks_cluster_id
-  aws_eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint
-  eks_oidc_provider        = module.eks_blueprints.oidc_provider
-  eks_cluster_version      = module.eks_blueprints.eks_cluster_version
+  eks_cluster_id       = module.eks_blueprints.eks_cluster_id
+  eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint
+  eks_oidc_provider    = module.eks_blueprints.oidc_provider
+  eks_cluster_version  = module.eks_blueprints.eks_cluster_version
 
   enable_argocd         = true
   argocd_manage_add_ons = true # Indicates that ArgoCD is responsible for managing/deploying add-ons

--- a/examples/gitops/argocd/main.tf
+++ b/examples/gitops/argocd/main.tf
@@ -73,7 +73,10 @@ module "eks_blueprints" {
 module "eks_blueprints_kubernetes_addons" {
   source = "../../../modules/kubernetes-addons"
 
-  eks_cluster_id = module.eks_blueprints.eks_cluster_id
+  eks_cluster_id           = module.eks_blueprints.eks_cluster_id
+  aws_eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint
+  eks_oidc_issuer_url      = module.eks_blueprints.eks_oidc_issuer_url
+  eks_cluster_version      = module.eks_blueprints.eks_cluster_version
 
   enable_argocd         = true
   argocd_manage_add_ons = true # Indicates that ArgoCD is responsible for managing/deploying add-ons

--- a/examples/gitops/argocd/main.tf
+++ b/examples/gitops/argocd/main.tf
@@ -75,7 +75,7 @@ module "eks_blueprints_kubernetes_addons" {
 
   eks_cluster_id           = module.eks_blueprints.eks_cluster_id
   aws_eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint
-  eks_oidc_issuer_url      = module.eks_blueprints.eks_oidc_issuer_url
+  eks_oidc_provider        = module.eks_blueprints.oidc_provider
   eks_cluster_version      = module.eks_blueprints.eks_cluster_version
 
   enable_argocd         = true

--- a/examples/ingress-controllers/nginx/main.tf
+++ b/examples/ingress-controllers/nginx/main.tf
@@ -72,7 +72,7 @@ module "eks_blueprints_kubernetes_addons" {
 
   eks_cluster_id           = module.eks_blueprints.eks_cluster_id
   aws_eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint
-  eks_oidc_issuer_url      = module.eks_blueprints.eks_oidc_issuer_url
+  eks_oidc_provider        = module.eks_blueprints.oidc_provider
   eks_cluster_version      = module.eks_blueprints.eks_cluster_version
 
   # EKS Managed Add-ons

--- a/examples/ingress-controllers/nginx/main.tf
+++ b/examples/ingress-controllers/nginx/main.tf
@@ -70,10 +70,10 @@ module "eks_blueprints" {
 module "eks_blueprints_kubernetes_addons" {
   source = "../../../modules/kubernetes-addons"
 
-  eks_cluster_id           = module.eks_blueprints.eks_cluster_id
-  aws_eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint
-  eks_oidc_provider        = module.eks_blueprints.oidc_provider
-  eks_cluster_version      = module.eks_blueprints.eks_cluster_version
+  eks_cluster_id       = module.eks_blueprints.eks_cluster_id
+  eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint
+  eks_oidc_provider    = module.eks_blueprints.oidc_provider
+  eks_cluster_version  = module.eks_blueprints.eks_cluster_version
 
   # EKS Managed Add-ons
   enable_amazon_eks_coredns    = true

--- a/examples/ingress-controllers/nginx/main.tf
+++ b/examples/ingress-controllers/nginx/main.tf
@@ -70,7 +70,10 @@ module "eks_blueprints" {
 module "eks_blueprints_kubernetes_addons" {
   source = "../../../modules/kubernetes-addons"
 
-  eks_cluster_id = module.eks_blueprints.eks_cluster_id
+  eks_cluster_id           = module.eks_blueprints.eks_cluster_id
+  aws_eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint
+  eks_oidc_issuer_url      = module.eks_blueprints.eks_oidc_issuer_url
+  eks_cluster_version      = module.eks_blueprints.eks_cluster_version
 
   # EKS Managed Add-ons
   enable_amazon_eks_coredns    = true

--- a/examples/ipv6-eks-cluster/main.tf
+++ b/examples/ipv6-eks-cluster/main.tf
@@ -73,10 +73,10 @@ module "eks_blueprints" {
 module "eks_blueprints_kubernetes_addons" {
   source = "../../modules/kubernetes-addons"
 
-  eks_cluster_id           = module.eks_blueprints.eks_cluster_id
-  aws_eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint
-  eks_oidc_provider        = module.eks_blueprints.oidc_provider
-  eks_cluster_version      = module.eks_blueprints.eks_cluster_version
+  eks_cluster_id       = module.eks_blueprints.eks_cluster_id
+  eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint
+  eks_oidc_provider    = module.eks_blueprints.oidc_provider
+  eks_cluster_version  = module.eks_blueprints.eks_cluster_version
 
   enable_ipv6 = true # Enable Ipv6 network. Attaches new VPC CNI policy to the IRSA role
 

--- a/examples/ipv6-eks-cluster/main.tf
+++ b/examples/ipv6-eks-cluster/main.tf
@@ -73,8 +73,12 @@ module "eks_blueprints" {
 module "eks_blueprints_kubernetes_addons" {
   source = "../../modules/kubernetes-addons"
 
-  eks_cluster_id = module.eks_blueprints.eks_cluster_id
-  enable_ipv6    = true # Enable Ipv6 network. Attaches new VPC CNI policy to the IRSA role
+  eks_cluster_id           = module.eks_blueprints.eks_cluster_id
+  aws_eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint
+  eks_oidc_issuer_url      = module.eks_blueprints.eks_oidc_issuer_url
+  eks_cluster_version      = module.eks_blueprints.eks_cluster_version
+
+  enable_ipv6 = true # Enable Ipv6 network. Attaches new VPC CNI policy to the IRSA role
 
   # EKS Managed Add-ons
   enable_amazon_eks_coredns    = true

--- a/examples/ipv6-eks-cluster/main.tf
+++ b/examples/ipv6-eks-cluster/main.tf
@@ -75,7 +75,7 @@ module "eks_blueprints_kubernetes_addons" {
 
   eks_cluster_id           = module.eks_blueprints.eks_cluster_id
   aws_eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint
-  eks_oidc_issuer_url      = module.eks_blueprints.eks_oidc_issuer_url
+  eks_oidc_provider        = module.eks_blueprints.oidc_provider
   eks_cluster_version      = module.eks_blueprints.eks_cluster_version
 
   enable_ipv6 = true # Enable Ipv6 network. Attaches new VPC CNI policy to the IRSA role

--- a/examples/karpenter/main.tf
+++ b/examples/karpenter/main.tf
@@ -104,10 +104,10 @@ module "eks_blueprints" {
 module "eks_blueprints_kubernetes_addons" {
   source = "../../modules/kubernetes-addons"
 
-  eks_cluster_id           = module.eks_blueprints.eks_cluster_id
-  aws_eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint
-  eks_oidc_provider        = module.eks_blueprints.oidc_provider
-  eks_cluster_version      = module.eks_blueprints.eks_cluster_version
+  eks_cluster_id       = module.eks_blueprints.eks_cluster_id
+  eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint
+  eks_oidc_provider    = module.eks_blueprints.oidc_provider
+  eks_cluster_version  = module.eks_blueprints.eks_cluster_version
 
   enable_karpenter = true
 

--- a/examples/karpenter/main.tf
+++ b/examples/karpenter/main.tf
@@ -106,7 +106,7 @@ module "eks_blueprints_kubernetes_addons" {
 
   eks_cluster_id           = module.eks_blueprints.eks_cluster_id
   aws_eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint
-  eks_oidc_issuer_url      = module.eks_blueprints.eks_oidc_issuer_url
+  eks_oidc_provider        = module.eks_blueprints.oidc_provider
   eks_cluster_version      = module.eks_blueprints.eks_cluster_version
 
   enable_karpenter = true

--- a/examples/karpenter/main.tf
+++ b/examples/karpenter/main.tf
@@ -104,7 +104,10 @@ module "eks_blueprints" {
 module "eks_blueprints_kubernetes_addons" {
   source = "../../modules/kubernetes-addons"
 
-  eks_cluster_id = module.eks_blueprints.eks_cluster_id
+  eks_cluster_id           = module.eks_blueprints.eks_cluster_id
+  aws_eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint
+  eks_oidc_issuer_url      = module.eks_blueprints.eks_oidc_issuer_url
+  eks_cluster_version      = module.eks_blueprints.eks_cluster_version
 
   enable_karpenter = true
 

--- a/examples/node-groups/managed-node-groups/main.tf
+++ b/examples/node-groups/managed-node-groups/main.tf
@@ -268,10 +268,10 @@ module "eks_blueprints" {
 module "eks_blueprints_kubernetes_addons" {
   source = "../../../modules/kubernetes-addons"
 
-  eks_cluster_id           = module.eks_blueprints.eks_cluster_id
-  aws_eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint
-  eks_oidc_provider        = module.eks_blueprints.oidc_provider
-  eks_cluster_version      = module.eks_blueprints.eks_cluster_version
+  eks_cluster_id       = module.eks_blueprints.eks_cluster_id
+  eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint
+  eks_oidc_provider    = module.eks_blueprints.oidc_provider
+  eks_cluster_version  = module.eks_blueprints.eks_cluster_version
 
   enable_metrics_server     = true
   enable_cluster_autoscaler = true

--- a/examples/node-groups/managed-node-groups/main.tf
+++ b/examples/node-groups/managed-node-groups/main.tf
@@ -268,7 +268,10 @@ module "eks_blueprints" {
 module "eks_blueprints_kubernetes_addons" {
   source = "../../../modules/kubernetes-addons"
 
-  eks_cluster_id = module.eks_blueprints.eks_cluster_id
+  eks_cluster_id           = module.eks_blueprints.eks_cluster_id
+  aws_eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint
+  eks_oidc_issuer_url      = module.eks_blueprints.eks_oidc_issuer_url
+  eks_cluster_version      = module.eks_blueprints.eks_cluster_version
 
   enable_metrics_server     = true
   enable_cluster_autoscaler = true

--- a/examples/node-groups/managed-node-groups/main.tf
+++ b/examples/node-groups/managed-node-groups/main.tf
@@ -270,7 +270,7 @@ module "eks_blueprints_kubernetes_addons" {
 
   eks_cluster_id           = module.eks_blueprints.eks_cluster_id
   aws_eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint
-  eks_oidc_issuer_url      = module.eks_blueprints.eks_oidc_issuer_url
+  eks_oidc_provider        = module.eks_blueprints.oidc_provider
   eks_cluster_version      = module.eks_blueprints.eks_cluster_version
 
   enable_metrics_server     = true

--- a/examples/node-groups/windows-node-groups/main.tf
+++ b/examples/node-groups/windows-node-groups/main.tf
@@ -85,7 +85,7 @@ module "eks_blueprints_kubernetes_addons" {
 
   eks_cluster_id           = module.eks_blueprints.eks_cluster_id
   aws_eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint
-  eks_oidc_issuer_url      = module.eks_blueprints.eks_oidc_issuer_url
+  eks_oidc_provider        = module.eks_blueprints.oidc_provider
   eks_cluster_version      = module.eks_blueprints.eks_cluster_version
 
   # EKS Managed Add-ons

--- a/examples/node-groups/windows-node-groups/main.tf
+++ b/examples/node-groups/windows-node-groups/main.tf
@@ -83,10 +83,10 @@ module "eks_blueprints" {
 module "eks_blueprints_kubernetes_addons" {
   source = "../../../modules/kubernetes-addons"
 
-  eks_cluster_id           = module.eks_blueprints.eks_cluster_id
-  aws_eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint
-  eks_oidc_provider        = module.eks_blueprints.oidc_provider
-  eks_cluster_version      = module.eks_blueprints.eks_cluster_version
+  eks_cluster_id       = module.eks_blueprints.eks_cluster_id
+  eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint
+  eks_oidc_provider    = module.eks_blueprints.oidc_provider
+  eks_cluster_version  = module.eks_blueprints.eks_cluster_version
 
   # EKS Managed Add-ons
   enable_amazon_eks_coredns    = true

--- a/examples/node-groups/windows-node-groups/main.tf
+++ b/examples/node-groups/windows-node-groups/main.tf
@@ -83,7 +83,10 @@ module "eks_blueprints" {
 module "eks_blueprints_kubernetes_addons" {
   source = "../../../modules/kubernetes-addons"
 
-  eks_cluster_id = module.eks_blueprints.eks_cluster_id
+  eks_cluster_id           = module.eks_blueprints.eks_cluster_id
+  aws_eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint
+  eks_oidc_issuer_url      = module.eks_blueprints.eks_oidc_issuer_url
+  eks_cluster_version      = module.eks_blueprints.eks_cluster_version
 
   # EKS Managed Add-ons
   enable_amazon_eks_coredns    = true

--- a/examples/observability/adot-amp-grafana-for-haproxy/main.tf
+++ b/examples/observability/adot-amp-grafana-for-haproxy/main.tf
@@ -79,7 +79,7 @@ module "eks_blueprints_kubernetes_addons" {
 
   eks_cluster_id           = module.eks_blueprints.eks_cluster_id
   aws_eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint
-  eks_oidc_issuer_url      = module.eks_blueprints.eks_oidc_issuer_url
+  eks_oidc_provider        = module.eks_blueprints.oidc_provider
   eks_cluster_version      = module.eks_blueprints.eks_cluster_version
 
   enable_cert_manager                  = true

--- a/examples/observability/adot-amp-grafana-for-haproxy/main.tf
+++ b/examples/observability/adot-amp-grafana-for-haproxy/main.tf
@@ -77,10 +77,10 @@ module "eks_blueprints" {
 module "eks_blueprints_kubernetes_addons" {
   source = "../../../modules/kubernetes-addons"
 
-  eks_cluster_id           = module.eks_blueprints.eks_cluster_id
-  aws_eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint
-  eks_oidc_provider        = module.eks_blueprints.oidc_provider
-  eks_cluster_version      = module.eks_blueprints.eks_cluster_version
+  eks_cluster_id       = module.eks_blueprints.eks_cluster_id
+  eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint
+  eks_oidc_provider    = module.eks_blueprints.oidc_provider
+  eks_cluster_version  = module.eks_blueprints.eks_cluster_version
 
   enable_cert_manager                  = true
   enable_opentelemetry_operator        = true

--- a/examples/observability/adot-amp-grafana-for-haproxy/main.tf
+++ b/examples/observability/adot-amp-grafana-for-haproxy/main.tf
@@ -77,7 +77,10 @@ module "eks_blueprints" {
 module "eks_blueprints_kubernetes_addons" {
   source = "../../../modules/kubernetes-addons"
 
-  eks_cluster_id = module.eks_blueprints.eks_cluster_id
+  eks_cluster_id           = module.eks_blueprints.eks_cluster_id
+  aws_eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint
+  eks_oidc_issuer_url      = module.eks_blueprints.eks_oidc_issuer_url
+  eks_cluster_version      = module.eks_blueprints.eks_cluster_version
 
   enable_cert_manager                  = true
   enable_opentelemetry_operator        = true

--- a/examples/observability/adot-amp-grafana-for-java/main.tf
+++ b/examples/observability/adot-amp-grafana-for-java/main.tf
@@ -79,7 +79,7 @@ module "eks_blueprints_kubernetes_addons" {
 
   eks_cluster_id           = module.eks_blueprints.eks_cluster_id
   aws_eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint
-  eks_oidc_issuer_url      = module.eks_blueprints.eks_oidc_issuer_url
+  eks_oidc_provider        = module.eks_blueprints.oidc_provider
   eks_cluster_version      = module.eks_blueprints.eks_cluster_version
 
   enable_cert_manager                  = true

--- a/examples/observability/adot-amp-grafana-for-java/main.tf
+++ b/examples/observability/adot-amp-grafana-for-java/main.tf
@@ -77,10 +77,10 @@ module "eks_blueprints" {
 module "eks_blueprints_kubernetes_addons" {
   source = "../../../modules/kubernetes-addons"
 
-  eks_cluster_id           = module.eks_blueprints.eks_cluster_id
-  aws_eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint
-  eks_oidc_provider        = module.eks_blueprints.oidc_provider
-  eks_cluster_version      = module.eks_blueprints.eks_cluster_version
+  eks_cluster_id       = module.eks_blueprints.eks_cluster_id
+  eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint
+  eks_oidc_provider    = module.eks_blueprints.oidc_provider
+  eks_cluster_version  = module.eks_blueprints.eks_cluster_version
 
   enable_cert_manager                  = true
   enable_opentelemetry_operator        = true

--- a/examples/observability/adot-amp-grafana-for-java/main.tf
+++ b/examples/observability/adot-amp-grafana-for-java/main.tf
@@ -77,7 +77,10 @@ module "eks_blueprints" {
 module "eks_blueprints_kubernetes_addons" {
   source = "../../../modules/kubernetes-addons"
 
-  eks_cluster_id = module.eks_blueprints.eks_cluster_id
+  eks_cluster_id           = module.eks_blueprints.eks_cluster_id
+  aws_eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint
+  eks_oidc_issuer_url      = module.eks_blueprints.eks_oidc_issuer_url
+  eks_cluster_version      = module.eks_blueprints.eks_cluster_version
 
   enable_cert_manager                  = true
   enable_opentelemetry_operator        = true

--- a/examples/observability/adot-amp-grafana-for-memcached/main.tf
+++ b/examples/observability/adot-amp-grafana-for-memcached/main.tf
@@ -77,10 +77,10 @@ module "eks_blueprints" {
 module "eks_blueprints_kubernetes_addons" {
   source = "../../../modules/kubernetes-addons"
 
-  eks_cluster_id           = module.eks_blueprints.eks_cluster_id
-  aws_eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint
-  eks_oidc_provider        = module.eks_blueprints.oidc_provider
-  eks_cluster_version      = module.eks_blueprints.eks_cluster_version
+  eks_cluster_id       = module.eks_blueprints.eks_cluster_id
+  eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint
+  eks_oidc_provider    = module.eks_blueprints.oidc_provider
+  eks_cluster_version  = module.eks_blueprints.eks_cluster_version
 
   # OTEL JMX use cases
   enable_cert_manager                  = true

--- a/examples/observability/adot-amp-grafana-for-memcached/main.tf
+++ b/examples/observability/adot-amp-grafana-for-memcached/main.tf
@@ -77,7 +77,10 @@ module "eks_blueprints" {
 module "eks_blueprints_kubernetes_addons" {
   source = "../../../modules/kubernetes-addons"
 
-  eks_cluster_id = module.eks_blueprints.eks_cluster_id
+  eks_cluster_id           = module.eks_blueprints.eks_cluster_id
+  aws_eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint
+  eks_oidc_issuer_url      = module.eks_blueprints.eks_oidc_issuer_url
+  eks_cluster_version      = module.eks_blueprints.eks_cluster_version
 
   # OTEL JMX use cases
   enable_cert_manager                  = true

--- a/examples/observability/adot-amp-grafana-for-memcached/main.tf
+++ b/examples/observability/adot-amp-grafana-for-memcached/main.tf
@@ -79,7 +79,7 @@ module "eks_blueprints_kubernetes_addons" {
 
   eks_cluster_id           = module.eks_blueprints.eks_cluster_id
   aws_eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint
-  eks_oidc_issuer_url      = module.eks_blueprints.eks_oidc_issuer_url
+  eks_oidc_provider        = module.eks_blueprints.oidc_provider
   eks_cluster_version      = module.eks_blueprints.eks_cluster_version
 
   # OTEL JMX use cases

--- a/examples/observability/adot-amp-grafana-for-nginx/main.tf
+++ b/examples/observability/adot-amp-grafana-for-nginx/main.tf
@@ -79,7 +79,7 @@ module "eks_blueprints_kubernetes_addons" {
 
   eks_cluster_id           = module.eks_blueprints.eks_cluster_id
   aws_eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint
-  eks_oidc_issuer_url      = module.eks_blueprints.eks_oidc_issuer_url
+  eks_oidc_provider        = module.eks_blueprints.oidc_provider
   eks_cluster_version      = module.eks_blueprints.eks_cluster_version
 
   enable_cert_manager                  = true

--- a/examples/observability/adot-amp-grafana-for-nginx/main.tf
+++ b/examples/observability/adot-amp-grafana-for-nginx/main.tf
@@ -77,10 +77,10 @@ module "eks_blueprints" {
 module "eks_blueprints_kubernetes_addons" {
   source = "../../../modules/kubernetes-addons"
 
-  eks_cluster_id           = module.eks_blueprints.eks_cluster_id
-  aws_eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint
-  eks_oidc_provider        = module.eks_blueprints.oidc_provider
-  eks_cluster_version      = module.eks_blueprints.eks_cluster_version
+  eks_cluster_id       = module.eks_blueprints.eks_cluster_id
+  eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint
+  eks_oidc_provider    = module.eks_blueprints.oidc_provider
+  eks_cluster_version  = module.eks_blueprints.eks_cluster_version
 
   enable_cert_manager                  = true
   enable_opentelemetry_operator        = true

--- a/examples/observability/adot-amp-grafana-for-nginx/main.tf
+++ b/examples/observability/adot-amp-grafana-for-nginx/main.tf
@@ -77,7 +77,10 @@ module "eks_blueprints" {
 module "eks_blueprints_kubernetes_addons" {
   source = "../../../modules/kubernetes-addons"
 
-  eks_cluster_id = module.eks_blueprints.eks_cluster_id
+  eks_cluster_id           = module.eks_blueprints.eks_cluster_id
+  aws_eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint
+  eks_oidc_issuer_url      = module.eks_blueprints.eks_oidc_issuer_url
+  eks_cluster_version      = module.eks_blueprints.eks_cluster_version
 
   enable_cert_manager                  = true
   enable_opentelemetry_operator        = true

--- a/examples/observability/amp-amg-opensearch/main.tf
+++ b/examples/observability/amp-amg-opensearch/main.tf
@@ -77,7 +77,10 @@ module "eks_blueprints" {
 module "eks_blueprints_kubernetes_addons" {
   source = "../../../modules/kubernetes-addons"
 
-  eks_cluster_id = module.eks_blueprints.eks_cluster_id
+  eks_cluster_id           = module.eks_blueprints.eks_cluster_id
+  aws_eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint
+  eks_oidc_issuer_url      = module.eks_blueprints.eks_oidc_issuer_url
+  eks_cluster_version      = module.eks_blueprints.eks_cluster_version
 
   # Add-ons
   enable_metrics_server     = true

--- a/examples/observability/amp-amg-opensearch/main.tf
+++ b/examples/observability/amp-amg-opensearch/main.tf
@@ -79,7 +79,7 @@ module "eks_blueprints_kubernetes_addons" {
 
   eks_cluster_id           = module.eks_blueprints.eks_cluster_id
   aws_eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint
-  eks_oidc_issuer_url      = module.eks_blueprints.eks_oidc_issuer_url
+  eks_oidc_provider        = module.eks_blueprints.oidc_provider
   eks_cluster_version      = module.eks_blueprints.eks_cluster_version
 
   # Add-ons

--- a/examples/observability/amp-amg-opensearch/main.tf
+++ b/examples/observability/amp-amg-opensearch/main.tf
@@ -77,10 +77,10 @@ module "eks_blueprints" {
 module "eks_blueprints_kubernetes_addons" {
   source = "../../../modules/kubernetes-addons"
 
-  eks_cluster_id           = module.eks_blueprints.eks_cluster_id
-  aws_eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint
-  eks_oidc_provider        = module.eks_blueprints.oidc_provider
-  eks_cluster_version      = module.eks_blueprints.eks_cluster_version
+  eks_cluster_id       = module.eks_blueprints.eks_cluster_id
+  eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint
+  eks_oidc_provider    = module.eks_blueprints.oidc_provider
+  eks_cluster_version  = module.eks_blueprints.eks_cluster_version
 
   # Add-ons
   enable_metrics_server     = true

--- a/examples/tls-with-aws-pca-issuer/main.tf
+++ b/examples/tls-with-aws-pca-issuer/main.tf
@@ -73,7 +73,10 @@ module "eks_blueprints" {
 module "eks_blueprints_kubernetes_addons" {
   source = "../../modules/kubernetes-addons"
 
-  eks_cluster_id = module.eks_blueprints.eks_cluster_id
+  eks_cluster_id           = module.eks_blueprints.eks_cluster_id
+  aws_eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint
+  eks_oidc_issuer_url      = module.eks_blueprints.eks_oidc_issuer_url
+  eks_cluster_version      = module.eks_blueprints.eks_cluster_version
 
   # EKS Managed Add-ons
   enable_amazon_eks_vpc_cni    = true

--- a/examples/tls-with-aws-pca-issuer/main.tf
+++ b/examples/tls-with-aws-pca-issuer/main.tf
@@ -75,7 +75,7 @@ module "eks_blueprints_kubernetes_addons" {
 
   eks_cluster_id           = module.eks_blueprints.eks_cluster_id
   aws_eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint
-  eks_oidc_issuer_url      = module.eks_blueprints.eks_oidc_issuer_url
+  eks_oidc_provider        = module.eks_blueprints.oidc_provider
   eks_cluster_version      = module.eks_blueprints.eks_cluster_version
 
   # EKS Managed Add-ons

--- a/examples/tls-with-aws-pca-issuer/main.tf
+++ b/examples/tls-with-aws-pca-issuer/main.tf
@@ -73,10 +73,10 @@ module "eks_blueprints" {
 module "eks_blueprints_kubernetes_addons" {
   source = "../../modules/kubernetes-addons"
 
-  eks_cluster_id           = module.eks_blueprints.eks_cluster_id
-  aws_eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint
-  eks_oidc_provider        = module.eks_blueprints.oidc_provider
-  eks_cluster_version      = module.eks_blueprints.eks_cluster_version
+  eks_cluster_id       = module.eks_blueprints.eks_cluster_id
+  eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint
+  eks_oidc_provider    = module.eks_blueprints.oidc_provider
+  eks_cluster_version  = module.eks_blueprints.eks_cluster_version
 
   # EKS Managed Add-ons
   enable_amazon_eks_vpc_cni    = true

--- a/modules/kubernetes-addons/README.md
+++ b/modules/kubernetes-addons/README.md
@@ -60,7 +60,6 @@
 | Name | Type |
 |------|------|
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
-| [aws_eks_cluster.eks_cluster](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_cluster) | data source |
 | [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 
@@ -88,6 +87,7 @@
 | <a name="input_aws_cloudwatch_metrics_helm_config"></a> [aws\_cloudwatch\_metrics\_helm\_config](#input\_aws\_cloudwatch\_metrics\_helm\_config) | AWS CloudWatch Metrics Helm Chart config | `any` | `{}` | no |
 | <a name="input_aws_cloudwatch_metrics_irsa_policies"></a> [aws\_cloudwatch\_metrics\_irsa\_policies](#input\_aws\_cloudwatch\_metrics\_irsa\_policies) | Additional IAM policies for a IAM role for service accounts | `list(string)` | `[]` | no |
 | <a name="input_aws_efs_csi_driver_helm_config"></a> [aws\_efs\_csi\_driver\_helm\_config](#input\_aws\_efs\_csi\_driver\_helm\_config) | AWS EFS CSI driver Helm Chart config | `any` | `{}` | no |
+| <a name="input_aws_eks_cluster_endpoint"></a> [aws\_eks\_cluster\_endpoint](#input\_aws\_eks\_cluster\_endpoint) | Endpoint for your Kubernetes API server | `string` | n/a | yes |
 | <a name="input_aws_for_fluentbit_cw_log_group_kms_key_arn"></a> [aws\_for\_fluentbit\_cw\_log\_group\_kms\_key\_arn](#input\_aws\_for\_fluentbit\_cw\_log\_group\_kms\_key\_arn) | FluentBit CloudWatch Log group KMS Key | `string` | `null` | no |
 | <a name="input_aws_for_fluentbit_cw_log_group_name"></a> [aws\_for\_fluentbit\_cw\_log\_group\_name](#input\_aws\_for\_fluentbit\_cw\_log\_group\_name) | FluentBit CloudWatch Log group name | `string` | `null` | no |
 | <a name="input_aws_for_fluentbit_cw_log_group_retention"></a> [aws\_for\_fluentbit\_cw\_log\_group\_retention](#input\_aws\_for\_fluentbit\_cw\_log\_group\_retention) | FluentBit CloudWatch Log group retention period | `number` | `90` | no |
@@ -110,6 +110,8 @@
 | <a name="input_crossplane_jet_aws_provider"></a> [crossplane\_jet\_aws\_provider](#input\_crossplane\_jet\_aws\_provider) | AWS Provider Jet AWS config for Crossplane | <pre>object({<br>    enable                   = bool<br>    provider_aws_version     = string<br>    additional_irsa_policies = list(string)<br>  })</pre> | <pre>{<br>  "additional_irsa_policies": [],<br>  "enable": false,<br>  "provider_aws_version": "v0.24.1"<br>}</pre> | no |
 | <a name="input_eks_cluster_domain"></a> [eks\_cluster\_domain](#input\_eks\_cluster\_domain) | The domain for the EKS cluster. | `string` | `""` | no |
 | <a name="input_eks_cluster_id"></a> [eks\_cluster\_id](#input\_eks\_cluster\_id) | EKS Cluster Id | `string` | n/a | yes |
+| <a name="input_eks_cluster_version"></a> [eks\_cluster\_version](#input\_eks\_cluster\_version) | The Kubernetes version for the cluster | `string` | n/a | yes |
+| <a name="input_eks_oidc_issuer_url"></a> [eks\_oidc\_issuer\_url](#input\_eks\_oidc\_issuer\_url) | The OpenID Connect identity provider (issuer URL without leading `https://`) | `string` | n/a | yes |
 | <a name="input_eks_worker_security_group_id"></a> [eks\_worker\_security\_group\_id](#input\_eks\_worker\_security\_group\_id) | EKS Worker Security group Id created by EKS module | `string` | `""` | no |
 | <a name="input_enable_adot_collector_haproxy"></a> [enable\_adot\_collector\_haproxy](#input\_enable\_adot\_collector\_haproxy) | Enable metrics for HAProxy workloads | `bool` | `false` | no |
 | <a name="input_enable_adot_collector_java"></a> [enable\_adot\_collector\_java](#input\_enable\_adot\_collector\_java) | Enable metrics for JMX workloads | `bool` | `false` | no |

--- a/modules/kubernetes-addons/README.md
+++ b/modules/kubernetes-addons/README.md
@@ -87,7 +87,6 @@
 | <a name="input_aws_cloudwatch_metrics_helm_config"></a> [aws\_cloudwatch\_metrics\_helm\_config](#input\_aws\_cloudwatch\_metrics\_helm\_config) | AWS CloudWatch Metrics Helm Chart config | `any` | `{}` | no |
 | <a name="input_aws_cloudwatch_metrics_irsa_policies"></a> [aws\_cloudwatch\_metrics\_irsa\_policies](#input\_aws\_cloudwatch\_metrics\_irsa\_policies) | Additional IAM policies for a IAM role for service accounts | `list(string)` | `[]` | no |
 | <a name="input_aws_efs_csi_driver_helm_config"></a> [aws\_efs\_csi\_driver\_helm\_config](#input\_aws\_efs\_csi\_driver\_helm\_config) | AWS EFS CSI driver Helm Chart config | `any` | `{}` | no |
-| <a name="input_aws_eks_cluster_endpoint"></a> [aws\_eks\_cluster\_endpoint](#input\_aws\_eks\_cluster\_endpoint) | Endpoint for your Kubernetes API server | `string` | n/a | yes |
 | <a name="input_aws_for_fluentbit_cw_log_group_kms_key_arn"></a> [aws\_for\_fluentbit\_cw\_log\_group\_kms\_key\_arn](#input\_aws\_for\_fluentbit\_cw\_log\_group\_kms\_key\_arn) | FluentBit CloudWatch Log group KMS Key | `string` | `null` | no |
 | <a name="input_aws_for_fluentbit_cw_log_group_name"></a> [aws\_for\_fluentbit\_cw\_log\_group\_name](#input\_aws\_for\_fluentbit\_cw\_log\_group\_name) | FluentBit CloudWatch Log group name | `string` | `null` | no |
 | <a name="input_aws_for_fluentbit_cw_log_group_retention"></a> [aws\_for\_fluentbit\_cw\_log\_group\_retention](#input\_aws\_for\_fluentbit\_cw\_log\_group\_retention) | FluentBit CloudWatch Log group retention period | `number` | `90` | no |
@@ -109,9 +108,10 @@
 | <a name="input_crossplane_helm_config"></a> [crossplane\_helm\_config](#input\_crossplane\_helm\_config) | Crossplane Helm Chart config | `any` | `null` | no |
 | <a name="input_crossplane_jet_aws_provider"></a> [crossplane\_jet\_aws\_provider](#input\_crossplane\_jet\_aws\_provider) | AWS Provider Jet AWS config for Crossplane | <pre>object({<br>    enable                   = bool<br>    provider_aws_version     = string<br>    additional_irsa_policies = list(string)<br>  })</pre> | <pre>{<br>  "additional_irsa_policies": [],<br>  "enable": false,<br>  "provider_aws_version": "v0.24.1"<br>}</pre> | no |
 | <a name="input_eks_cluster_domain"></a> [eks\_cluster\_domain](#input\_eks\_cluster\_domain) | The domain for the EKS cluster. | `string` | `""` | no |
+| <a name="input_eks_cluster_endpoint"></a> [eks\_cluster\_endpoint](#input\_eks\_cluster\_endpoint) | Endpoint for your Kubernetes API server | `string` | n/a | yes |
 | <a name="input_eks_cluster_id"></a> [eks\_cluster\_id](#input\_eks\_cluster\_id) | EKS Cluster Id | `string` | n/a | yes |
 | <a name="input_eks_cluster_version"></a> [eks\_cluster\_version](#input\_eks\_cluster\_version) | The Kubernetes version for the cluster | `string` | n/a | yes |
-| <a name="input_eks_oidc_issuer_url"></a> [eks\_oidc\_issuer\_url](#input\_eks\_oidc\_issuer\_url) | The OpenID Connect identity provider (issuer URL without leading `https://`) | `string` | n/a | yes |
+| <a name="input_eks_oidc_provider"></a> [eks\_oidc\_provider](#input\_eks\_oidc\_provider) | The OpenID Connect identity provider (issuer URL without leading `https://`) | `string` | n/a | yes |
 | <a name="input_eks_worker_security_group_id"></a> [eks\_worker\_security\_group\_id](#input\_eks\_worker\_security\_group\_id) | EKS Worker Security group Id created by EKS module | `string` | `""` | no |
 | <a name="input_enable_adot_collector_haproxy"></a> [enable\_adot\_collector\_haproxy](#input\_enable\_adot\_collector\_haproxy) | Enable metrics for HAProxy workloads | `bool` | `false` | no |
 | <a name="input_enable_adot_collector_java"></a> [enable\_adot\_collector\_java](#input\_enable\_adot\_collector\_java) | Enable metrics for JMX workloads | `bool` | `false` | no |

--- a/modules/kubernetes-addons/data.tf
+++ b/modules/kubernetes-addons/data.tf
@@ -1,7 +1,3 @@
-data "aws_eks_cluster" "eks_cluster" {
-  name = var.eks_cluster_id
-}
-
 data "aws_partition" "current" {}
 
 data "aws_caller_identity" "current" {}

--- a/modules/kubernetes-addons/locals.tf
+++ b/modules/kubernetes-addons/locals.tf
@@ -25,12 +25,12 @@ locals {
     externalDns               = var.enable_external_dns ? module.external_dns[0].argocd_gitops_config : null
   }
 
-  eks_oidc_issuer_url = var.eks_oidc_issuer_url
+  eks_oidc_issuer_url = var.eks_oidc_provider
 
   addon_context = {
     aws_caller_identity_account_id = data.aws_caller_identity.current.account_id
     aws_caller_identity_arn        = data.aws_caller_identity.current.arn
-    aws_eks_cluster_endpoint       = var.aws_eks_cluster_endpoint
+    aws_eks_cluster_endpoint       = var.eks_cluster_endpoint
     aws_partition_id               = data.aws_partition.current.partition
     aws_region_name                = data.aws_region.current.name
     eks_cluster_id                 = var.eks_cluster_id

--- a/modules/kubernetes-addons/locals.tf
+++ b/modules/kubernetes-addons/locals.tf
@@ -25,12 +25,12 @@ locals {
     externalDns               = var.enable_external_dns ? module.external_dns[0].argocd_gitops_config : null
   }
 
-  eks_oidc_issuer_url = replace(data.aws_eks_cluster.eks_cluster.identity[0].oidc[0].issuer, "https://", "")
+  eks_oidc_issuer_url = var.eks_oidc_issuer_url
 
   addon_context = {
     aws_caller_identity_account_id = data.aws_caller_identity.current.account_id
     aws_caller_identity_arn        = data.aws_caller_identity.current.arn
-    aws_eks_cluster_endpoint       = data.aws_eks_cluster.eks_cluster.endpoint
+    aws_eks_cluster_endpoint       = var.aws_eks_cluster_endpoint
     aws_partition_id               = data.aws_partition.current.partition
     aws_region_name                = data.aws_region.current.name
     eks_cluster_id                 = var.eks_cluster_id

--- a/modules/kubernetes-addons/main.tf
+++ b/modules/kubernetes-addons/main.tf
@@ -19,7 +19,7 @@ module "aws_coredns" {
   enable_amazon_eks_coredns = var.enable_amazon_eks_coredns
   addon_config = merge(
     {
-      kubernetes_version = data.aws_eks_cluster.eks_cluster.version
+      kubernetes_version = var.eks_cluster_version
     },
     var.amazon_eks_coredns_config,
   )
@@ -28,7 +28,7 @@ module "aws_coredns" {
   enable_self_managed_coredns = var.enable_self_managed_coredns
   helm_config = merge(
     {
-      kubernetes_version = data.aws_eks_cluster.eks_cluster.version
+      kubernetes_version = var.eks_cluster_version
     },
     var.self_managed_coredns_helm_config,
     {

--- a/modules/kubernetes-addons/variables.tf
+++ b/modules/kubernetes-addons/variables.tf
@@ -39,7 +39,7 @@ variable "irsa_iam_permissions_boundary" {
   description = "IAM permissions boundary for IRSA roles"
 }
 
-variable "eks_oidc_issuer_url" {
+variable "eks_oidc_provider" {
   type        = string
   description = "The OpenID Connect identity provider (issuer URL without leading `https://`)"
 }

--- a/modules/kubernetes-addons/variables.tf
+++ b/modules/kubernetes-addons/variables.tf
@@ -39,6 +39,21 @@ variable "irsa_iam_permissions_boundary" {
   description = "IAM permissions boundary for IRSA roles"
 }
 
+variable "eks_oidc_issuer_url" {
+  type        = string
+  description = "The OpenID Connect identity provider (issuer URL without leading `https://`)"
+}
+
+variable "aws_eks_cluster_endpoint" {
+  type        = string
+  description = "Endpoint for your Kubernetes API server"
+}
+
+variable "eks_cluster_version" {
+  type        = string
+  description = "The Kubernetes version for the cluster"
+}
+
 #-----------EKS MANAGED ADD-ONS------------
 variable "enable_ipv6" {
   description = "Enable Ipv6 network. Attaches new VPC CNI policy to the IRSA role"

--- a/modules/kubernetes-addons/variables.tf
+++ b/modules/kubernetes-addons/variables.tf
@@ -44,7 +44,7 @@ variable "eks_oidc_provider" {
   description = "The OpenID Connect identity provider (issuer URL without leading `https://`)"
 }
 
-variable "aws_eks_cluster_endpoint" {
+variable "eks_cluster_endpoint" {
   type        = string
   description = "Endpoint for your Kubernetes API server"
 }


### PR DESCRIPTION
### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
- Passing EKS Blueprint outputs to addons module as inputs (vars) instead of using eks data resource in k8s-addons module 

### Motivation

<!-- What inspired you to submit this pull request? -->
- Support updates without disruptive changes (depends_on forcing downstream modules/resources to re-compute) - e.g. may occur during cluster upgrade process
- Building a better implicit dependency map (goes towards the single apply, ensuring correct ordering)


### More

TODO: 
- Parallel E2E tests needs to be done on this PR, plan examples [passed successfully](https://github.com/aws-ia/terraform-aws-eks-blueprints/actions/runs/2418089266)

- [ ] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR - TF docs may be fixed in multiple places here, will let CI run first and then will correct running manually if needed (since it can take LONG time for it to run locally).


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
