### PR TITLE
fix: adot operator & java example

### DIFF
--- a/examples/observability/adot-amp-grafana-for-java/main.tf
+++ b/examples/observability/adot-amp-grafana-for-java/main.tf
@@ -88,7 +88,7 @@ module "eks_blueprints_kubernetes_addons" {
   # or enable a customer-managed OpenTelemetry operator
   # enable_opentelemetry_operator = true
 
-  enable_adot_collector_java           = false
+  enable_adot_collector_java           = true
   amazon_prometheus_workspace_endpoint = module.eks_blueprints.amazon_prometheus_workspace_endpoint
   amazon_prometheus_workspace_region   = local.region
 

--- a/modules/kubernetes-addons/opentelemetry-operator/main.tf
+++ b/modules/kubernetes-addons/opentelemetry-operator/main.tf
@@ -1,5 +1,9 @@
 module "cert_manager" {
-  source        = "../cert-manager"
+  source = "../cert-manager"
+
+  # https://docs.aws.amazon.com/eks/latest/userguide/adot-reqts.html
+  # certmanaager v1.6.0 onwards is not supported yet
+  helm_config   = { version = "v1.5.0" }
   addon_context = var.addon_context
 }
 


### PR DESCRIPTION
### What does this PR do?

ADOT Managed Add-on only supports `cert-manager` up to 1.5, this PR addresses that issue.
Also enables the java operator to be deployed by default 

### More

- [ ] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
