### PR TITLE
docs: adding workshop link

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -16,6 +16,12 @@ You can use EKS Blueprints to easily bootstrap an EKS cluster with Amazon EKS ad
 
 To view a library of examples for how you can leverage `terraform-aws-eks-blueprints`, please see our [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples).
 
+## Workshop
+We maintain a hands-on self-paced workshop, the [EKS Blueprints for Terraform workshop](https://catalog.workshops.aws/eks-blueprints-terraform/en-US) helps you with foundational setup of your EKS cluster, and it gradually adds complexity via existing and new modules.
+
+![EKS Blueprints for Terraform](https://static.us-east-1.prod.workshops.aws/public/6ad9b13b-df6a-4609-a586-fd2b7f25863c/static/eks_cluster_1.svg)
+
+
 ## Motivation
 
 Kubernetes is a powerful and extensible container orchestration technology that allows you to deploy and manage containerized applications at scale. The extensible nature of Kubernetes also allows you to use a wide range of popular open-source tools, commonly referred to as add-ons, in Kubernetes clusters. With such a large number of tooling and design choices available however, building a tailored EKS cluster that meets your application’s specific needs can take a significant amount of time. It involves integrating a wide range of open-source tools and AWS services and requires deep expertise in AWS and Kubernetes.


### PR DESCRIPTION
Finally adding the official workshop link.


### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->


### Motivation

<!-- What inspired you to submit this pull request? -->


### More

- [ ] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
