### PR TITLE
fix: Re-add labels for managed node groups

### DIFF
--- a/modules/aws-eks-managed-node-groups/main.tf
+++ b/modules/aws-eks-managed-node-groups/main.tf
@@ -62,6 +62,8 @@ resource "aws_eks_node_group" "managed_ng" {
     }
   }
 
+  labels = local.managed_node_group["k8s_labels"]
+
   tags = local.common_tags
 
   dynamic "timeouts" {


### PR DESCRIPTION
### What does this PR do?
- Re-add labels for managed node groups

### Motivation
- Re-adds labels that were inadvertently removed in https://github.com/aws-ia/terraform-aws-eks-blueprints/pull/484/files#diff-a7a8838394fad05655d13cefd255e1add3a2eab122c3092163c8271bd7d3fda9L65 
- Closes #652

### More

- [ ] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
