### PR TITLE
Add missing nth queueurl

### DIFF
--- a/modules/kubernetes-addons/aws-node-termination-handler/locals.tf
+++ b/modules/kubernetes-addons/aws-node-termination-handler/locals.tf
@@ -32,6 +32,9 @@ locals {
     {
       name  = "serviceAccount.create"
       value = false
+    },
+    { name  = "queueURL"
+      value = aws_sqs_queue.aws_node_termination_handler_queue.url
     }
   ]
 


### PR DESCRIPTION
### What does this PR do?

Adds in the missing queueURL helm value that will allow this to work properly since it is set in queue mode.


### Motivation

Comments from [rt-outofservice](https://github.com/rt-outofservice), [here](https://github.com/aws-ia/terraform-aws-eks-blueprints/pull/593#issuecomment-1146376611) and [here](https://github.com/aws-ia/terraform-aws-eks-blueprints/pull/593#issuecomment-1146401476) showing oversights in my prior PR #593.  Unfortunately it was merged and I forgot to go back and add the queueURL update.


### More

- [X] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
