### PR TITLE
fix: terratest expected worker nodes to 2

### DIFF
--- a/test/src/eks_blueprints_e2e_test.go
+++ b/test/src/eks_blueprints_e2e_test.go
@@ -57,7 +57,7 @@ var (
 	}
 
 	/*EKS API Validation*/
-	expectedEKSWorkerNodes = 3
+	expectedEKSWorkerNodes = 2
 
 	/*Update the expected Deployments names and the namespace*/
 	expectedDeployments = [...]Deployment{


### PR DESCRIPTION
### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
- Setting expected worker nodes to 2 in terratest.

### Motivation
- Terratest currently failing because of that.
[Example](https://github.com/aws-ia/terraform-aws-eks-blueprints/runs/6989483103?check_suite_focus=true) 
```
=== RUN   TestEksBlueprintsE2E/EKS_ADDON_VALIDATION/MATCH_TOTAL_EKS_WORKER_NODES
    eks_blueprints_e2e_test.go:253: 
        	Error Trace:	eks_blueprints_e2e_test.go:253
        	Error:      	Not equal: 
        	            	expected: 3
        	            	actual  : 2
        	Test:       	TestEksBlueprintsE2E/EKS_ADDON_VALIDATION/MATCH_TOTAL_EKS_WORKER_NODES
```
<!-- What inspired you to submit this pull request? -->


### More

- [ ] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
