### PR TITLE
fix: e2e multiple TF apply in order using "-target"

### DIFF
--- a/.github/workflows/e2e-parallel-full.yml
+++ b/.github/workflows/e2e-parallel-full.yml
@@ -67,6 +67,9 @@ jobs:
         working-directory: ${{ matrix.example_path }}
         run: |
           terraform init -upgrade=true
+          terraform apply -target=module.vpc -no-color -input=false -auto-approve
+          terraform apply -target=module.eks_blueprints -no-color -input=false -auto-approve
+          terraform apply -target=module.eks_blueprints_kubernetes_addons -no-color -input=false -auto-approve
           terraform apply -no-color -input=false -auto-approve
 
       - name: Terraform Destroy


### PR DESCRIPTION
### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
- Adjust e2e parallel to  use multiple TF apply in order by modules (vpc->blueprints->addons) using -target

### Motivation
- While working on https://github.com/aws-ia/terraform-aws-eks-blueprints/pull/634 and running the e2e parallel multiple times, we [identified failures](https://github.com/aws-ia/terraform-aws-eks-blueprints/pull/634#issuecomment-1158489670) where addons are timing out as the addons were created in parallel when worker nodes were created, and worker nodes might take up to 10 minutes (or more) to be properly created, leading to helm/addons timeouts error messages.
Targeting and deploying modules in order should prevent from this issue to happen as addons will not be created in parallel with the workers nodes, but only after worker nodes have been deployed successfully.

To keep things simple, I did not return the option of custom deployment order as it doesn't seem to be needed, but, incase it will be needed in the future you can copy+paste and tweak from [here](https://github.com/aws-ia/terraform-aws-eks-blueprints/commit/4757dd4262db9ce2c4743aebb8bfb5486e29b6a4#diff-3432691ea1a56fa1e615c1831f2dc029b3069f781183e75f4ac0db71a34abad3L92-L103)

<!-- What inspired you to submit this pull request? -->


### More

- [ ] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
