### PR TITLE
[teams module] add team_sa_irsa_iam_role to output

### DIFF
--- a/modules/aws-eks-teams/README.md
+++ b/modules/aws-eks-teams/README.md
@@ -176,5 +176,6 @@ No modules.
 | <a name="output_application_teams_iam_role_arn"></a> [application\_teams\_iam\_role\_arn](#output\_application\_teams\_iam\_role\_arn) | IAM role ARN for Teams |
 | <a name="output_platform_teams_configure_kubectl"></a> [platform\_teams\_configure\_kubectl](#output\_platform\_teams\_configure\_kubectl) | Configure kubectl for each Platform Team: make sure you're logged in with the correct AWS profile and run the following command to update your kubeconfig |
 | <a name="output_platform_teams_iam_role_arn"></a> [platform\_teams\_iam\_role\_arn](#output\_platform\_teams\_iam\_role\_arn) | IAM role ARN for Platform Teams |
+| <a name="output_team_sa_irsa_iam_role"></a> [team\_sa\_irsa\_iam\_role](#output\_team\_sa\_irsa\_iam\_role) | IAM role name for Teams EKS Service Account (IRSA) |
 | <a name="output_team_sa_irsa_iam_role_arn"></a> [team\_sa\_irsa\_iam\_role\_arn](#output\_team\_sa\_irsa\_iam\_role\_arn) | IAM role ARN for Teams EKS Service Account (IRSA) |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/aws-eks-teams/outputs.tf
+++ b/modules/aws-eks-teams/outputs.tf
@@ -12,6 +12,13 @@ output "application_teams_iam_role_arn" {
   })
 }
 
+output "team_sa_irsa_iam_role" {
+  description = "IAM role name for Teams EKS Service Account (IRSA)"
+  value = tomap({
+    for k, v in aws_iam_role.team_sa_irsa : k => v.name
+  })
+}
+
 output "team_sa_irsa_iam_role_arn" {
   description = "IAM role ARN for Teams EKS Service Account (IRSA)"
   value = tomap({


### PR DESCRIPTION
### What does this PR do?
When I create policy and attach it to role,

We need role name like below.
```
resource "aws_iam_role_policy_attachment" "test-attach" {
  role       = aws_iam_role.role.name
  policy_arn = aws_iam_policy.policy.arn
}
```

### Motivation


### More

- [x] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [x] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [x] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [x] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
