### PR TITLE
External secrets operator

### DIFF
--- a/docs/add-ons/external-secrets.md
+++ b/docs/add-ons/external-secrets.md
@@ -1,0 +1,37 @@
+
+# External Secrets Operator
+
+[External Secrets Operator](https://external-secrets.io/latest) is a Kubernetes operator that integrates external secret management systems like AWS Secrets Manager, HashiCorp Vault, Google Secrets Manager, Azure Key Vault and many more. The operator reads information from external APIs and automatically injects the values into a Kubernetes Secret.
+
+## Usage
+
+The External Secrets Operator can be deployed by enabling the add-on via the following.
+
+```hcl
+enable_external_secrets = true
+```
+
+You can optionally customize the Helm chart that deploys the operator via the following configuration.
+
+```hcl
+  enable_external_secrets = true
+  external_secrets_helm_config = {
+    name                       = "external-secrets"
+    chart                      = "external-secrets"
+    repository                 = "https://charts.external-secrets.io/"
+    version                    = "0.5.6"
+    namespace                  = "external-secrets"
+  }
+```
+
+###  GitOps Configuration
+
+The following properties are made available for use when managing the add-on via GitOps.
+
+Refer to [locals.tf](modules/kubernetes-addons/external-secrets/locals.tf) for latest config. GitOps with ArgoCD Add-on repo is located [here](https://github.com/aws-samples/eks-blueprints-add-ons/blob/main/chart/values.yaml).
+
+```hcl
+  argocd_gitops_config = {
+    enable = true
+  }
+```

--- a/examples/external-secrets-kubernetes-addon/README.md
+++ b/examples/external-secrets-kubernetes-addon/README.md
@@ -60,7 +60,7 @@ This following command used to update the `kubeconfig` in your local machine whe
     $ aws eks --region <enter-your-region> update-kubeconfig --name <cluster-name>
 
 ### Step 6: List the secret resources in the `external-secrets` namespace
-  
+
     $ kubectl get externalsecrets -n external-secrets
     $ kubectl get secrets -n external-secrets
 

--- a/examples/external-secrets-kubernetes-addon/README.md
+++ b/examples/external-secrets-kubernetes-addon/README.md
@@ -1,0 +1,83 @@
+# External Secrets Operator Kubernetes addon
+
+This example deploys an EKS Cluster with the External Secrets Operator. The cluster is populated with a ClusterSecretStore and SecretStore example using SecretManager and Parameter Store respectively. A secret for each store is also created. Both stores use IRSA to retrieve the secret values from AWS.
+
+## How to Deploy
+
+### Prerequisites:
+
+Ensure that you have installed the following tools in your Mac or Windows Laptop before start working with this module and run Terraform Plan and Apply
+
+1. [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html)
+2. [Kubectl](https://Kubernetes.io/docs/tasks/tools/)
+3. [Terraform](https://learn.hashicorp.com/tutorials/terraform/install-cli)
+
+### Deployment Steps
+
+#### Step 1: Clone the repo using the command below
+
+```sh
+git clone https://github.com/aws-ia/terraform-aws-eks-blueprints.git
+```
+
+#### Step 2: Run Terraform INIT
+
+Initialize a working directory with configuration files
+
+```sh
+cd examples/external-secrets-kubernetes-addon/
+terraform init
+```
+
+#### Step 3: Run Terraform PLAN
+
+Verify the resources created by this execution
+
+```sh
+export AWS_REGION=<ENTER YOUR REGION>   # Select your own region
+terraform plan
+```
+
+#### Step 4: Finally, Terraform APPLY
+
+**Deploy the pattern**
+
+```sh
+terraform apply
+```
+
+Enter `yes` to apply.
+
+### Configure `kubectl` and test cluster
+
+EKS Cluster details can be extracted from terraform output or from AWS Console to get the name of cluster.
+This following command used to update the `kubeconfig` in your local machine where you run kubectl commands to interact with your EKS Cluster.
+
+#### Step 5: Run `update-kubeconfig` command
+
+`~/.kube/config` file gets updated with cluster details and certificate from the below command
+
+    $ aws eks --region <enter-your-region> update-kubeconfig --name <cluster-name>
+
+### Step 6: List the secret resources in the `external-secrets` namespace
+  
+    $ kubectl get externalsecrets -n external-secrets
+    $ kubectl get secrets -n external-secrets
+
+## Cleanup
+
+To clean up your environment, destroy the Terraform modules in reverse order.
+
+Destroy the Kubernetes Add-ons, EKS cluster with Node groups and VPC
+
+```sh
+terraform destroy -target="module.eks_blueprints_kubernetes_addons" -auto-approve
+terraform destroy -target="module.eks_blueprints" -auto-approve
+terraform destroy -target="module.vpc" -auto-approve
+```
+
+Finally, destroy any additional resources that are not in the above modules
+
+```sh
+terraform destroy -auto-approve
+```

--- a/examples/external-secrets-kubernetes-addon/main.tf
+++ b/examples/external-secrets-kubernetes-addon/main.tf
@@ -265,7 +265,6 @@ YAML
 }
 
 resource "aws_secretsmanager_secret" "secret" {
-  name                    = local.name
   recovery_window_in_days = 0
   kms_key_id              = aws_kms_key.secrets.arn
 }

--- a/examples/external-secrets-kubernetes-addon/main.tf
+++ b/examples/external-secrets-kubernetes-addon/main.tf
@@ -1,0 +1,392 @@
+provider "aws" {
+  region = local.region
+}
+
+provider "kubernetes" {
+  host                   = module.eks_blueprints.eks_cluster_endpoint
+  cluster_ca_certificate = base64decode(module.eks_blueprints.eks_cluster_certificate_authority_data)
+
+  exec {
+    api_version = "client.authentication.k8s.io/v1alpha1"
+    command     = "aws"
+    # This requires the awscli to be installed locally where Terraform is executed
+    args = ["eks", "get-token", "--cluster-name", module.eks_blueprints.eks_cluster_id]
+  }
+}
+
+provider "helm" {
+  kubernetes {
+    host                   = module.eks_blueprints.eks_cluster_endpoint
+    cluster_ca_certificate = base64decode(module.eks_blueprints.eks_cluster_certificate_authority_data)
+
+    exec {
+      api_version = "client.authentication.k8s.io/v1alpha1"
+      command     = "aws"
+      # This requires the awscli to be installed locally where Terraform is executed
+      args = ["eks", "get-token", "--cluster-name", module.eks_blueprints.eks_cluster_id]
+    }
+  }
+}
+
+provider "kubectl" {
+  host                   = module.eks_blueprints.eks_cluster_endpoint
+  cluster_ca_certificate = base64decode(module.eks_blueprints.eks_cluster_certificate_authority_data)
+
+  exec {
+    api_version = "client.authentication.k8s.io/v1alpha1"
+    command     = "aws"
+    # This requires the awscli to be installed locally where Terraform is executed
+    args = ["eks", "get-token", "--cluster-name", module.eks_blueprints.eks_cluster_id]
+  }
+}
+
+
+data "aws_availability_zones" "available" {}
+
+locals {
+  name      = basename(path.cwd)
+  namespace = "external-secrets"
+  region    = "us-west-2"
+
+  vpc_cidr = "10.0.0.0/16"
+  azs      = slice(data.aws_availability_zones.available.names, 0, 3)
+
+  cluster_secretstore_name = "cluster-secretstore-sm"
+  cluster_secretstore_sa   = "cluster-secretstore-sa"
+  secretstore_name         = "secretstore-ps"
+  secretstore_sa           = "secretstore-sa"
+
+
+  tags = {
+    Blueprint  = local.name
+    GithubRepo = "github.com/aws-ia/terraform-aws-eks-blueprints"
+  }
+}
+
+#---------------------------------------------------------------
+# EKS Blueprints
+#---------------------------------------------------------------
+module "eks_blueprints" {
+  source = "../.."
+
+  cluster_name    = local.name
+  cluster_version = "1.21"
+
+  vpc_id             = module.vpc.vpc_id
+  private_subnet_ids = module.vpc.private_subnets
+
+  #----------------------------------------------------------------------------------------------------------#
+  # Security groups used in this module created by the upstream modules terraform-aws-eks (https://github.com/terraform-aws-modules/terraform-aws-eks).
+  #   Upstream module implemented Security groups based on the best practices doc https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html.
+  #   So, by default the security groups are restrictive. Users needs to enable rules for specific ports required for App requirement or Add-ons
+  #   See the notes below for each rule used in these examples
+  #----------------------------------------------------------------------------------------------------------#
+  node_security_group_additional_rules = {
+    # Extend node-to-node security group rules. Recommended and required for the Add-ons
+    ingress_self_all = {
+      description = "Node to node all ports/protocols"
+      protocol    = "-1"
+      from_port   = 0
+      to_port     = 0
+      type        = "ingress"
+      self        = true
+    }
+    # Recommended outbound traffic for Node groups
+    egress_all = {
+      description      = "Node all egress"
+      protocol         = "-1"
+      from_port        = 0
+      to_port          = 0
+      type             = "egress"
+      cidr_blocks      = ["0.0.0.0/0"]
+      ipv6_cidr_blocks = ["::/0"]
+    }
+    # Allows Control Plane Nodes to talk to Worker nodes on all ports. Added this to simplify the example and further avoid issues with Add-ons communication with Control plane.
+    # This can be restricted further to specific port based on the requirement for each Add-on e.g., metrics-server 4443, spark-operator 8080, karpenter 8443 etc.
+    # Change this according to your security requirements if needed
+    ingress_cluster_to_node_all_traffic = {
+      description                   = "Cluster API to Nodegroup all traffic"
+      protocol                      = "-1"
+      from_port                     = 0
+      to_port                       = 0
+      type                          = "ingress"
+      source_cluster_security_group = true
+    }
+  }
+
+  managed_node_groups = {
+    mg_5 = {
+      node_group_name      = "managed-ondemand"
+      instance_types       = ["m5.large"]
+      subnet_ids           = module.vpc.private_subnets
+      force_update_version = true
+    }
+  }
+
+  tags = local.tags
+}
+
+module "eks_blueprints_kubernetes_addons" {
+  source = "../../modules/kubernetes-addons"
+
+  eks_cluster_id               = module.eks_blueprints.eks_cluster_id
+  eks_cluster_endpoint         = module.eks_blueprints.eks_cluster_endpoint
+  eks_oidc_provider            = module.eks_blueprints.oidc_provider
+  eks_cluster_version          = module.eks_blueprints.eks_cluster_version
+  eks_worker_security_group_id = module.eks_blueprints.worker_node_security_group_id
+
+  enable_external_secrets = true
+
+  tags = local.tags
+
+}
+
+#---------------------------------------------------------------
+# Supporting Resources
+#---------------------------------------------------------------
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "~> 3.0"
+
+  name = local.name
+  cidr = local.vpc_cidr
+
+  azs             = local.azs
+  public_subnets  = [for k, v in local.azs : cidrsubnet(local.vpc_cidr, 8, k)]
+  private_subnets = [for k, v in local.azs : cidrsubnet(local.vpc_cidr, 8, k + 10)]
+
+  enable_nat_gateway   = true
+  single_nat_gateway   = true
+  enable_dns_hostnames = true
+
+  # Manage so we can name
+  manage_default_network_acl    = true
+  default_network_acl_tags      = { Name = "${local.name}-default" }
+  manage_default_route_table    = true
+  default_route_table_tags      = { Name = "${local.name}-default" }
+  manage_default_security_group = true
+  default_security_group_tags   = { Name = "${local.name}-default" }
+
+  public_subnet_tags = {
+    "kubernetes.io/cluster/${local.name}" = "shared"
+    "kubernetes.io/role/elb"              = 1
+  }
+
+  private_subnet_tags = {
+    "kubernetes.io/cluster/${local.name}" = "shared"
+    "kubernetes.io/role/internal-elb"     = 1
+  }
+
+  tags = local.tags
+}
+
+data "aws_partition" "current" {}
+
+data "aws_caller_identity" "current" {}
+
+data "aws_region" "current" {}
+
+#---------------------------------------------------------------
+# External Secrets Operator - Secret 
+#---------------------------------------------------------------
+
+module "cluster_secretstore_role" {
+  source                      = "../../modules/irsa"
+  kubernetes_namespace        = local.namespace
+  create_kubernetes_namespace = false
+  kubernetes_service_account  = local.cluster_secretstore_sa
+  irsa_iam_policies           = [aws_iam_policy.cluster_secretstore.arn]
+
+  addon_context = {
+    aws_caller_identity_account_id = data.aws_caller_identity.current.account_id
+    aws_caller_identity_arn        = data.aws_caller_identity.current.arn
+    aws_eks_cluster_endpoint       = module.eks_blueprints.eks_cluster_endpoint
+    aws_partition_id               = data.aws_partition.current.partition
+    aws_region_name                = data.aws_region.current.name
+    eks_cluster_id                 = module.eks_blueprints.eks_cluster_id
+    eks_oidc_issuer_url            = module.eks_blueprints.eks_oidc_issuer_url
+    eks_oidc_provider_arn          = module.eks_blueprints.eks_oidc_provider_arn
+    tags                           = {}
+  }
+
+  depends_on = [module.eks_blueprints_kubernetes_addons]
+}
+
+resource "aws_iam_policy" "cluster_secretstore" {
+  name_prefix = local.cluster_secretstore_sa
+  policy      = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "secretsmanager:GetResourcePolicy",
+        "secretsmanager:GetSecretValue",
+        "secretsmanager:DescribeSecret",
+        "secretsmanager:ListSecretVersionIds"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "kms:Decrypt"
+      ],
+      "Resource": "*"
+    }
+  ]
+}
+POLICY
+}
+
+resource "kubectl_manifest" "cluster_secretstore" {
+  yaml_body  = <<YAML
+apiVersion: external-secrets.io/v1beta1
+kind: ClusterSecretStore
+metadata: 
+  name: ${local.cluster_secretstore_name}
+spec: 
+  provider:
+    aws: 
+      service: SecretsManager
+      region: ${data.aws_region.current.name}
+      auth: 
+        jwt:
+          serviceAccountRef:
+            name: ${local.cluster_secretstore_sa}
+            namespace: ${local.namespace}
+YAML
+  depends_on = [module.eks_blueprints_kubernetes_addons]
+}
+
+resource "aws_secretsmanager_secret" "secret" {
+  name = local.name
+}
+
+resource "aws_secretsmanager_secret_version" "secret" {
+  secret_id = aws_secretsmanager_secret.secret.id
+  secret_string = jsonencode({
+    username = "secretuser",
+    password = "secretpassword"
+  })
+}
+
+resource "kubectl_manifest" "secret" {
+  yaml_body  = <<YAML
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: ${local.name}-sm
+  namespace: ${local.namespace}
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: ${local.cluster_secretstore_name}
+    kind: ClusterSecretStore
+  dataFrom:
+  - extract:
+      key: ${aws_secretsmanager_secret.secret.name}
+YAML
+  depends_on = [kubectl_manifest.cluster_secretstore]
+}
+
+#---------------------------------------------------------------
+# External Secrets Operator - Parameter Store
+#---------------------------------------------------------------
+
+module "secretstore_role" {
+  source                      = "../../modules/irsa"
+  kubernetes_namespace        = local.namespace
+  create_kubernetes_namespace = false
+  kubernetes_service_account  = local.secretstore_sa
+  irsa_iam_policies           = [aws_iam_policy.secretstore.arn]
+
+  addon_context = {
+    aws_caller_identity_account_id = data.aws_caller_identity.current.account_id
+    aws_caller_identity_arn        = data.aws_caller_identity.current.arn
+    aws_eks_cluster_endpoint       = module.eks_blueprints.eks_cluster_endpoint
+    aws_partition_id               = data.aws_partition.current.partition
+    aws_region_name                = data.aws_region.current.name
+    eks_cluster_id                 = module.eks_blueprints.eks_cluster_id
+    eks_oidc_issuer_url            = module.eks_blueprints.eks_oidc_issuer_url
+    eks_oidc_provider_arn          = module.eks_blueprints.eks_oidc_provider_arn
+    tags                           = {}
+  }
+
+  depends_on = [module.eks_blueprints_kubernetes_addons]
+}
+
+resource "aws_iam_policy" "secretstore" {
+  name_prefix = local.secretstore_sa
+  policy      = <<POLICY
+{
+	"Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ssm:GetParameter*"
+      ],
+      "Resource": "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter/${local.name}/*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "kms:Decrypt"
+      ],
+      "Resource": "*"
+    }
+  ]
+}
+POLICY
+}
+
+resource "kubectl_manifest" "secretstore" {
+  yaml_body  = <<YAML
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata: 
+  name: ${local.secretstore_name}
+  namespace: ${local.namespace}
+spec: 
+  provider:
+    aws: 
+      service: ParameterStore
+      region: ${data.aws_region.current.name}
+      auth: 
+        jwt:
+          serviceAccountRef:
+            name: ${local.secretstore_sa}
+YAML
+  depends_on = [module.eks_blueprints_kubernetes_addons]
+}
+
+resource "aws_ssm_parameter" "secret_parameter" {
+  name = "/${local.name}/secret"
+  type = "SecureString"
+  value = jsonencode({
+    username = "secretuser",
+    password = "secretpassword"
+  })
+}
+
+
+resource "kubectl_manifest" "secret_parameter" {
+  yaml_body  = <<YAML
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: ${local.name}-ps
+  namespace: ${local.namespace}
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: ${local.secretstore_name}
+    kind: SecretStore
+  dataFrom:
+  - extract:
+      key: ${aws_ssm_parameter.secret_parameter.name}
+YAML
+  depends_on = [kubectl_manifest.secretstore]
+}

--- a/examples/external-secrets-kubernetes-addon/main.tf
+++ b/examples/external-secrets-kubernetes-addon/main.tf
@@ -187,7 +187,7 @@ data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
 
 #---------------------------------------------------------------
-# External Secrets Operator - Secret 
+# External Secrets Operator - Secret
 #---------------------------------------------------------------
 
 module "cluster_secretstore_role" {
@@ -226,7 +226,7 @@ resource "aws_iam_policy" "cluster_secretstore" {
         "secretsmanager:DescribeSecret",
         "secretsmanager:ListSecretVersionIds"
       ],
-      "Resource": "*"
+      "Resource": "${aws_secretsmanager_secret.secret.arn}"
     },
     {
       "Effect": "Allow",
@@ -244,14 +244,14 @@ resource "kubectl_manifest" "cluster_secretstore" {
   yaml_body  = <<YAML
 apiVersion: external-secrets.io/v1beta1
 kind: ClusterSecretStore
-metadata: 
+metadata:
   name: ${local.cluster_secretstore_name}
-spec: 
+spec:
   provider:
-    aws: 
+    aws:
       service: SecretsManager
       region: ${data.aws_region.current.name}
-      auth: 
+      auth:
         jwt:
           serviceAccountRef:
             name: ${local.cluster_secretstore_sa}
@@ -346,15 +346,15 @@ resource "kubectl_manifest" "secretstore" {
   yaml_body  = <<YAML
 apiVersion: external-secrets.io/v1beta1
 kind: SecretStore
-metadata: 
+metadata:
   name: ${local.secretstore_name}
   namespace: ${local.namespace}
-spec: 
+spec:
   provider:
-    aws: 
+    aws:
       service: ParameterStore
       region: ${data.aws_region.current.name}
-      auth: 
+      auth:
         jwt:
           serviceAccountRef:
             name: ${local.secretstore_sa}

--- a/examples/external-secrets-kubernetes-addon/main.tf
+++ b/examples/external-secrets-kubernetes-addon/main.tf
@@ -7,7 +7,7 @@ provider "kubernetes" {
   cluster_ca_certificate = base64decode(module.eks_blueprints.eks_cluster_certificate_authority_data)
 
   exec {
-    api_version = "client.authentication.k8s.io/v1alpha1"
+    api_version = "client.authentication.k8s.io/v1beta1"
     command     = "aws"
     # This requires the awscli to be installed locally where Terraform is executed
     args = ["eks", "get-token", "--cluster-name", module.eks_blueprints.eks_cluster_id]
@@ -20,7 +20,7 @@ provider "helm" {
     cluster_ca_certificate = base64decode(module.eks_blueprints.eks_cluster_certificate_authority_data)
 
     exec {
-      api_version = "client.authentication.k8s.io/v1alpha1"
+      api_version = "client.authentication.k8s.io/v1beta1"
       command     = "aws"
       # This requires the awscli to be installed locally where Terraform is executed
       args = ["eks", "get-token", "--cluster-name", module.eks_blueprints.eks_cluster_id]
@@ -33,7 +33,7 @@ provider "kubectl" {
   cluster_ca_certificate = base64decode(module.eks_blueprints.eks_cluster_certificate_authority_data)
 
   exec {
-    api_version = "client.authentication.k8s.io/v1alpha1"
+    api_version = "client.authentication.k8s.io/v1beta1"
     command     = "aws"
     # This requires the awscli to be installed locally where Terraform is executed
     args = ["eks", "get-token", "--cluster-name", module.eks_blueprints.eks_cluster_id]

--- a/examples/external-secrets-kubernetes-addon/outputs.tf
+++ b/examples/external-secrets-kubernetes-addon/outputs.tf
@@ -1,0 +1,4 @@
+output "configure_kubectl" {
+  description = "Configure kubectl: make sure you're logged in with the correct AWS profile and run the following command to update your kubeconfig"
+  value       = module.eks_blueprints.configure_kubectl
+}

--- a/examples/external-secrets-kubernetes-addon/versions.tf
+++ b/examples/external-secrets-kubernetes-addon/versions.tf
@@ -1,0 +1,29 @@
+terraform {
+  required_version = ">= 1.0.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.9"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.10"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = ">= 2.4.1"
+    }
+    kubectl = {
+      source  = "gavinbunney/kubectl"
+      version = ">= 1.7.0"
+    }
+  }
+
+  # ##  Used for end-to-end testing on project; update to suit your needs
+  # backend "s3" {
+  #   bucket = "terraform-ssp-github-actions-state"
+  #   region = "us-west-2"
+  #   key    = "e2e/complete-kubernetes-addons/terraform.tfstate"
+  # }
+}

--- a/examples/fully-private-eks-cluster/eks/main.tf
+++ b/examples/fully-private-eks-cluster/eks/main.tf
@@ -8,7 +8,7 @@ provider "kubernetes" {
   cluster_ca_certificate = base64decode(module.eks_blueprints.eks_cluster_certificate_authority_data)
 
   exec {
-    api_version = "client.authentication.k8s.io/v1alpha1"
+    api_version = "client.authentication.k8s.io/v1beta1"
     command     = "aws"
     # This requires the awscli to be installed locally where Terraform is executed
     args = ["eks", "get-token", "--cluster-name", module.eks_blueprints.eks_cluster_id]

--- a/modules/kubernetes-addons/README.md
+++ b/modules/kubernetes-addons/README.md
@@ -146,12 +146,8 @@
 | <a name="input_enable_cluster_autoscaler"></a> [enable\_cluster\_autoscaler](#input\_enable\_cluster\_autoscaler) | Enable Cluster autoscaler add-on | `bool` | `false` | no |
 | <a name="input_enable_coredns_autoscaler"></a> [enable\_coredns\_autoscaler](#input\_enable\_coredns\_autoscaler) | Enable CoreDNS autoscaler add-on | `bool` | `false` | no |
 | <a name="input_enable_crossplane"></a> [enable\_crossplane](#input\_enable\_crossplane) | Enable Crossplane add-on | `bool` | `false` | no |
-<<<<<<< HEAD
 | <a name="input_enable_external_dns"></a> [enable\_external\_dns](#input\_enable\_external\_dns) | External DNS add-on | `bool` | `false` | no |
-=======
-| <a name="input_enable_external_dns"></a> [enable\_external\_dns](#input\_enable\_external\_dns) | External DNS add-on. | `bool` | `false` | no |
 | <a name="input_enable_external_secrets"></a> [enable\_external\_secrets](#input\_enable\_external\_secrets) | Enable External Secrets operator add-on | `bool` | `false` | no |
->>>>>>> 2dd94ce (Support external secrets from the main module)
 | <a name="input_enable_fargate_fluentbit"></a> [enable\_fargate\_fluentbit](#input\_enable\_fargate\_fluentbit) | Enable Fargate FluentBit add-on | `bool` | `false` | no |
 | <a name="input_enable_ingress_nginx"></a> [enable\_ingress\_nginx](#input\_enable\_ingress\_nginx) | Enable Ingress Nginx add-on | `bool` | `false` | no |
 | <a name="input_enable_ipv6"></a> [enable\_ipv6](#input\_enable\_ipv6) | Enable Ipv6 network. Attaches new VPC CNI policy to the IRSA role | `bool` | `false` | no |

--- a/modules/kubernetes-addons/README.md
+++ b/modules/kubernetes-addons/README.md
@@ -41,6 +41,7 @@
 | <a name="module_crossplane"></a> [crossplane](#module\_crossplane) | ./crossplane | n/a |
 | <a name="module_csi_secrets_store_provider_aws"></a> [csi\_secrets\_store\_provider\_aws](#module\_csi\_secrets\_store\_provider\_aws) | ./csi-secrets-store-provider-aws | n/a |
 | <a name="module_external_dns"></a> [external\_dns](#module\_external\_dns) | ./external-dns | n/a |
+| <a name="module_external_secrets"></a> [external\_secrets](#module\_external\_secrets) | ./external-secrets | n/a |
 | <a name="module_fargate_fluentbit"></a> [fargate\_fluentbit](#module\_fargate\_fluentbit) | ./fargate-fluentbit | n/a |
 | <a name="module_ingress_nginx"></a> [ingress\_nginx](#module\_ingress\_nginx) | ./ingress-nginx | n/a |
 | <a name="module_karpenter"></a> [karpenter](#module\_karpenter) | ./karpenter | n/a |
@@ -145,7 +146,12 @@
 | <a name="input_enable_cluster_autoscaler"></a> [enable\_cluster\_autoscaler](#input\_enable\_cluster\_autoscaler) | Enable Cluster autoscaler add-on | `bool` | `false` | no |
 | <a name="input_enable_coredns_autoscaler"></a> [enable\_coredns\_autoscaler](#input\_enable\_coredns\_autoscaler) | Enable CoreDNS autoscaler add-on | `bool` | `false` | no |
 | <a name="input_enable_crossplane"></a> [enable\_crossplane](#input\_enable\_crossplane) | Enable Crossplane add-on | `bool` | `false` | no |
+<<<<<<< HEAD
 | <a name="input_enable_external_dns"></a> [enable\_external\_dns](#input\_enable\_external\_dns) | External DNS add-on | `bool` | `false` | no |
+=======
+| <a name="input_enable_external_dns"></a> [enable\_external\_dns](#input\_enable\_external\_dns) | External DNS add-on. | `bool` | `false` | no |
+| <a name="input_enable_external_secrets"></a> [enable\_external\_secrets](#input\_enable\_external\_secrets) | Enable External Secrets operator add-on | `bool` | `false` | no |
+>>>>>>> 2dd94ce (Support external secrets from the main module)
 | <a name="input_enable_fargate_fluentbit"></a> [enable\_fargate\_fluentbit](#input\_enable\_fargate\_fluentbit) | Enable Fargate FluentBit add-on | `bool` | `false` | no |
 | <a name="input_enable_ingress_nginx"></a> [enable\_ingress\_nginx](#input\_enable\_ingress\_nginx) | Enable Ingress Nginx add-on | `bool` | `false` | no |
 | <a name="input_enable_ipv6"></a> [enable\_ipv6](#input\_enable\_ipv6) | Enable Ipv6 network. Attaches new VPC CNI policy to the IRSA role | `bool` | `false` | no |
@@ -169,6 +175,7 @@
 | <a name="input_external_dns_helm_config"></a> [external\_dns\_helm\_config](#input\_external\_dns\_helm\_config) | External DNS Helm Chart config | `any` | `{}` | no |
 | <a name="input_external_dns_irsa_policies"></a> [external\_dns\_irsa\_policies](#input\_external\_dns\_irsa\_policies) | Additional IAM policies for a IAM role for service accounts | `list(string)` | `[]` | no |
 | <a name="input_external_dns_private_zone"></a> [external\_dns\_private\_zone](#input\_external\_dns\_private\_zone) | Determines if referenced Route53 zone is private. | `bool` | `false` | no |
+| <a name="input_external_secrets_helm_config"></a> [external\_secrets\_helm\_config](#input\_external\_secrets\_helm\_config) | External Secrets operator Helm Chart config | `any` | `{}` | no |
 | <a name="input_fargate_fluentbit_addon_config"></a> [fargate\_fluentbit\_addon\_config](#input\_fargate\_fluentbit\_addon\_config) | Fargate fluentbit add-on config | `any` | `{}` | no |
 | <a name="input_ingress_nginx_helm_config"></a> [ingress\_nginx\_helm\_config](#input\_ingress\_nginx\_helm\_config) | Ingress Nginx Helm Chart config | `any` | `{}` | no |
 | <a name="input_irsa_iam_permissions_boundary"></a> [irsa\_iam\_permissions\_boundary](#input\_irsa\_iam\_permissions\_boundary) | IAM permissions boundary for IRSA roles | `string` | `""` | no |

--- a/modules/kubernetes-addons/external-secrets/README.md
+++ b/modules/kubernetes-addons/external-secrets/README.md
@@ -1,0 +1,44 @@
+# External Secrets Operator
+
+External Secrets Operator is a Kubernetes operator that integrates external secret management systems like AWS Secrets Manager, HashiCorp Vault, Google Secrets Manager, Azure Key Vault and many more. The operator reads information from external APIs and automatically injects the values into a Kubernetes Secret.
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
+| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.10 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | >= 2.10 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_helm_addon"></a> [helm\_addon](#module\_helm\_addon) | ../helm-addon | n/a |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [kubernetes_namespace_v1.this](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace_v1) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_addon_context"></a> [addon\_context](#input\_addon\_context) | Input configuration for the addon | <pre>object({<br>    aws_caller_identity_account_id = string<br>    aws_caller_identity_arn        = string<br>    aws_eks_cluster_endpoint       = string<br>    aws_partition_id               = string<br>    aws_region_name                = string<br>    eks_cluster_id                 = string<br>    eks_oidc_issuer_url            = string<br>    eks_oidc_provider_arn          = string<br>    tags                           = map(string)<br>  })</pre> | n/a | yes |
+| <a name="input_helm_config"></a> [helm\_config](#input\_helm\_config) | Helm provider config for External Secrets Operator | `any` | `{}` | no |
+| <a name="input_manage_via_gitops"></a> [manage\_via\_gitops](#input\_manage\_via\_gitops) | Determines if the add-on should be managed via GitOps | `bool` | `false` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_argocd_gitops_config"></a> [argocd\_gitops\_config](#output\_argocd\_gitops\_config) | Configuration used for managing the add-on with ArgoCD |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/kubernetes-addons/external-secrets/locals.tf
+++ b/modules/kubernetes-addons/external-secrets/locals.tf
@@ -1,0 +1,23 @@
+locals {
+  name = "external-secrets"
+
+  default_helm_config = {
+    name        = local.name
+    chart       = local.name
+    repository  = "https://charts.external-secrets.io/external-secrets"
+    version     = "0.5.6"
+    namespace   = local.name
+    description = "The External Secrets Operator Helm chart default configuration"
+    values      = null
+    timeout     = "1200"
+  }
+
+  helm_config = merge(
+    local.default_helm_config,
+    var.helm_config
+  )
+
+  argocd_gitops_config = {
+    enable = true
+  }
+}

--- a/modules/kubernetes-addons/external-secrets/locals.tf
+++ b/modules/kubernetes-addons/external-secrets/locals.tf
@@ -4,7 +4,7 @@ locals {
   default_helm_config = {
     name        = local.name
     chart       = local.name
-    repository  = "https://charts.external-secrets.io/external-secrets"
+    repository  = "https://charts.external-secrets.io/"
     version     = "0.5.6"
     namespace   = local.name
     description = "The External Secrets Operator Helm chart default configuration"

--- a/modules/kubernetes-addons/external-secrets/main.tf
+++ b/modules/kubernetes-addons/external-secrets/main.tf
@@ -1,0 +1,20 @@
+module "helm_addon" {
+  source            = "../helm-addon"
+  manage_via_gitops = var.manage_via_gitops
+  helm_config       = local.helm_config
+  irsa_config       = null
+  addon_context     = var.addon_context
+
+  depends_on = [kubernetes_namespace_v1.this]
+}
+
+resource "kubernetes_namespace_v1" "this" {
+  count = try(local.helm_config["create_namespace"], true) && local.helm_config["namespace"] != "kube-system" ? 1 : 0
+  metadata {
+    name = local.helm_config["namespace"]
+
+    labels = {
+      "app.kubernetes.io/managed-by" = "terraform-aws-eks-blueprints"
+    }
+  }
+}

--- a/modules/kubernetes-addons/external-secrets/outputs.tf
+++ b/modules/kubernetes-addons/external-secrets/outputs.tf
@@ -1,0 +1,4 @@
+output "argocd_gitops_config" {
+  description = "Configuration used for managing the add-on with ArgoCD"
+  value       = var.manage_via_gitops ? local.argocd_gitops_config : null
+}

--- a/modules/kubernetes-addons/external-secrets/variables.tf
+++ b/modules/kubernetes-addons/external-secrets/variables.tf
@@ -1,0 +1,26 @@
+variable "helm_config" {
+  type        = any
+  description = "Helm provider config for External Secrets Operator"
+  default     = {}
+}
+
+variable "manage_via_gitops" {
+  type        = bool
+  default     = false
+  description = "Determines if the add-on should be managed via GitOps"
+}
+
+variable "addon_context" {
+  type = object({
+    aws_caller_identity_account_id = string
+    aws_caller_identity_arn        = string
+    aws_eks_cluster_endpoint       = string
+    aws_partition_id               = string
+    aws_region_name                = string
+    eks_cluster_id                 = string
+    eks_oidc_issuer_url            = string
+    eks_oidc_provider_arn          = string
+    tags                           = map(string)
+  })
+  description = "Input configuration for the addon"
+}

--- a/modules/kubernetes-addons/external-secrets/versions.tf
+++ b/modules/kubernetes-addons/external-secrets/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.0.0"
+
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.10"
+    }
+  }
+}

--- a/modules/kubernetes-addons/main.tf
+++ b/modules/kubernetes-addons/main.tf
@@ -435,3 +435,10 @@ module "adot_collector_nginx" {
     module.opentelemetry_operator
   ]
 }
+
+module "external_secrets" {
+  count         = var.enable_external_secrets ? 1 : 0
+  source        = "./external-secrets"
+  helm_config   = var.external_secrets_helm_config
+  addon_context = local.addon_context
+}

--- a/modules/kubernetes-addons/variables.tf
+++ b/modules/kubernetes-addons/variables.tf
@@ -889,3 +889,16 @@ variable "secrets_store_csi_driver_helm_config" {
   default     = null
   description = "CSI Secrets Store Provider Helm Configurations"
 }
+
+#-----------EXTERNAL SECRETS OPERATOR-----------
+variable "enable_external_secrets" {
+  type        = bool
+  default     = false
+  description = "Enable External Secrets operator add-on"
+}
+
+variable "external_secrets_helm_config" {
+  type        = any
+  default     = {}
+  description = "External Secrets operator Helm Chart config"
+}


### PR DESCRIPTION
### What does this PR do?

Adds the [External Secrets operator](https://external-secrets.io/v0.5.6/) as an addon


### Motivation

The External Secrets operator integrates external secrets management services with a Kubernetes cluster. It's more flexible than the Secret Store CSI driver. It transparently handles secret rotation, as secrets are kept synchronised. By using Kubernetes secrets, it's easy to map secrets as environment variables. 


### More

- [x] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [x] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable) (https://github.com/aws-samples/eks-blueprints-add-ons/pull/50)
- [x] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
