### PR TITLE
fix: enable cluster log types upstream example

### DIFF
--- a/examples/upstream-with-k8s-addons/main.tf
+++ b/examples/upstream-with-k8s-addons/main.tf
@@ -58,6 +58,8 @@ module "eks" {
   vpc_id     = module.vpc.vpc_id
   subnet_ids = module.vpc.private_subnets
 
+  enabled_cluster_log_types = ["api", "audit", "authenticator", "controllerManager", "scheduler"]
+
   eks_managed_node_group_defaults = {
     instance_types        = ["m6i.large", "m5.large", "m5n.large", "m5zn.large"]
     create_security_group = false

--- a/examples/upstream-with-k8s-addons/main.tf
+++ b/examples/upstream-with-k8s-addons/main.tf
@@ -58,7 +58,7 @@ module "eks" {
   vpc_id     = module.vpc.vpc_id
   subnet_ids = module.vpc.private_subnets
 
-  enabled_cluster_log_types = ["api", "audit", "authenticator", "controllerManager", "scheduler"]
+  cluster_enabled_log_types = ["api", "audit", "authenticator", "controllerManager", "scheduler"]
 
   eks_managed_node_group_defaults = {
     instance_types        = ["m6i.large", "m5.large", "m5n.large", "m5zn.large"]


### PR DESCRIPTION
### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
- Enabling control plane logs for upstream example

### Motivation

<!-- What inspired you to submit this pull request? -->
- tfsec check failing due to control plane logs not enabled - https://github.com/aws-ia/terraform-aws-eks-blueprints/runs/7099360400?check_suite_focus=true

### More

- [ ] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
