### PR TITLE
fix: Remove remaining `depends_on` from examples to avoid upgrade disruptions

### DIFF
--- a/examples/eks-cluster-with-external-dns/main.tf
+++ b/examples/eks-cluster-with-external-dns/main.tf
@@ -108,11 +108,6 @@ module "eks_blueprints_kubernetes_addons" {
   enable_external_dns                 = true
 
   tags = local.tags
-
-  depends_on = [
-    module.vpc,
-    module.eks_blueprints.managed_node_groups
-  ]
 }
 
 #---------------------------------------------------------------

--- a/examples/karpenter/main.tf
+++ b/examples/karpenter/main.tf
@@ -114,8 +114,6 @@ module "eks_blueprints_kubernetes_addons" {
   enable_aws_node_termination_handler = true
 
   tags = local.tags
-
-  depends_on = [module.eks_blueprints.self_managed_node_groups]
 }
 
 # Creates Launch templates for Karpenter

--- a/examples/observability/amp-amg-opensearch/main.tf
+++ b/examples/observability/amp-amg-opensearch/main.tf
@@ -108,11 +108,6 @@ module "eks_blueprints_kubernetes_addons" {
   amazon_prometheus_workspace_endpoint = module.eks_blueprints.amazon_prometheus_workspace_endpoint
 
   tags = local.tags
-
-  depends_on = [
-    module.eks_blueprints.managed_node_groups,
-    module.vpc
-  ]
 }
 
 #---------------------------------------------------------------


### PR DESCRIPTION
### What does this PR do?
- Remove remaining `depends_on` from addon definitions in examples to avoid upgrade disruptions

### Motivation
- Closes #559 (in conjunction with the other PRs attached to that issue, this just removes the last few `depends_on` blocks)

### More

- [ ] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
