### PR TITLE
fix: Remove `app.kubernetes.io/managed-by` label

### DIFF
--- a/aws-auth-configmap.tf
+++ b/aws-auth-configmap.tf
@@ -4,13 +4,7 @@ resource "kubernetes_config_map" "aws_auth" {
   metadata {
     name      = "aws-auth"
     namespace = "kube-system"
-    labels = merge(
-      {
-        "app.kubernetes.io/managed-by" = "Terraform"
-        "terraform.io/module"          = "terraform-aws-eks-blueprints"
-      },
-      var.aws_auth_additional_labels
-    )
+    labels    = var.aws_auth_additional_labels
   }
 
   data = {

--- a/aws-auth-configmap.tf
+++ b/aws-auth-configmap.tf
@@ -4,7 +4,13 @@ resource "kubernetes_config_map" "aws_auth" {
   metadata {
     name      = "aws-auth"
     namespace = "kube-system"
-    labels    = var.aws_auth_additional_labels
+    labels = merge(
+      {
+        "app.kubernetes.io/managed-by" = "terraform-aws-eks-blueprints"
+        "app.kubernetes.io/created-by" = "terraform-aws-eks-blueprints"
+      },
+      var.aws_auth_additional_labels
+    )
   }
 
   data = {

--- a/modules/emr-on-eks/main.tf
+++ b/modules/emr-on-eks/main.tf
@@ -5,8 +5,7 @@ resource "kubernetes_namespace" "spark" {
     }
 
     labels = {
-      job-type                       = "spark"
-      "app.kubernetes.io/managed-by" = "terraform-aws-eks-blueprints"
+      job-type = "spark"
     }
 
     name = local.emr_on_eks_team["namespace"]

--- a/modules/irsa/main.tf
+++ b/modules/irsa/main.tf
@@ -2,10 +2,6 @@ resource "kubernetes_namespace_v1" "irsa" {
   count = var.create_kubernetes_namespace && var.kubernetes_namespace != "kube-system" ? 1 : 0
   metadata {
     name = var.kubernetes_namespace
-
-    labels = {
-      "app.kubernetes.io/managed-by" = "terraform-aws-eks-blueprints"
-    }
   }
 }
 
@@ -15,9 +11,6 @@ resource "kubernetes_service_account_v1" "irsa" {
     name        = var.kubernetes_service_account
     namespace   = var.kubernetes_namespace
     annotations = var.irsa_iam_policies != null ? { "eks.amazonaws.com/role-arn" : aws_iam_role.irsa[0].arn } : null
-    labels = {
-      "app.kubernetes.io/managed-by" = "terraform-aws-eks-blueprints"
-    }
   }
 
   automount_service_account_token = true
@@ -51,8 +44,7 @@ resource "aws_iam_role" "irsa" {
 
   tags = merge(
     {
-      "Name"                         = format("%s-%s-%s", var.addon_context.eks_cluster_id, trim(var.kubernetes_service_account, "-*"), "irsa"),
-      "app.kubernetes.io/managed-by" = "terraform-aws-eks-blueprints"
+      "Name" = format("%s-%s-%s", var.addon_context.eks_cluster_id, trim(var.kubernetes_service_account, "-*"), "irsa"),
     },
     var.addon_context.tags
   )

--- a/modules/kubernetes-addons/adot-collector-haproxy/main.tf
+++ b/modules/kubernetes-addons/adot-collector-haproxy/main.tf
@@ -12,8 +12,5 @@ module "helm_addon" {
 resource "kubernetes_namespace_v1" "collector" {
   metadata {
     name = local.helm_config["namespace"]
-    labels = {
-      "app.kubernetes.io/managed-by" = "terraform-aws-eks-blueprints"
-    }
   }
 }

--- a/modules/kubernetes-addons/adot-collector-java/main.tf
+++ b/modules/kubernetes-addons/adot-collector-java/main.tf
@@ -12,8 +12,5 @@ module "helm_addon" {
 resource "kubernetes_namespace_v1" "collector" {
   metadata {
     name = local.helm_config["namespace"]
-    labels = {
-      "app.kubernetes.io/managed-by" = "terraform-aws-eks-blueprints"
-    }
   }
 }

--- a/modules/kubernetes-addons/adot-collector-memcached/main.tf
+++ b/modules/kubernetes-addons/adot-collector-memcached/main.tf
@@ -12,8 +12,5 @@ module "helm_addon" {
 resource "kubernetes_namespace_v1" "collector" {
   metadata {
     name = local.helm_config["namespace"]
-    labels = {
-      "app.kubernetes.io/managed-by" = "terraform-aws-eks-blueprints"
-    }
   }
 }

--- a/modules/kubernetes-addons/adot-collector-nginx/main.tf
+++ b/modules/kubernetes-addons/adot-collector-nginx/main.tf
@@ -12,8 +12,5 @@ module "helm_addon" {
 resource "kubernetes_namespace_v1" "collector" {
   metadata {
     name = local.helm_config["namespace"]
-    labels = {
-      "app.kubernetes.io/managed-by" = "terraform-aws-eks-blueprints"
-    }
   }
 }

--- a/modules/kubernetes-addons/agones/main.tf
+++ b/modules/kubernetes-addons/agones/main.tf
@@ -11,10 +11,6 @@ module "helm_addon" {
 resource "kubernetes_namespace_v1" "this" {
   metadata {
     name = local.helm_config["namespace"]
-
-    labels = {
-      "app.kubernetes.io/managed-by" = "terraform-aws-eks-blueprints"
-    }
   }
 }
 

--- a/modules/kubernetes-addons/argo-rollouts/main.tf
+++ b/modules/kubernetes-addons/argo-rollouts/main.tf
@@ -11,9 +11,5 @@ module "helm_addon" {
 resource "kubernetes_namespace_v1" "this" {
   metadata {
     name = local.helm_config["namespace"]
-
-    labels = {
-      "app.kubernetes.io/managed-by" = "terraform-aws-eks-blueprints"
-    }
   }
 }

--- a/modules/kubernetes-addons/argocd/main.tf
+++ b/modules/kubernetes-addons/argocd/main.tf
@@ -11,10 +11,6 @@ module "helm_addon" {
 resource "kubernetes_namespace_v1" "this" {
   metadata {
     name = local.helm_config["namespace"]
-
-    labels = {
-      "app.kubernetes.io/managed-by" = "terraform-aws-eks-blueprints"
-    }
   }
 }
 # ---------------------------------------------------------------------------------------------------------------------

--- a/modules/kubernetes-addons/crossplane/main.tf
+++ b/modules/kubernetes-addons/crossplane/main.tf
@@ -1,10 +1,6 @@
 resource "kubernetes_namespace_v1" "crossplane" {
   metadata {
     name = local.namespace
-
-    labels = {
-      "app.kubernetes.io/managed-by" = "terraform-aws-eks-blueprints"
-    }
   }
 }
 

--- a/modules/kubernetes-addons/fargate-fluentbit/main.tf
+++ b/modules/kubernetes-addons/fargate-fluentbit/main.tf
@@ -7,8 +7,7 @@ resource "kubernetes_namespace" "aws_observability" {
     name = "aws-observability"
 
     labels = {
-      aws-observability              = "enabled"
-      "app.kubernetes.io/managed-by" = "terraform-aws-eks-blueprints"
+      aws-observability = "enabled"
     }
   }
 }

--- a/modules/kubernetes-addons/ingress-nginx/main.tf
+++ b/modules/kubernetes-addons/ingress-nginx/main.tf
@@ -19,9 +19,5 @@ module "helm_addon" {
 resource "kubernetes_namespace_v1" "this" {
   metadata {
     name = local.helm_config["namespace"]
-
-    labels = {
-      "app.kubernetes.io/managed-by" = "terraform-aws-eks-blueprints"
-    }
   }
 }

--- a/modules/kubernetes-addons/metrics-server/main.tf
+++ b/modules/kubernetes-addons/metrics-server/main.tf
@@ -13,8 +13,5 @@ resource "kubernetes_namespace_v1" "this" {
 
   metadata {
     name = local.helm_config["namespace"]
-    labels = {
-      "app.kubernetes.io/managed-by" = "terraform-aws-eks-blueprints"
-    }
   }
 }

--- a/modules/kubernetes-addons/opentelemetry-operator/main.tf
+++ b/modules/kubernetes-addons/opentelemetry-operator/main.tf
@@ -10,8 +10,5 @@ module "operator" {
 resource "kubernetes_namespace_v1" "prometheus" {
   metadata {
     name = local.helm_config["namespace"]
-    labels = {
-      "app.kubernetes.io/managed-by" = "terraform-aws-eks-blueprints"
-    }
   }
 }

--- a/modules/kubernetes-addons/prometheus/main.tf
+++ b/modules/kubernetes-addons/prometheus/main.tf
@@ -12,9 +12,6 @@ module "helm_addon" {
 resource "kubernetes_namespace_v1" "prometheus" {
   metadata {
     name = local.helm_config["namespace"]
-    labels = {
-      "app.kubernetes.io/managed-by" = "terraform-aws-eks-blueprints"
-    }
   }
 }
 

--- a/modules/kubernetes-addons/spark-k8s-operator/main.tf
+++ b/modules/kubernetes-addons/spark-k8s-operator/main.tf
@@ -11,9 +11,5 @@ module "helm_addon" {
 resource "kubernetes_namespace_v1" "this" {
   metadata {
     name = local.helm_config["namespace"]
-
-    labels = {
-      "app.kubernetes.io/managed-by" = "terraform-aws-eks-blueprints"
-    }
   }
 }

--- a/modules/kubernetes-addons/traefik/main.tf
+++ b/modules/kubernetes-addons/traefik/main.tf
@@ -11,9 +11,5 @@ module "helm_addon" {
 resource "kubernetes_namespace_v1" "this" {
   metadata {
     name = local.helm_config["namespace"]
-
-    labels = {
-      "app.kubernetes.io/managed-by" = "terraform-aws-eks-blueprints"
-    }
   }
 }

--- a/modules/kubernetes-addons/vpa/main.tf
+++ b/modules/kubernetes-addons/vpa/main.tf
@@ -11,9 +11,5 @@ module "helm_addon" {
 resource "kubernetes_namespace_v1" "vpa" {
   metadata {
     name = local.helm_config["namespace"]
-
-    labels = {
-      "app.kubernetes.io/managed-by" = "terraform-aws-eks-blueprints"
-    }
   }
 }

--- a/modules/kubernetes-addons/yunikorn/main.tf
+++ b/modules/kubernetes-addons/yunikorn/main.tf
@@ -11,9 +11,5 @@ module "helm_addon" {
 resource "kubernetes_namespace_v1" "yunikorn" {
   metadata {
     name = local.helm_config["namespace"]
-
-    labels = {
-      "app.kubernetes.io/managed-by" = "terraform-aws-eks-blueprints"
-    }
   }
 }


### PR DESCRIPTION
### What does this PR do?
- Removes the `app.kubernetes.io/managed-by` label from Terraform created resources

### Motivation
- Avoid competing updates with Helm
- Fixes #499 

### More

- [ ] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
