### PR TITLE
Update addons versions | Examples to use cluster version 1.22 | Fix self-managed-node example

### DIFF
--- a/examples/analytics/emr-on-eks/main.tf
+++ b/examples/analytics/emr-on-eks/main.tf
@@ -50,7 +50,7 @@ module "eks_blueprints" {
   source = "../../.."
 
   cluster_name    = local.name
-  cluster_version = "1.21"
+  cluster_version = "1.22"
 
   vpc_id             = module.vpc.vpc_id
   private_subnet_ids = module.vpc.private_subnets

--- a/examples/analytics/spark-k8s-operator/main.tf
+++ b/examples/analytics/spark-k8s-operator/main.tf
@@ -50,7 +50,7 @@ module "eks_blueprints" {
   source = "../../.."
 
   cluster_name    = local.name
-  cluster_version = "1.21"
+  cluster_version = "1.22"
 
   vpc_id             = module.vpc.vpc_id
   private_subnet_ids = module.vpc.private_subnets

--- a/examples/aws-efs-csi-driver/main.tf
+++ b/examples/aws-efs-csi-driver/main.tf
@@ -50,7 +50,7 @@ module "eks_blueprints" {
   source = "../.."
 
   cluster_name    = local.name
-  cluster_version = "1.21"
+  cluster_version = "1.22"
 
   vpc_id             = module.vpc.vpc_id
   private_subnet_ids = module.vpc.private_subnets

--- a/examples/ci-cd/gitlab-ci-cd/main.tf
+++ b/examples/ci-cd/gitlab-ci-cd/main.tf
@@ -54,7 +54,7 @@ module "eks_blueprints" {
   source = "../../.."
 
   cluster_name    = local.name
-  cluster_version = "1.21"
+  cluster_version = "1.22"
 
   vpc_id             = module.vpc.vpc_id
   private_subnet_ids = module.vpc.private_subnets

--- a/examples/complete-kubernetes-addons/main.tf
+++ b/examples/complete-kubernetes-addons/main.tf
@@ -50,7 +50,7 @@ module "eks_blueprints" {
   source = "../.."
 
   cluster_name    = local.name
-  cluster_version = "1.21"
+  cluster_version = "1.22"
 
   vpc_id             = module.vpc.vpc_id
   private_subnet_ids = module.vpc.private_subnets

--- a/examples/crossplane/main.tf
+++ b/examples/crossplane/main.tf
@@ -64,7 +64,7 @@ module "eks_blueprints" {
   source = "../.."
 
   cluster_name    = local.name
-  cluster_version = "1.21"
+  cluster_version = "1.22"
 
   vpc_id             = module.vpc.vpc_id
   private_subnet_ids = module.vpc.private_subnets

--- a/examples/eks-cluster-with-external-dns/main.tf
+++ b/examples/eks-cluster-with-external-dns/main.tf
@@ -55,7 +55,7 @@ module "eks_blueprints" {
   source = "../.."
 
   cluster_name    = local.name
-  cluster_version = "1.21"
+  cluster_version = "1.22"
 
   vpc_id             = module.vpc.vpc_id
   private_subnet_ids = module.vpc.private_subnets

--- a/examples/eks-cluster-with-new-vpc/main.tf
+++ b/examples/eks-cluster-with-new-vpc/main.tf
@@ -52,7 +52,7 @@ module "eks_blueprints" {
   source = "../.."
 
   cluster_name    = local.cluster_name
-  cluster_version = "1.21"
+  cluster_version = "1.22"
 
   vpc_id             = module.vpc.vpc_id
   private_subnet_ids = module.vpc.private_subnets

--- a/examples/fargate-serverless/main.tf
+++ b/examples/fargate-serverless/main.tf
@@ -51,7 +51,7 @@ module "eks_blueprints" {
   source = "../.."
 
   cluster_name    = local.name
-  cluster_version = "1.21"
+  cluster_version = "1.22"
 
   vpc_id             = module.vpc.vpc_id
   private_subnet_ids = module.vpc.private_subnets

--- a/examples/fully-private-eks-cluster/main.tf
+++ b/examples/fully-private-eks-cluster/main.tf
@@ -36,7 +36,7 @@ module "eks_blueprints" {
   source = "../.."
 
   cluster_name    = local.name
-  cluster_version = "1.21"
+  cluster_version = "1.22"
 
   vpc_id             = module.vpc.vpc_id
   private_subnet_ids = module.vpc.private_subnets

--- a/examples/game-tech/agones-game-controller/main.tf
+++ b/examples/game-tech/agones-game-controller/main.tf
@@ -50,7 +50,7 @@ module "eks_blueprints" {
   source = "../../.."
 
   cluster_name    = local.name
-  cluster_version = "1.21"
+  cluster_version = "1.22"
 
   vpc_id             = module.vpc.vpc_id
   private_subnet_ids = module.vpc.private_subnets

--- a/examples/gitops/argocd/main.tf
+++ b/examples/gitops/argocd/main.tf
@@ -50,7 +50,7 @@ module "eks_blueprints" {
   source = "../../.."
 
   cluster_name    = local.name
-  cluster_version = "1.21"
+  cluster_version = "1.22"
 
   vpc_id             = module.vpc.vpc_id
   private_subnet_ids = module.vpc.private_subnets

--- a/examples/ipv6-eks-cluster/main.tf
+++ b/examples/ipv6-eks-cluster/main.tf
@@ -50,7 +50,7 @@ module "eks_blueprints" {
   source = "../.."
 
   cluster_name      = local.name
-  cluster_version   = "1.21"
+  cluster_version   = "1.22"
   cluster_ip_family = "ipv6"
 
   vpc_id             = module.vpc.vpc_id

--- a/examples/karpenter/main.tf
+++ b/examples/karpenter/main.tf
@@ -66,7 +66,7 @@ module "eks_blueprints" {
   source = "../.."
 
   cluster_name    = local.name
-  cluster_version = "1.21"
+  cluster_version = "1.22"
 
   vpc_id             = module.vpc.vpc_id
   private_subnet_ids = module.vpc.private_subnets

--- a/examples/multi-tenancy-with-teams/main.tf
+++ b/examples/multi-tenancy-with-teams/main.tf
@@ -65,7 +65,7 @@ module "eks_blueprints" {
   source = "../.."
 
   cluster_name    = local.name
-  cluster_version = "1.21"
+  cluster_version = "1.22"
 
   vpc_id             = module.vpc.vpc_id
   private_subnet_ids = module.vpc.private_subnets

--- a/examples/node-groups/fargate-profiles/main.tf
+++ b/examples/node-groups/fargate-profiles/main.tf
@@ -36,7 +36,7 @@ module "eks_blueprints" {
   source = "../../.."
 
   cluster_name    = local.name
-  cluster_version = "1.21"
+  cluster_version = "1.22"
 
   vpc_id             = module.vpc.vpc_id
   private_subnet_ids = module.vpc.private_subnets

--- a/examples/node-groups/managed-node-groups/main.tf
+++ b/examples/node-groups/managed-node-groups/main.tf
@@ -46,7 +46,7 @@ locals {
   name   = basename(path.cwd)
   region = "us-west-2"
 
-  cluster_version = "1.21"
+  cluster_version = "1.22"
 
   vpc_cidr = "10.0.0.0/16"
   azs      = slice(data.aws_availability_zones.available.names, 0, 3)

--- a/examples/node-groups/self-managed-node-groups/main.tf
+++ b/examples/node-groups/self-managed-node-groups/main.tf
@@ -14,6 +14,20 @@ provider "kubernetes" {
   }
 }
 
+provider "helm" {
+  kubernetes {
+    host                   = module.eks_blueprints.eks_cluster_endpoint
+    cluster_ca_certificate = base64decode(module.eks_blueprints.eks_cluster_certificate_authority_data)
+
+    exec {
+      api_version = "client.authentication.k8s.io/v1alpha1"
+      command     = "aws"
+      # This requires the awscli to be installed locally where Terraform is executed
+      args = ["eks", "get-token", "--cluster-name", module.eks_blueprints.eks_cluster_id]
+    }
+  }
+}
+
 data "aws_availability_zones" "available" {}
 
 locals {

--- a/examples/node-groups/self-managed-node-groups/main.tf
+++ b/examples/node-groups/self-managed-node-groups/main.tf
@@ -36,7 +36,7 @@ module "eks_blueprints" {
   source = "../../.."
 
   cluster_name    = local.name
-  cluster_version = "1.21"
+  cluster_version = "1.22"
 
   vpc_id             = module.vpc.vpc_id
   private_subnet_ids = module.vpc.private_subnets

--- a/examples/node-groups/windows-node-groups/main.tf
+++ b/examples/node-groups/windows-node-groups/main.tf
@@ -50,7 +50,7 @@ module "eks_blueprints" {
   source = "../../.."
 
   cluster_name    = local.name
-  cluster_version = "1.21"
+  cluster_version = "1.22"
 
   vpc_id             = module.vpc.vpc_id
   private_subnet_ids = module.vpc.private_subnets

--- a/examples/observability/adot-amp-grafana-for-haproxy/main.tf
+++ b/examples/observability/adot-amp-grafana-for-haproxy/main.tf
@@ -55,7 +55,7 @@ module "eks_blueprints" {
   source = "../../.."
 
   cluster_name    = local.name
-  cluster_version = "1.21"
+  cluster_version = "1.22"
 
   vpc_id             = module.vpc.vpc_id
   private_subnet_ids = module.vpc.private_subnets

--- a/examples/observability/adot-amp-grafana-for-java/main.tf
+++ b/examples/observability/adot-amp-grafana-for-java/main.tf
@@ -55,7 +55,7 @@ module "eks_blueprints" {
   source = "../../.."
 
   cluster_name    = local.name
-  cluster_version = "1.21"
+  cluster_version = "1.22"
 
   vpc_id             = module.vpc.vpc_id
   private_subnet_ids = module.vpc.private_subnets

--- a/examples/observability/adot-amp-grafana-for-memcached/main.tf
+++ b/examples/observability/adot-amp-grafana-for-memcached/main.tf
@@ -55,7 +55,7 @@ module "eks_blueprints" {
   source = "../../.."
 
   cluster_name    = local.name
-  cluster_version = "1.21"
+  cluster_version = "1.22"
 
   vpc_id             = module.vpc.vpc_id
   private_subnet_ids = module.vpc.private_subnets

--- a/examples/observability/adot-amp-grafana-for-nginx/main.tf
+++ b/examples/observability/adot-amp-grafana-for-nginx/main.tf
@@ -55,7 +55,7 @@ module "eks_blueprints" {
   source = "../../.."
 
   cluster_name    = local.name
-  cluster_version = "1.21"
+  cluster_version = "1.22"
 
   vpc_id             = module.vpc.vpc_id
   private_subnet_ids = module.vpc.private_subnets

--- a/examples/observability/amp-amg-opensearch/main.tf
+++ b/examples/observability/amp-amg-opensearch/main.tf
@@ -55,7 +55,7 @@ module "eks_blueprints" {
   source = "../../.."
 
   cluster_name    = local.name
-  cluster_version = "1.21"
+  cluster_version = "1.22"
 
   vpc_id             = module.vpc.vpc_id
   private_subnet_ids = module.vpc.private_subnets

--- a/examples/tls-with-aws-pca-issuer/main.tf
+++ b/examples/tls-with-aws-pca-issuer/main.tf
@@ -53,7 +53,7 @@ module "eks_blueprints" {
   source = "../.."
 
   cluster_name    = local.name
-  cluster_version = "1.21"
+  cluster_version = "1.22"
 
   vpc_id             = module.vpc.vpc_id
   private_subnet_ids = module.vpc.private_subnets

--- a/modules/kubernetes-addons/agones/locals.tf
+++ b/modules/kubernetes-addons/agones/locals.tf
@@ -6,7 +6,7 @@ locals {
     name               = local.name
     chart              = local.name
     repository         = "https://agones.dev/chart/stable"
-    version            = "1.18.0"
+    version            = "1.23.0"
     namespace          = local.namespace
     timeout            = "1200"
     description        = "Agones Gaming Server Helm Chart deployment configuration"

--- a/modules/kubernetes-addons/argo-rollouts/locals.tf
+++ b/modules/kubernetes-addons/argo-rollouts/locals.tf
@@ -5,7 +5,7 @@ locals {
     name        = local.name
     chart       = local.name
     repository  = "https://argoproj.github.io/argo-helm"
-    version     = "2.9.1"
+    version     = "2.16.0"
     namespace   = local.name
     description = "Argo Rollouts AddOn Helm Chart"
     values      = []

--- a/modules/kubernetes-addons/argocd/locals.tf
+++ b/modules/kubernetes-addons/argocd/locals.tf
@@ -16,7 +16,7 @@ locals {
     name             = local.name
     chart            = local.name
     repository       = "https://argoproj.github.io/argo-helm"
-    version          = "3.33.3"
+    version          = "4.9.1"
     namespace        = local.namespace
     timeout          = 1200
     create_namespace = true

--- a/modules/kubernetes-addons/aws-efs-csi-driver/locals.tf
+++ b/modules/kubernetes-addons/aws-efs-csi-driver/locals.tf
@@ -7,7 +7,7 @@ locals {
     name        = local.name
     chart       = local.name
     repository  = "https://kubernetes-sigs.github.io/aws-efs-csi-driver/"
-    version     = "2.2.3"
+    version     = "2.2.6"
     namespace   = local.namespace
     values      = local.default_helm_values
     description = "The AWS EFS CSI driver Helm chart deployment configuration"

--- a/modules/kubernetes-addons/aws-for-fluentbit/locals.tf
+++ b/modules/kubernetes-addons/aws-for-fluentbit/locals.tf
@@ -18,7 +18,7 @@ locals {
     name        = local.name
     chart       = local.name
     repository  = "https://aws.github.io/eks-charts"
-    version     = "0.1.11"
+    version     = "0.1.17"
     namespace   = local.name
     values      = local.default_helm_values
     description = "aws-for-fluentbit Helm Chart deployment configuration"

--- a/modules/kubernetes-addons/aws-load-balancer-controller/locals.tf
+++ b/modules/kubernetes-addons/aws-load-balancer-controller/locals.tf
@@ -6,7 +6,7 @@ locals {
     name        = local.name
     chart       = local.name
     repository  = "https://aws.github.io/eks-charts"
-    version     = "1.4.1"
+    version     = "1.4.2"
     namespace   = "kube-system"
     timeout     = "1200"
     values      = local.default_helm_values

--- a/modules/kubernetes-addons/aws-node-termination-handler/locals.tf
+++ b/modules/kubernetes-addons/aws-node-termination-handler/locals.tf
@@ -7,7 +7,7 @@ locals {
     name             = local.name
     chart            = local.name
     repository       = "https://aws.github.io/eks-charts"
-    version          = "0.16.0"
+    version          = "0.18.5"
     namespace        = local.namespace
     timeout          = "1200"
     create_namespace = false

--- a/modules/kubernetes-addons/aws-privateca-issuer/locals.tf
+++ b/modules/kubernetes-addons/aws-privateca-issuer/locals.tf
@@ -6,7 +6,7 @@ locals {
     name        = local.name
     chart       = local.name
     repository  = "https://cert-manager.github.io/aws-privateca-issuer"
-    version     = "0.1.2"
+    version     = "1.2.2"
     namespace   = local.name
     description = "AWS PCA Issuer helm Chart deployment configuration."
     values      = local.default_helm_values

--- a/modules/kubernetes-addons/cert-manager/locals.tf
+++ b/modules/kubernetes-addons/cert-manager/locals.tf
@@ -6,7 +6,7 @@ locals {
     name        = local.name
     chart       = local.name
     repository  = "https://charts.jetstack.io"
-    version     = "v1.7.1"
+    version     = "v1.8.0"
     namespace   = local.name
     description = "Cert Manager Add-on"
     values      = local.default_helm_values

--- a/modules/kubernetes-addons/cluster-autoscaler/locals.tf
+++ b/modules/kubernetes-addons/cluster-autoscaler/locals.tf
@@ -6,7 +6,7 @@ locals {
     name        = local.name
     chart       = local.name
     repository  = "https://kubernetes.github.io/autoscaler"
-    version     = "9.15.0"
+    version     = "9.19.1"
     namespace   = "kube-system"
     description = "Cluster AutoScaler helm Chart deployment configuration."
     values      = local.default_helm_values

--- a/modules/kubernetes-addons/crossplane/locals.tf
+++ b/modules/kubernetes-addons/crossplane/locals.tf
@@ -5,7 +5,7 @@ locals {
     name        = "crossplane"
     chart       = "crossplane"
     repository  = "https://charts.crossplane.io/stable/"
-    version     = "1.6.3"
+    version     = "1.8.1"
     namespace   = local.namespace
     description = "Crossplane Helm chart"
     values      = local.default_helm_values

--- a/modules/kubernetes-addons/external-dns/locals.tf
+++ b/modules/kubernetes-addons/external-dns/locals.tf
@@ -8,7 +8,7 @@ locals {
     name        = local.name
     chart       = local.name
     repository  = "https://charts.bitnami.com/bitnami"
-    version     = "6.1.6"
+    version     = "6.5.6"
     namespace   = local.name
     values      = local.default_helm_values
   }

--- a/modules/kubernetes-addons/ingress-nginx/locals.tf
+++ b/modules/kubernetes-addons/ingress-nginx/locals.tf
@@ -5,7 +5,7 @@ locals {
     name             = local.name
     chart            = local.name
     repository       = "https://kubernetes.github.io/ingress-nginx"
-    version          = "4.0.17"
+    version          = "4.1.4"
     namespace        = local.name
     create_namespace = false
     values           = local.default_helm_values

--- a/modules/kubernetes-addons/karpenter/locals.tf
+++ b/modules/kubernetes-addons/karpenter/locals.tf
@@ -17,7 +17,7 @@ locals {
     name        = local.name
     chart       = local.name
     repository  = "https://charts.karpenter.sh"
-    version     = "0.6.5"
+    version     = "0.11.0"
     namespace   = local.name
     timeout     = "300"
     values      = local.default_helm_values

--- a/modules/kubernetes-addons/keda/locals.tf
+++ b/modules/kubernetes-addons/keda/locals.tf
@@ -5,7 +5,7 @@ locals {
     name        = local.name
     chart       = local.name
     repository  = "https://kedacore.github.io/charts"
-    version     = "2.6.2"
+    version     = "2.7.2"
     namespace   = local.name
     description = "Keda Event-based autoscaler for workloads on Kubernetes"
     values      = local.default_helm_values

--- a/modules/kubernetes-addons/kubernetes-dashboard/locals.tf
+++ b/modules/kubernetes-addons/kubernetes-dashboard/locals.tf
@@ -5,7 +5,7 @@ locals {
     name        = local.name
     chart       = local.name
     repository  = "https://kubernetes.github.io/dashboard/"
-    version     = "5.4.1"
+    version     = "5.7.0"
     namespace   = local.name
     description = "Kubernetes Dashboard Helm Chart"
     values      = []

--- a/modules/kubernetes-addons/metrics-server/locals.tf
+++ b/modules/kubernetes-addons/metrics-server/locals.tf
@@ -5,7 +5,7 @@ locals {
     name        = local.name
     chart       = local.name
     repository  = "https://kubernetes-sigs.github.io/metrics-server/"
-    version     = "3.8.1"
+    version     = "3.8.2"
     namespace   = "kube-system"
     description = "Metric server helm Chart deployment configuration"
     values      = []

--- a/modules/kubernetes-addons/opentelemetry-operator/locals.tf
+++ b/modules/kubernetes-addons/opentelemetry-operator/locals.tf
@@ -3,7 +3,7 @@ locals {
     name        = "opentelemetry"
     repository  = "https://open-telemetry.github.io/opentelemetry-helm-charts"
     chart       = "opentelemetry-operator"
-    version     = "0.6.6"
+    version     = "0.7.0"
     namespace   = "opentelemetry-operator-system"
     timeout     = "1200"
     description = "ADOT Operator helm chart"

--- a/modules/kubernetes-addons/prometheus/locals.tf
+++ b/modules/kubernetes-addons/prometheus/locals.tf
@@ -4,7 +4,7 @@ locals {
     name        = local.name
     chart       = local.name
     repository  = "https://prometheus-community.github.io/helm-charts"
-    version     = "15.3.0"
+    version     = "15.10.1"
     namespace   = local.name
     timeout     = "1200"
     description = "Prometheus helm Chart deployment configuration"

--- a/modules/kubernetes-addons/spark-k8s-operator/locals.tf
+++ b/modules/kubernetes-addons/spark-k8s-operator/locals.tf
@@ -5,7 +5,7 @@ locals {
     name        = local.name
     chart       = local.name
     repository  = "https://googlecloudplatform.github.io/spark-on-k8s-operator"
-    version     = "1.1.19"
+    version     = "1.1.25"
     namespace   = local.name
     description = "The spark_k8s_operator HelmChart Ingress Controller deployment configuration"
     values      = null

--- a/modules/kubernetes-addons/traefik/locals.tf
+++ b/modules/kubernetes-addons/traefik/locals.tf
@@ -5,7 +5,7 @@ locals {
     name        = local.name
     chart       = local.name
     repository  = "https://helm.traefik.io/traefik"
-    version     = "10.14.1"
+    version     = "10.20.1"
     namespace   = local.name
     description = "The Traefik Helm Chart is focused on Traefik deployment configuration"
     values      = local.default_helm_values

--- a/modules/kubernetes-addons/vpa/locals.tf
+++ b/modules/kubernetes-addons/vpa/locals.tf
@@ -5,7 +5,7 @@ locals {
     name        = local.name
     chart       = local.name
     repository  = "https://charts.fairwinds.com/stable"
-    version     = "1.0.0"
+    version     = "1.4.0"
     namespace   = local.name
     description = "Kubernetes Vertical Pod Autoscaler"
     values      = local.default_helm_values

--- a/modules/kubernetes-addons/yunikorn/locals.tf
+++ b/modules/kubernetes-addons/yunikorn/locals.tf
@@ -4,7 +4,7 @@ locals {
     name        = local.name
     chart       = local.name
     repository  = "https://apache.github.io/yunikorn-release"
-    version     = "0.12.2"
+    version     = "1.0.0"
     namespace   = local.name
     description = "Apache YuniKorn (Incubating) is a light-weight, universal resource scheduler for container orchestrator systems"
     values      = local.default_helm_values


### PR DESCRIPTION
### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
- Update all addons to latest released version 
- Update all examples cluster_version to 1.22
- Add helm provider to self-manged node example

### Motivation

<!-- What inspired you to submit this pull request? -->
- This industry moves fast. Addons contributors fixing bugs, adding features, resolving security concerns and more! we need to keep things updated.
- Support EKS version 1.22 for EKS Blueprints
  - NOTE: this PR does not cover migration from 1.21 to 1.22, this is focused on testing and validating creation of clusters versions 1.22 and deploying addons using the latest version across all current examples ( see below "For Moderators" for link).
- self-managed node group is failing today due to helm provider config missing, preventing from issues such as:
```
Error: Kubernetes cluster unreachable: invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable

```
### More

- [X] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
   - Sanity testing by leveraging E2E action workflow, creating examples and leaving clusters up, then manually checking each individual cluster events, nodes and overall pods restarts.
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [X] E2E Test successfully complete before merge? - https://github.com/aws-ia/terraform-aws-eks-blueprints/actions/runs/2513475993 

### Additional Notes

<!-- Anything else we should know when reviewing? -->
- This PR focused around cluster creation using version 1.22 with latest addons versions, this does not cover upgrade from 1.21 to 1.22.