### PR TITLE
fix: typo in null_resource

### DIFF
--- a/examples/fargate-serverless/main.tf
+++ b/examples/fargate-serverless/main.tf
@@ -194,7 +194,7 @@ resource "null_resource" "modify_kube_dns" {
 
     # We are maintaing the existing kube-dns service and annotating it for Helm to assume control
     command = <<-EOT
-      echo "Setting implicit dependency on ${module.eks_blueprints.fargate_profiles["kube_system"].eks_fargate_profile_arn}"
+      echo "Setting implicit dependency on ${module.eks_blueprints.fargate_profiles["kube-system"].eks_fargate_profile_arn}"
       kubectl --namespace kube-system annotate --overwrite service kube-dns meta.helm.sh/release-name=coredns --kubeconfig <(echo $KUBECONFIG | base64 --decode)
       kubectl --namespace kube-system annotate --overwrite service kube-dns meta.helm.sh/release-namespace=kube-system --kubeconfig <(echo $KUBECONFIG | base64 --decode)
       kubectl --namespace kube-system label --overwrite service kube-dns app.kubernetes.io/managed-by=Helm --kubeconfig <(echo $KUBECONFIG | base64 --decode)


### PR DESCRIPTION

### What does this PR do?

fixing a typo: from kube_system to kube-system

### Motivation

Right now, fargate-serverless doesn't work well. This type prevents it from running.
