### PR TITLE
Node termination handler updates for karpenter

### DIFF
--- a/examples/karpenter/main.tf
+++ b/examples/karpenter/main.tf
@@ -110,6 +110,7 @@ module "eks_blueprints_kubernetes_addons" {
   eks_cluster_version  = module.eks_blueprints.eks_cluster_version
 
   enable_karpenter = true
+  enable_aws_node_termination_handler = true
 
   tags = local.tags
 

--- a/examples/karpenter/main.tf
+++ b/examples/karpenter/main.tf
@@ -109,7 +109,7 @@ module "eks_blueprints_kubernetes_addons" {
   eks_oidc_provider    = module.eks_blueprints.oidc_provider
   eks_cluster_version  = module.eks_blueprints.eks_cluster_version
 
-  enable_karpenter = true
+  enable_karpenter                    = true
   enable_aws_node_termination_handler = true
 
   tags = local.tags

--- a/modules/kubernetes-addons/aws-node-termination-handler/locals.tf
+++ b/modules/kubernetes-addons/aws-node-termination-handler/locals.tf
@@ -20,7 +20,9 @@ locals {
     var.helm_config
   )
 
-  default_helm_values = [templatefile("${path.module}/values.yaml", {})]
+  default_helm_values = [templatefile("${path.module}/values.yaml", {
+    autoscaling_group_names = var.autoscaling_group_names
+  })]
 
   set_values = [
     {
@@ -41,13 +43,14 @@ locals {
     irsa_iam_policies                 = concat([aws_iam_policy.aws_node_termination_handler_irsa.arn], var.irsa_policies)
   }
 
-  event_rules = [
-    {
+  event_rules = flatten([
+    length(var.autoscaling_group_names) > 0 ?
+    [{
       name          = "NTHASGTermRule",
       event_pattern = <<EOF
 {"source":["aws.autoscaling"],"detail-type":["EC2 Instance-terminate Lifecycle Action"]}
 EOF
-    },
+    }] : [],
     {
       name          = "NTHSpotTermRule",
       event_pattern = <<EOF
@@ -72,5 +75,5 @@ EOF
 {"source": ["aws.health"],"detail-type": ["AWS Health Event"]}
 EOF
     }
-  ]
+  ])
 }

--- a/modules/kubernetes-addons/aws-node-termination-handler/values.yaml
+++ b/modules/kubernetes-addons/aws-node-termination-handler/values.yaml
@@ -1,2 +1,5 @@
 enableSqsTerminationDraining: true
 enablePrometheusServer: true
+%{ if length(autoscaling_group_names) == 0 ~}
+checkASGTagBeforeDraining: false
+%{ endif ~}

--- a/modules/kubernetes-addons/main.tf
+++ b/modules/kubernetes-addons/main.tf
@@ -119,7 +119,7 @@ module "aws_load_balancer_controller" {
 }
 
 module "aws_node_termination_handler" {
-  count                   = var.enable_aws_node_termination_handler && length(var.auto_scaling_group_names) > 0 ? 1 : 0
+  count                   = var.enable_aws_node_termination_handler && (length(var.auto_scaling_group_names) > 0 || var.enable_karpenter)? 1 : 0
   source                  = "./aws-node-termination-handler"
   helm_config             = var.aws_node_termination_handler_helm_config
   irsa_policies           = var.aws_node_termination_handler_irsa_policies

--- a/modules/kubernetes-addons/main.tf
+++ b/modules/kubernetes-addons/main.tf
@@ -119,7 +119,7 @@ module "aws_load_balancer_controller" {
 }
 
 module "aws_node_termination_handler" {
-  count                   = var.enable_aws_node_termination_handler && (length(var.auto_scaling_group_names) > 0 || var.enable_karpenter)? 1 : 0
+  count                   = var.enable_aws_node_termination_handler && (length(var.auto_scaling_group_names) > 0 || var.enable_karpenter) ? 1 : 0
   source                  = "./aws-node-termination-handler"
   helm_config             = var.aws_node_termination_handler_helm_config
   irsa_policies           = var.aws_node_termination_handler_irsa_policies


### PR DESCRIPTION
### What does this PR do?

Add node termination handler support for karpenter based on the blog post from aws:
    [Using Amazon EC2 Spot Instances with Karpenter]([https://aws.amazon.com/blogs/containers/using-amazon-ec2-spot-instances-with-karpenter/)

### Motivation

Need for node termination support for karpenter

### More

- [X] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [X] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [] E2E Test successfully complete before merge?

### Additional Notes
```
--- PASS: TestEksBlueprintsE2E (0.00s)
    --- PASS: TestEksBlueprintsE2E/TF_PLAN_VALIDATION (23.13s)
    --- PASS: TestEksBlueprintsE2E/TF_OUTPUTS_VALIDATION (7.94s)
        --- PASS: TestEksBlueprintsE2E/TF_OUTPUTS_VALIDATION/vpc_cidr (1.62s)
        --- PASS: TestEksBlueprintsE2E/TF_OUTPUTS_VALIDATION/vpc_private_subnet_cidr (1.57s)
        --- PASS: TestEksBlueprintsE2E/TF_OUTPUTS_VALIDATION/vpc_public_subnet_cidr (1.58s)
        --- PASS: TestEksBlueprintsE2E/TF_OUTPUTS_VALIDATION/eks_cluster_id (1.58s)
        --- PASS: TestEksBlueprintsE2E/TF_OUTPUTS_VALIDATION/eks_managed_nodegroup_status (1.59s)
    --- PASS: TestEksBlueprintsE2E/EKS_ADDON_VALIDATION (5.49s)
        --- PASS: TestEksBlueprintsE2E/EKS_ADDON_VALIDATION/MATCH_EKS_CLUSTER_NAME (0.00s)
        --- PASS: TestEksBlueprintsE2E/EKS_ADDON_VALIDATION/MATCH_TOTAL_EKS_WORKER_NODES (0.00s)
        --- PASS: TestEksBlueprintsE2E/EKS_ADDON_VALIDATION/EKS_DEPLOYMENTS_VALIDATION (0.56s)
            --- PASS: TestEksBlueprintsE2E/EKS_ADDON_VALIDATION/EKS_DEPLOYMENTS_VALIDATION/MATCH_REPLICAS_VS_READY-REPLICAS/aws-load-balancer-controller (0.00s)
            --- PASS: TestEksBlueprintsE2E/EKS_ADDON_VALIDATION/EKS_DEPLOYMENTS_VALIDATION/UNAVAILABLE_REPLICAS/aws-load-balancer-controller (0.00s)
            --- PASS: TestEksBlueprintsE2E/EKS_ADDON_VALIDATION/EKS_DEPLOYMENTS_VALIDATION/MATCH_REPLICAS_VS_READY-REPLICAS/cluster-autoscaler-aws-cluster-autoscaler (0.00s)
            --- PASS: TestEksBlueprintsE2E/EKS_ADDON_VALIDATION/EKS_DEPLOYMENTS_VALIDATION/UNAVAILABLE_REPLICAS/cluster-autoscaler-aws-cluster-autoscaler (0.00s)
            --- PASS: TestEksBlueprintsE2E/EKS_ADDON_VALIDATION/EKS_DEPLOYMENTS_VALIDATION/MATCH_REPLICAS_VS_READY-REPLICAS/coredns (0.00s)
            --- PASS: TestEksBlueprintsE2E/EKS_ADDON_VALIDATION/EKS_DEPLOYMENTS_VALIDATION/UNAVAILABLE_REPLICAS/coredns (0.00s)
            --- PASS: TestEksBlueprintsE2E/EKS_ADDON_VALIDATION/EKS_DEPLOYMENTS_VALIDATION/MATCH_REPLICAS_VS_READY-REPLICAS/metrics-server (0.00s)
            --- PASS: TestEksBlueprintsE2E/EKS_ADDON_VALIDATION/EKS_DEPLOYMENTS_VALIDATION/UNAVAILABLE_REPLICAS/metrics-server (0.00s)
        --- PASS: TestEksBlueprintsE2E/EKS_ADDON_VALIDATION/EKS_DAEMONSETS_VALIDATION (0.28s)
            --- PASS: TestEksBlueprintsE2E/EKS_ADDON_VALIDATION/EKS_DAEMONSETS_VALIDATION/MATCH_DESIRED_VS_CURRENT_PODS/aws-node (0.00s)
            --- PASS: TestEksBlueprintsE2E/EKS_ADDON_VALIDATION/EKS_DAEMONSETS_VALIDATION/UNAVAILABLE_REPLICAS/aws-node (0.00s)
            --- PASS: TestEksBlueprintsE2E/EKS_ADDON_VALIDATION/EKS_DAEMONSETS_VALIDATION/MATCH_DESIRED_VS_CURRENT_PODS/kube-proxy (0.00s)
            --- PASS: TestEksBlueprintsE2E/EKS_ADDON_VALIDATION/EKS_DAEMONSETS_VALIDATION/UNAVAILABLE_REPLICAS/kube-proxy (0.00s)
            --- PASS: TestEksBlueprintsE2E/EKS_ADDON_VALIDATION/EKS_DAEMONSETS_VALIDATION/MATCH_DESIRED_VS_CURRENT_PODS/aws-cloudwatch-metrics (0.00s)
            --- PASS: TestEksBlueprintsE2E/EKS_ADDON_VALIDATION/EKS_DAEMONSETS_VALIDATION/UNAVAILABLE_REPLICAS/aws-cloudwatch-metrics (0.00s)
        --- PASS: TestEksBlueprintsE2E/EKS_ADDON_VALIDATION/EKS_SERVICES_VALIDATION (0.39s)
            --- PASS: TestEksBlueprintsE2E/EKS_ADDON_VALIDATION/EKS_SERVICES_VALIDATION/SERVICE_STATUS/cluster-autoscaler-aws-cluster-autoscaler (0.00s)
            --- PASS: TestEksBlueprintsE2E/EKS_ADDON_VALIDATION/EKS_SERVICES_VALIDATION/SERVICE_STATUS/kube-dns (0.00s)
            --- PASS: TestEksBlueprintsE2E/EKS_ADDON_VALIDATION/EKS_SERVICES_VALIDATION/SERVICE_STATUS/kubernetes (0.00s)
            --- PASS: TestEksBlueprintsE2E/EKS_ADDON_VALIDATION/EKS_SERVICES_VALIDATION/SERVICE_STATUS/metrics-server (0.00s)
    --- PASS: TestEksBlueprintsE2E/eks-cluster-with-new-vpc (2480.71s)
PASS
ok  	github.com/aws-ia/terraform-aws-eks-blueprints/src	2481.262s
```
