### PR TITLE
:bug: :wrench: Kubernetes dashboard support for EKS 1.22

### DIFF
--- a/modules/kubernetes-addons/kubernetes-dashboard/README.md
+++ b/modules/kubernetes-addons/kubernetes-dashboard/README.md
@@ -36,7 +36,7 @@ This add-on bootstraps the Kubernetes Dashboard on the EKS cluster using a [helm
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_addon_context"></a> [addon\_context](#input\_addon\_context) | Input configuration for the addon | <pre>object({<br>    aws_caller_identity_account_id = string<br>    aws_caller_identity_arn        = string<br>    aws_eks_cluster_endpoint       = string<br>    aws_partition_id               = string<br>    aws_region_name                = string<br>    eks_cluster_id                 = string<br>    eks_oidc_issuer_url            = string<br>    eks_oidc_provider_arn          = string<br>    tags                           = map(string)<br>  })</pre> | n/a | yes |
+| <a name="input_addon_context"></a> [addon\_context](#input\_addon\_context) | Input configuration for the addon | <pre>object({<br>    aws_caller_identity_account_id = string<br>    aws_caller_identity_arn        = string<br>    aws_eks_cluster_endpoint       = string<br>    aws_partition_id               = string<br>    aws_region_name                = string<br>    eks_cluster_id                 = string<br>    eks_oidc_issuer_url            = string<br>    eks_oidc_provider_arn          = string<br>    tags                           = map(string)<br>    eks_cluster_version            = string<br>  })</pre> | n/a | yes |
 | <a name="input_helm_config"></a> [helm\_config](#input\_helm\_config) | Helm provider config for the Kubernetes Dashboard | `any` | `{}` | no |
 | <a name="input_manage_via_gitops"></a> [manage\_via\_gitops](#input\_manage\_via\_gitops) | Determines if the add-on should be managed via GitOps | `bool` | `false` | no |
 

--- a/modules/kubernetes-addons/kubernetes-dashboard/locals.tf
+++ b/modules/kubernetes-addons/kubernetes-dashboard/locals.tf
@@ -11,7 +11,7 @@ locals {
     namespace   = local.namespace
     description = "Kubernetes Dashboard Helm Chart"
     values      = local.default_helm_values
-    timeout     = "1200"
+    timeout     = "300"
   }
 
   helm_config = merge(
@@ -35,7 +35,7 @@ locals {
   irsa_config = {
     kubernetes_namespace              = local.helm_config["namespace"]
     kubernetes_service_account        = local.service_account_name
-    create_kubernetes_namespace       = false
+    create_kubernetes_namespace       = true
     create_kubernetes_service_account = true
   }
 

--- a/modules/kubernetes-addons/kubernetes-dashboard/main.tf
+++ b/modules/kubernetes-addons/kubernetes-dashboard/main.tf
@@ -7,10 +7,12 @@ module "helm_addon" {
   addon_context     = var.addon_context
 }
 
+#
 resource "kubectl_manifest" "sa_config" {
   yaml_body = templatefile("${path.module}/manifests/eks-admin-service-account.yaml", {
-    sa-name   = local.service_account_name
-    namespace = local.helm_config["namespace"]
+    sa-name     = local.service_account_name
+    namespace   = local.helm_config["namespace"]
+    api-version = var.addon_context.eks_cluster_version > "1.21" ? "rbac.authorization.k8s.io/v1" : "rbac.authorization.k8s.io/v1beta1"
   })
 
   depends_on = [module.helm_addon]

--- a/modules/kubernetes-addons/kubernetes-dashboard/manifests/eks-admin-service-account.yaml
+++ b/modules/kubernetes-addons/kubernetes-dashboard/manifests/eks-admin-service-account.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: ${api-version}
 kind: ClusterRoleBinding
 metadata:
   name: ${sa-name}

--- a/modules/kubernetes-addons/kubernetes-dashboard/variables.tf
+++ b/modules/kubernetes-addons/kubernetes-dashboard/variables.tf
@@ -21,6 +21,7 @@ variable "addon_context" {
     eks_oidc_issuer_url            = string
     eks_oidc_provider_arn          = string
     tags                           = map(string)
+    eks_cluster_version            = string
   })
   description = "Input configuration for the addon"
 }

--- a/modules/kubernetes-addons/locals.tf
+++ b/modules/kubernetes-addons/locals.tf
@@ -34,6 +34,7 @@ locals {
     aws_partition_id               = data.aws_partition.current.partition
     aws_region_name                = data.aws_region.current.name
     eks_cluster_id                 = var.eks_cluster_id
+    eks_cluster_version            = var.eks_cluster_version
     eks_oidc_issuer_url            = local.eks_oidc_issuer_url
     eks_oidc_provider_arn          = "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:oidc-provider/${local.eks_oidc_issuer_url}"
     tags                           = var.tags


### PR DESCRIPTION
### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
- Support for EKS Cluster version 1.22
- Fix for creating a namespace if its not `kube-system` 


### Motivation

<!-- What inspired you to submit this pull request? -->


### More

- [x] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [x] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
