### PR TITLE
Update plan-examples.py to skip full-private

### DIFF
--- a/.github/workflows/plan-examples.py
+++ b/.github/workflows/plan-examples.py
@@ -11,6 +11,7 @@ def get_examples():
     exclude = {
         'examples/eks-cluster-with-external-dns',  # excluded until Rout53 is setup
         'examples/ci-cd/gitlab-ci-cd',  # excluded since GitLab auth, backend, etc. required
+        'examples/fully-private-eks-cluster' # excluded until part-2 of the enhancement is done (needs refactoring)
     }
 
     projects = {


### PR DESCRIPTION
### What does this PR do?

Skips the full-private-eks-cluster example. This is a temporary change which will be reverted once the example is refactored.


### Motivation

<!-- What inspired you to submit this pull request? -->


### More

- [ ] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
