### PR TITLE
fix: Correct target destroy resource name for VPC

### DIFF
--- a/examples/analytics/emr-on-eks/README.md
+++ b/examples/analytics/emr-on-eks/README.md
@@ -135,7 +135,7 @@ Destroy the Kubernetes Add-ons, EKS cluster with Node groups and VPC
 ```sh
 terraform destroy -target="module.eks_blueprints_kubernetes_addons" -auto-approve
 terraform destroy -target="module.eks_blueprints" -auto-approve
-terraform destroy -target="module.aws_vpc" -auto-approve
+terraform destroy -target="module.vpc" -auto-approve
 ```
 
 Finally, destroy any additional resources that are not in the above modules

--- a/examples/analytics/spark-k8s-operator/README.md
+++ b/examples/analytics/spark-k8s-operator/README.md
@@ -82,7 +82,7 @@ Destroy the Kubernetes Add-ons, EKS cluster with Node groups and VPC
 ```sh
 terraform destroy -target="module.eks_blueprints_kubernetes_addons" -auto-approve
 terraform destroy -target="module.eks_blueprints" -auto-approve
-terraform destroy -target="module.aws_vpc" -auto-approve
+terraform destroy -target="module.vpc" -auto-approve
 ```
 
 Finally, destroy any additional resources that are not in the above modules

--- a/examples/aws-efs-csi-driver/README.md
+++ b/examples/aws-efs-csi-driver/README.md
@@ -127,7 +127,7 @@ Destroy the Kubernetes Add-ons, EKS cluster with Node groups and VPC
 ```sh
 terraform destroy -target="module.eks_blueprints_kubernetes_addons" -auto-approve
 terraform destroy -target="module.eks_blueprints" -auto-approve
-terraform destroy -target="module.aws_vpc" -auto-approve
+terraform destroy -target="module.vpc" -auto-approve
 ```
 
 Finally, destroy any additional resources that are not in the above modules

--- a/examples/complete-kubernetes-addons/README.md
+++ b/examples/complete-kubernetes-addons/README.md
@@ -76,7 +76,7 @@ Destroy the Kubernetes Add-ons, EKS cluster with Node groups and VPC
 ```sh
 terraform destroy -target="module.eks_blueprints_kubernetes_addons" -auto-approve
 terraform destroy -target="module.eks_blueprints" -auto-approve
-terraform destroy -target="module.aws_vpc" -auto-approve
+terraform destroy -target="module.vpc" -auto-approve
 ```
 
 Finally, destroy any additional resources that are not in the above modules

--- a/examples/crossplane/README.md
+++ b/examples/crossplane/README.md
@@ -182,7 +182,7 @@ Destroy the Kubernetes Add-ons, EKS cluster with Node groups and VPC
 ```sh
 terraform destroy -target="module.eks_blueprints_kubernetes_addons" -auto-approve
 terraform destroy -target="module.eks_blueprints" -auto-approve
-terraform destroy -target="module.aws_vpc" -auto-approve
+terraform destroy -target="module.vpc" -auto-approve
 ```
 
 Finally, destroy any additional resources that are not in the above modules

--- a/examples/eks-cluster-with-external-dns/README.md
+++ b/examples/eks-cluster-with-external-dns/README.md
@@ -102,7 +102,7 @@ Destroy the Kubernetes Add-ons, EKS cluster with Node groups and VPC
 ```sh
 terraform destroy -target="module.eks_blueprints_kubernetes_addons" -auto-approve
 terraform destroy -target="module.eks_blueprints" -auto-approve
-terraform destroy -target="module.aws_vpc" -auto-approve
+terraform destroy -target="module.vpc" -auto-approve
 ```
 
 Finally, destroy any additional resources that are not in the above modules

--- a/examples/eks-cluster-with-new-vpc/README.md
+++ b/examples/eks-cluster-with-new-vpc/README.md
@@ -80,7 +80,7 @@ Destroy the Kubernetes Add-ons, EKS cluster with Node groups and VPC
 ```sh
 terraform destroy -target="module.eks_blueprints_kubernetes_addons" -auto-approve
 terraform destroy -target="module.eks_blueprints" -auto-approve
-terraform destroy -target="module.aws_vpc" -auto-approve
+terraform destroy -target="module.vpc" -auto-approve
 ```
 
 Finally, destroy any additional resources that are not in the above modules

--- a/examples/game-tech/agones-game-controller/README.md
+++ b/examples/game-tech/agones-game-controller/README.md
@@ -150,7 +150,7 @@ Destroy the Kubernetes Add-ons, EKS cluster with Node groups and VPC
 ```sh
 terraform destroy -target="module.eks_blueprints_kubernetes_addons" -auto-approve
 terraform destroy -target="module.eks_blueprints" -auto-approve
-terraform destroy -target="module.aws_vpc" -auto-approve
+terraform destroy -target="module.vpc" -auto-approve
 ```
 
 Finally, destroy any additional resources that are not in the above modules

--- a/examples/ipv6-eks-cluster/README.md
+++ b/examples/ipv6-eks-cluster/README.md
@@ -101,7 +101,7 @@ Destroy the Kubernetes Add-ons, EKS cluster with Node groups and VPC
 ```sh
 terraform destroy -target="module.eks_blueprints_kubernetes_addons" -auto-approve
 terraform destroy -target="module.eks_blueprints" -auto-approve
-terraform destroy -target="module.aws_vpc" -auto-approve
+terraform destroy -target="module.vpc" -auto-approve
 ```
 
 Finally, destroy any additional resources that are not in the above modules

--- a/examples/karpenter/README.md
+++ b/examples/karpenter/README.md
@@ -95,7 +95,7 @@ Destroy the Kubernetes Add-ons, EKS cluster with Node groups and VPC
 ```sh
 terraform destroy -target="module.eks_blueprints_kubernetes_addons" -auto-approve
 terraform destroy -target="module.eks_blueprints" -auto-approve
-terraform destroy -target="module.aws_vpc" -auto-approve
+terraform destroy -target="module.vpc" -auto-approve
 ```
 
 Finally, destroy any additional resources that are not in the above modules

--- a/examples/node-groups/managed-node-groups/README.md
+++ b/examples/node-groups/managed-node-groups/README.md
@@ -80,7 +80,7 @@ Destroy the Kubernetes Add-ons, EKS cluster with Node groups and VPC
 ```sh
 terraform destroy -target="module.eks_blueprints_kubernetes_addons" -auto-approve
 terraform destroy -target="module.eks_blueprints" -auto-approve
-terraform destroy -target="module.aws_vpc" -auto-approve
+terraform destroy -target="module.vpc" -auto-approve
 ```
 
 Finally, destroy any additional resources that are not in the above modules

--- a/examples/node-groups/windows-node-groups/README.md
+++ b/examples/node-groups/windows-node-groups/README.md
@@ -114,7 +114,7 @@ kubectl delete svc,deploy -n linux --all
 ```sh
 terraform destroy -target="module.eks_blueprints_kubernetes_addons" -auto-approve
 terraform destroy -target="module.eks_blueprints" -auto-approve
-terraform destroy -target="module.aws_vpc" -auto-approve
+terraform destroy -target="module.vpc" -auto-approve
 ```
 
 Finally, destroy any additional resources that are not in the above modules

--- a/examples/tls-with-aws-pca-issuer/README.md
+++ b/examples/tls-with-aws-pca-issuer/README.md
@@ -89,7 +89,7 @@ Destroy the Kubernetes Add-ons, EKS cluster with Node groups and VPC
 ```sh
 terraform destroy -target="module.eks_blueprints_kubernetes_addons" -auto-approve
 terraform destroy -target="module.eks_blueprints" -auto-approve
-terraform destroy -target="module.aws_vpc" -auto-approve
+terraform destroy -target="module.vpc" -auto-approve
 ```
 
 Finally, destroy any additional resources that are not in the above modules


### PR DESCRIPTION
### What does this PR do?
- Correct target destroy resource name for VPC

### Motivation
- Resource name is `module "vpc" {}`
- Relates to #601 and #602 (will need to push new release for doc update)

### More

- [ ] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
