### PR TITLE
updated IAM policy for lb2 service account

### DIFF
--- a/modules/kubernetes-addons/aws-load-balancer-controller/data.tf
+++ b/modules/kubernetes-addons/aws-load-balancer-controller/data.tf
@@ -11,6 +11,7 @@ data "aws_iam_policy_document" "aws_lb" {
       "ec2:DescribeInternetGateways",
       "ec2:DescribeAvailabilityZones",
       "ec2:DescribeVpcs",
+      "ec2:DescribeVpcPeeringConnections",
       "ec2:DescribeSubnets",
       "ec2:DescribeSecurityGroups",
       "ec2:DescribeInstances",

--- a/modules/kubernetes-addons/kubernetes-dashboard/main.tf
+++ b/modules/kubernetes-addons/kubernetes-dashboard/main.tf
@@ -4,13 +4,13 @@ module "helm_addon" {
   helm_config       = local.helm_config
   irsa_config       = null
   addon_context     = var.addon_context
-  
+
   depends_on = [kubernetes_namespace_v1.this]
 }
 
 resource "kubernetes_namespace_v1" "this" {
   count = local.helm_config["namespace"] == "kube-system" ? 0 : 1
-  
+
   metadata {
     name = local.helm_config["namespace"]
     labels = {


### PR DESCRIPTION
### What does this PR do?

Adds missing permission to IAM role assume by AWS Load Balancer Controller pods.

### Motivation

While deploying example at "examples/ipv6-eks-cluster" an EKS cluster along with addon alb-ingress-controller is created. However when I tried to create an Ingress, alb-ingress-controller pod was failing to add targets to TargetGroup with AccessDenied error on permission "ec2:DescribeVpcPeeringConnections". Thus this PR includes commit on missing permission "ec2:DescribeVpcPeeringConnections".


### More

- [ ] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
