### PR TITLE
Fixed arm instances in the nodegroup documentation

### DIFF
--- a/docs/node-groups.md
+++ b/docs/node-groups.md
@@ -196,7 +196,7 @@ The below example demonstrates advanced configuration options using GPU instance
     #---------------------------------------------------------#
     arm = {
       # 1> Node Group configuration - Part1
-      node_group_name        = "arm-mg5"         # Max 40 characters for node group name
+      node_group_name        = "arm-m6g-2vcpu-8gb"         # Max 40 characters for node group name
       create_launch_template = true              # false will use the default launch template
       launch_template_os     = "amazonlinux2eks" # amazonlinux2eks or bottlerocket
       public_ip              = false             # Use this to enable public IP for EC2 instances; only for public subnets used in launch templates ;
@@ -213,7 +213,7 @@ The below example demonstrates advanced configuration options using GPU instance
       # 3> Node Group compute configuration
       ami_type       = "AL2_ARM_64" # AL2_x86_64, AL2_x86_64_GPU, AL2_ARM_64, CUSTOM, BOTTLEROCKET_ARM_64, BOTTLEROCKET_x86_64
       capacity_type  = "ON_DEMAND"  # ON_DEMAND or SPOT
-      instance_types = ["m5.large"] # List of instances to get capacity from multipe pools
+      instance_types = ["m6g.large"] # List of instances to get capacity from multipe pools
       block_device_mappings = [
         {
           device_name = "/dev/xvda"
@@ -232,8 +232,8 @@ The below example demonstrates advanced configuration options using GPU instance
         WorkerType  = "ON_DEMAND"
       }
       additional_tags = {
-        ExtraTag    = "m5x-on-demand"
-        Name        = "m5x-on-demand"
+        ExtraTag    = "m6g-on-demand"
+        Name        = "m6g-on-demand"
         subnet_type = "private"
       }
     }
@@ -257,7 +257,7 @@ The below example demonstrates advanced configuration options using GPU instance
       # 3> Node Group compute configuration
       ami_type       = "BOTTLEROCKET_ARM_64" # AL2_x86_64, AL2_x86_64_GPU, AL2_ARM_64, CUSTOM, BOTTLEROCKET_ARM_64, BOTTLEROCKET_x86_64
       capacity_type  = "ON_DEMAND"           # ON_DEMAND or SPOT
-      instance_types = ["m5.large"]          # List of instances to get capacity from multipe pools
+      instance_types = ["m6g.large"]          # List of instances to get capacity from multipe pools
       disk_size      = 50
 
       # 4> Node Group network configuration
@@ -271,8 +271,8 @@ The below example demonstrates advanced configuration options using GPU instance
         WorkerType  = "ON_DEMAND"
       }
       additional_tags = {
-        ExtraTag    = "m5x-on-demand"
-        Name        = "m5x-on-demand"
+        ExtraTag    = "m6g-on-demand"
+        Name        = "m6g-on-demand"
         subnet_type = "private"
       }
     }


### PR DESCRIPTION
### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->

The nodegroup documentation makes reference to ARM nodegroups. The configuration of the instances however was selecting m5.large instances instead of ARM/Graviton m6g.instances. This change just amends the configuration. In a future change I'll be happy to add a few graviton examples to the nodegroup configurations.

### Motivation

<!-- What inspired you to submit this pull request? -->

While reading the configuration for nodes setup, there was a clear mistake in the selection of Graviton instances; Both examples were listing x86_64 rather than.

### More

- [ ] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [x ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->

Note: in this PR There is nothing to test at this stage; There was a mistake in the nodegroup documentation selection of ARM instances. Happy to add in a different PR a Graviton example in the nodegroup section.


While running 'terraform validate' passes the validation with success, when running pre-commit run -a , the validate phase gets stuck and after a long pause it fails as if the terraform init was not executed.

