### PR TITLE
docs: Fix link for Velero add-on on navbar

### DIFF
--- a/docs/add-ons/velero.md
+++ b/docs/add-ons/velero.md
@@ -1,6 +1,6 @@
-# [Velero](https://velero.io/)
+# Velero
 
-Velero is an open source tool to safely backup and restore, perform disaster recovery, and migrate Kubernetes cluster resources and persistent volumes.
+[Velero](https://velero.io/) is an open source tool to safely backup and restore, perform disaster recovery, and migrate Kubernetes cluster resources and persistent volumes.
 
 - [Helm chart](https://github.com/vmware-tanzu/helm-charts/tree/main/charts/velero)
 - [Plugin for AWS](https://github.com/vmware-tanzu/velero-plugin-for-aws)


### PR DESCRIPTION
### What does this PR do?

Fix the link for Velero on the add-ons documentation's section.


### Motivation

<!-- What inspired you to submit this pull request? -->


### More

- [ ] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [X] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
