### PR TITLE
docs: fix link (pen) to edit pages

### DIFF
--- a/docs/extensibility.md
+++ b/docs/extensibility.md
@@ -49,7 +49,7 @@ There are two ways in which a customer can implement fully private add-ons:
 1. Add-ons specific to a customer instance of EKS Blueprints can be implemented inline with the blueprint in the same codebase. Such extensions are scoped to the customer base. Forking the repo however has disadvantages when it comes to ongoing feature releases and bug fixes which will have to be manually ported to your fork.
 2. We recommend, you implement a separate repository for your private add-on while still using the upstream framework. This gives you the advantage of keeping up with ongoing feature releases and bug fixes while keeping your add-on private.
 
-The following example shows you can leverage EKS Blueprints to provide your own helm add-on. 
+The following example shows you can leverage EKS Blueprints to provide your own helm add-on.
 
 ```hcl
 #---------------------------------------------------------------

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,7 @@
 site_name: Amazon EKS Blueprints for Terraform
 repo_name: "aws-ia/terraform-aws-eks-blueprints"
 repo_url: "https://github.com/aws-ia/terraform-aws-eks-blueprints"
+edit_uri: "edit/main/docs/"
 docs_dir: "docs"
 theme:
   name: material


### PR DESCRIPTION
### What does this PR do?

Fixes the link to edit pages.
![image](https://user-images.githubusercontent.com/5385290/172870557-1370286e-649f-440b-814e-81105e9ce66b.png)

### Motivation

Today, clicking on the pen to suggest a pull request leads to a 404 error. This is because the code is on main branch where mkdocs expects master by default. See [mkdocs documentation](https://www.mkdocs.org/user-guide/configuration/).


### More

- [X] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [X] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [X] Yes, I ran `pre-commit run -a` with this PR

**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

None