### PR TITLE
feat: Update karpenter permissions for making more accurate decisions regarding spot deployments

### DIFF
--- a/modules/kubernetes-addons/karpenter/data.tf
+++ b/modules/kubernetes-addons/karpenter/data.tf
@@ -5,20 +5,22 @@ data "aws_iam_policy_document" "karpenter" {
     resources = ["*"]
 
     actions = [
-      "ec2:CreateLaunchTemplate",
       "ec2:CreateFleet",
-      "ec2:RunInstances",
+      "ec2:CreateLaunchTemplate",
       "ec2:CreateTags",
-      "iam:PassRole",
       "ec2:DeleteLaunchTemplate",
-      "ec2:DescribeLaunchTemplates",
-      "ec2:DescribeInstances",
-      "ec2:DescribeSecurityGroups",
-      "ec2:DescribeSubnets",
-      "ec2:DescribeInstanceTypes",
-      "ec2:DescribeInstanceTypeOfferings",
       "ec2:DescribeAvailabilityZones",
-      "ssm:GetParameter"
+      "ec2:DescribeInstances",
+      "ec2:DescribeInstanceTypeOfferings",
+      "ec2:DescribeInstanceTypes",
+      "ec2:DescribeLaunchTemplates",
+      "ec2:DescribeSecurityGroups",
+      "ec2:DescribeSpotPriceHistory",
+      "ec2:DescribeSubnets",
+      "ec2:RunInstances",
+      "iam:PassRole",
+      "pricing:GetProducts",
+      "ssm:GetParameter",
     ]
   }
 


### PR DESCRIPTION
Signed-off-by: Fernando Miguel <github@FernandoMiguel.net>


### What does this PR do?

adds two extra IAM permissions to karpenter

### Motivation

Two new IAM permissions will be required on the next karpenter release
https://github.com/aws/karpenter/pull/1994/files
https://github.com/aws/karpenter/pull/1994/files

### More

- [ ] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?
