### PR TITLE
ci: add workflow for mkdocs (by versions using mike)

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -1,0 +1,51 @@
+name: Publish docs via GitHub Pages
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+
+  release:
+    types:
+      - published
+
+env:
+  PYTHON_VERSION: 3.x
+
+jobs:
+  build:
+    name: Deploy docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python ${{ env.PYTHON_VERSION }}
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install mike mkdocs-material
+
+      - name: git config
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+
+      - name: mike deploy main
+        if: contains(github.ref, 'refs/heads/main')
+        run: |
+          mike deploy --push main
+
+      - name: mike deploy new version
+        if: contains(github.ref, 'refs/tags/v') && !github.event.release.prerelease
+        run: |
+          VERSION=${GITHUB_REF/refs\/tags\//}
+          mike deploy --rebase --push --update-aliases "${VERSION}" latest

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -54,3 +54,6 @@ markdown_extensions:
       permalink: true
 plugins:
   - search
+extra:
+  version:
+    provider: mike


### PR DESCRIPTION
### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
- Add new GH workflow to deploy mkdocs using [mike](https://github.com/jimporter/mike)

### Motivation

<!-- What inspired you to submit this pull request? -->
- Project GH pages (https://aws-ia.github.io/terraform-aws-eks-blueprints/) is not updated since we've been using mkdocs manually until now and behind multiple releases.
- Few issues (e.g. https://github.com/aws-ia/terraform-aws-eks-blueprints/issues/573) caused because of docs are incorrect and need to be fixed and updated docs to be published.
- mike allows us to have multiple versions (per release) of mkdocs, allowing customers to switch docs by release version.

### More

- [ ] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
