### PR TITLE
fix: Replace hardcoded IAM policy ARN partitions with data source partition for non-commercial regions

### DIFF
--- a/modules/kubernetes-addons/adot-collector-haproxy/locals.tf
+++ b/modules/kubernetes-addons/adot-collector-haproxy/locals.tf
@@ -55,6 +55,6 @@ locals {
     create_kubernetes_namespace       = false
     kubernetes_service_account        = local.adot_collector_service_account
     create_kubernetes_service_account = true
-    irsa_iam_policies                 = ["arn:aws:iam::aws:policy/AmazonPrometheusRemoteWriteAccess"]
+    irsa_iam_policies                 = ["arn:${var.addon_context.aws_partition_id}:iam::aws:policy/AmazonPrometheusRemoteWriteAccess"]
   }
 }

--- a/modules/kubernetes-addons/adot-collector-java/locals.tf
+++ b/modules/kubernetes-addons/adot-collector-java/locals.tf
@@ -55,6 +55,6 @@ locals {
     create_kubernetes_namespace       = false
     kubernetes_service_account        = local.adot_collector_service_account
     create_kubernetes_service_account = true
-    irsa_iam_policies                 = ["arn:aws:iam::aws:policy/AmazonPrometheusRemoteWriteAccess"]
+    irsa_iam_policies                 = ["arn:${var.addon_context.aws_partition_id}:iam::aws:policy/AmazonPrometheusRemoteWriteAccess"]
   }
 }

--- a/modules/kubernetes-addons/adot-collector-memcached/locals.tf
+++ b/modules/kubernetes-addons/adot-collector-memcached/locals.tf
@@ -55,6 +55,6 @@ locals {
     create_kubernetes_namespace       = false
     kubernetes_service_account        = local.adot_collector_service_account
     create_kubernetes_service_account = true
-    irsa_iam_policies                 = ["arn:aws:iam::aws:policy/AmazonPrometheusRemoteWriteAccess"]
+    irsa_iam_policies                 = ["arn:${var.addon_context.aws_partition_id}:iam::aws:policy/AmazonPrometheusRemoteWriteAccess"]
   }
 }

--- a/modules/kubernetes-addons/adot-collector-nginx/locals.tf
+++ b/modules/kubernetes-addons/adot-collector-nginx/locals.tf
@@ -55,6 +55,6 @@ locals {
     create_kubernetes_namespace       = false
     kubernetes_service_account        = local.adot_collector_service_account
     create_kubernetes_service_account = true
-    irsa_iam_policies                 = ["arn:aws:iam::aws:policy/AmazonPrometheusRemoteWriteAccess"]
+    irsa_iam_policies                 = ["arn:${var.addon_context.aws_partition_id}:iam::aws:policy/AmazonPrometheusRemoteWriteAccess"]
   }
 }

--- a/modules/kubernetes-addons/cert-manager/data.tf
+++ b/modules/kubernetes-addons/cert-manager/data.tf
@@ -7,7 +7,7 @@ data "aws_route53_zone" "selected" {
 data "aws_iam_policy_document" "cert_manager_iam_policy_document" {
   statement {
     effect    = "Allow"
-    resources = ["arn:aws:route53:::change/*"]
+    resources = ["arn:${var.addon_context.aws_partition_id}:route53:::change/*"]
     actions   = ["route53:GetChange"]
   }
 


### PR DESCRIPTION
### What does this PR do?
- Replace hardcoded IAM policy ARN partitions with data source partition for non-commercial regions=

### Motivation
- Relates to #582 - this PR removes the remaining hardcoded partition values, but the issue in #582 is actually due to using an older version of blueprints that doesn't contain the fixes

### More

- [ ] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
