### PR TITLE
Fix pod to pod communication between different nodes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,10 +35,12 @@ terraform.rc
 
 # Locals
 kubeconfig*
+kube-config*
 local_tf_state/
 .vscode
 .gitallowed
 site
+.env*
 
 # Checks
 .tfsec

--- a/examples/karpenter/README.md
+++ b/examples/karpenter/README.md
@@ -6,9 +6,10 @@ This example shows how to deploy and leverage Karpenter for Autoscaling. The fol
 
 - Creates a new VPC, 3 Private Subnets and 3 Public Subnets
 - Creates Internet gateway for Public Subnets and NAT Gateway for Private Subnets
-- Creates EKS Cluster Control plane with one Self-managed node group with Max ASG of 1
+- Creates EKS Cluster Control plane with one Managed node group with Max ASG of 1
 - Deploys Karpenter Helm Chart
-- Deploys default Karpenter Provisioner
+- Deploys default Karpenter Provisioner (with dedicated node labels ant taint)
+- Deploys default-lt Karpenter Provisioner using Launch Template (with dedicated node labels ant taint)
 
 # How to Deploy
 
@@ -69,7 +70,7 @@ EKS Cluster details can be extracted from terraform output or from AWS Console t
 
 #### Step 6: List all the worker nodes by running the command below
 
-You should see one Self-managed node up and running
+You should see one managed node up and running
 
     $ kubectl get nodes
 
@@ -79,8 +80,44 @@ You should see one Self-managed node up and running
 
     # Output should look like below
       NAME                                    READY   STATUS    RESTARTS   AGE
-      karpenter-controller-5f959cdc44-8dmjb   1/1     Running   0          31m
-      karpenter-webhook-65f48f8d49-5hkpb      1/1     Running   0          31m
+      karpenter-68f999967f-m4t4n  1/1     Running   0          31m
+
+#### Step 8: List all karpenter provisioners deployed
+
+    $  kubectl get provisioners
+
+    # Output should look like below
+    NAME         AGE
+    default      88s
+    default-lt   90s
+
+#### Step 8: Deploy workload on Karpenter provisioners
+
+Terraform has configured 2 provisioners : `default` and `default-lt` and we have 2 deployment examples, to be deployed using thoses provisioners.
+
+Deploy workload on `default` provisioner:
+
+    $ kubectl apply -f provisioners/sample_deployment.yaml
+
+
+Deploy workload on `default-lt` provisioner:
+
+    $ kubectl apply -f provisioners/sample_deployment_lt.yaml
+
+After few times you should see 2 new nodes (one created by each provisioner)
+
+    $ kubectl get node -L karpenter.sh/provisioner-name
+
+    # Output should look like below
+    NAME                                        STATUS   ROLES    AGE     VERSION               PROVISIONER-NAME
+    ip-10-0-10-14.us-west-2.compute.internal    Ready    <none>   11m     v1.22.9-eks-810597c   default
+    ip-10-0-11-16.us-west-2.compute.internal    Ready    <none>   70m     v1.22.9-eks-810597c   
+    ip-10-0-12-138.us-west-2.compute.internal   Ready    <none>   4m57s   v1.22.9-eks-810597c   default-lt
+
+We now have :
+- 1 Managed node group instance
+- 1 instance from the default provisioner
+- 1 instance from the default-lt provisioner
 
 # How to Destroy
 

--- a/examples/karpenter/main.tf
+++ b/examples/karpenter/main.tf
@@ -48,7 +48,7 @@ locals {
   name   = basename(path.cwd)
   region = "us-west-2"
 
-  node_group_name = "self-ondemand"
+  node_group_name = "managed-ondemand"
 
   vpc_cidr = "10.0.0.0/16"
   azs      = slice(data.aws_availability_zones.available.names, 0, 3)
@@ -71,7 +71,36 @@ module "eks_blueprints" {
   vpc_id             = module.vpc.vpc_id
   private_subnet_ids = module.vpc.private_subnets
 
+  #----------------------------------------------------------------------------------------------------------#
+  # Security groups used in this module created by the upstream modules terraform-aws-eks (https://github.com/terraform-aws-modules/terraform-aws-eks).
+  #   Upstream module implemented Security groups based on the best practices doc https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html.
+  #   So, by default the security groups are restrictive. Users needs to enable rules for specific ports required for App requirement or Add-ons
+  #   See the notes below for each rule used in these examples
+  #----------------------------------------------------------------------------------------------------------#
   node_security_group_additional_rules = {
+    # Extend node-to-node security group rules. Recommended and required for the Add-ons
+    ingress_self_all = {
+      description = "Node to node all ports/protocols"
+      protocol    = "-1"
+      from_port   = 0
+      to_port     = 0
+      type        = "ingress"
+      self        = true
+    }
+    # Recommended outbound traffic for Node groups
+    egress_all = {
+      description      = "Node all egress"
+      protocol         = "-1"
+      from_port        = 0
+      to_port          = 0
+      type             = "egress"
+      cidr_blocks      = ["0.0.0.0/0"]
+      ipv6_cidr_blocks = ["::/0"]
+    }
+
+    # Allows Control Plane Nodes to talk to Worker nodes on Karpenter ports.
+    # This can be extended further to specific port based on the requirement for others Add-on e.g., metrics-server 4443, spark-operator 8080, etc.
+    # Change this according to your security requirements if needed
     ingress_nodes_karpenter_port = {
       description                   = "Cluster API to Nodegroup for Karpenter"
       protocol                      = "tcp"
@@ -87,14 +116,26 @@ module "eks_blueprints" {
     "karpenter.sh/discovery/${local.name}" = local.name
   }
 
-  # Self-managed Node Group
-  # Karpenter requires one node to get up and running
-  self_managed_node_groups = {
-    self_mg_5 = {
-      node_group_name    = local.node_group_name
-      launch_template_os = "amazonlinux2eks"
-      max_size           = 1
-      subnet_ids         = module.vpc.private_subnets
+  # EKS MANAGED NODE GROUPS
+  # We recommend to have a MNG to place your critical workloads and add-ons
+  # Then rely on Karpenter to scale your workloads
+  # You can also make uses on nodeSelector and Taints/tolerations to spread workloads on MNG or Karpenter provisioners
+  managed_node_groups = {
+    mg_5 = {
+      node_group_name = "managed-ondemand"
+      instance_types  = ["m5.large"]
+
+      subnet_ids      = module.vpc.private_subnets
+      max_size        = 2
+      desired_size    = 1
+      min_size        = 1
+      update_config = [{
+        max_unavailable_percentage = 30
+      }]
+
+      # Launch template configuration
+      create_launch_template = true              # false will use the default launch template
+      launch_template_os     = "amazonlinux2eks" # amazonlinux2eks or bottlerocket
     }
   }
 
@@ -108,12 +149,13 @@ module "eks_blueprints_kubernetes_addons" {
   eks_cluster_endpoint     = module.eks_blueprints.eks_cluster_endpoint
   eks_oidc_provider        = module.eks_blueprints.oidc_provider
   eks_cluster_version      = module.eks_blueprints.eks_cluster_version
-  auto_scaling_group_names = module.eks_blueprints.self_managed_node_group_autoscaling_groups
 
   enable_karpenter                    = true
   enable_aws_node_termination_handler = true
 
   tags = local.tags
+
+  depends_on = [module.eks_blueprints.managed_node_group_autoscaling_groups]
 }
 
 # Creates Launch templates for Karpenter
@@ -127,7 +169,7 @@ module "karpenter_launch_templates" {
     linux = {
       ami                    = data.aws_ami.eks.id
       launch_template_prefix = "karpenter"
-      iam_instance_profile   = module.eks_blueprints.self_managed_node_group_iam_instance_profile_id[0]
+      iam_instance_profile   = module.eks_blueprints.managed_node_group_iam_instance_profile_id[0]
       vpc_security_group_ids = [module.eks_blueprints.worker_node_security_group_id]
       block_device_mappings = [
         {
@@ -142,7 +184,7 @@ module "karpenter_launch_templates" {
       ami                    = data.aws_ami.bottlerocket.id
       launch_template_os     = "bottlerocket"
       launch_template_prefix = "bottle"
-      iam_instance_profile   = module.eks_blueprints.self_managed_node_group_iam_instance_profile_id[0]
+      iam_instance_profile   = module.eks_blueprints.managed_node_group_iam_instance_profile_id[0]
       vpc_security_group_ids = [module.eks_blueprints.worker_node_security_group_id]
       block_device_mappings = [
         {
@@ -157,9 +199,9 @@ module "karpenter_launch_templates" {
   tags = merge(local.tags, { Name = "karpenter" })
 }
 
-# Deploying default provisioner for Karpenter autoscaler
+# Deploying default provisioner and default-lt (using launch template) for Karpenter autoscaler
 data "kubectl_path_documents" "karpenter_provisioners" {
-  pattern = "${path.module}/provisioners/default_provisioner.yaml"
+  pattern = "${path.module}/provisioners/default_provisioner*.yaml" # without launch template
   vars = {
     azs                     = join(",", local.azs)
     iam-instance-profile-id = "${local.name}-${local.node_group_name}"
@@ -167,11 +209,6 @@ data "kubectl_path_documents" "karpenter_provisioners" {
     eks-vpc_name            = local.name
   }
 }
-
-# You can also deploy multiple provisioner files with the below code snippet
-# data "kubectl_path_documents" "karpenter_provisioners" {
-#   pattern = "${path.module}/provisioners/*.yaml"
-# }
 
 resource "kubectl_manifest" "karpenter_provisioner" {
   for_each  = toset(data.kubectl_path_documents.karpenter_provisioners.documents)
@@ -195,6 +232,7 @@ module "vpc" {
   private_subnets = [for k, v in local.azs : cidrsubnet(local.vpc_cidr, 8, k + 10)]
 
   enable_nat_gateway   = true
+  create_igw           = true
   single_nat_gateway   = true
   enable_dns_hostnames = true
 
@@ -208,12 +246,12 @@ module "vpc" {
 
   public_subnet_tags = {
     "kubernetes.io/cluster/${local.name}" = "shared"
-    "kubernetes.io/role/elb"              = 1
+    "kubernetes.io/role/elb"              = "1"
   }
 
   private_subnet_tags = {
     "kubernetes.io/cluster/${local.name}" = "shared"
-    "kubernetes.io/role/internal-elb"     = 1
+    "kubernetes.io/role/internal-elb"     = "1"
   }
 
   tags = local.tags

--- a/examples/karpenter/provisioners/default_provisioner.yaml
+++ b/examples/karpenter/provisioners/default_provisioner.yaml
@@ -19,4 +19,11 @@ spec:
       Name: "${eks-vpc_name}-private*"
     securityGroupSelector:
       karpenter.sh/discovery/${eks-cluster-id}: '${eks-cluster-id}'
+  labels:
+    type: karpenter
+    provisioner: default
+  taints:
+    - key: default
+      value: 'true'
+      effect: NoSchedule
   ttlSecondsAfterEmpty: 120

--- a/examples/karpenter/provisioners/default_provisioner_with_launch_templates.yaml
+++ b/examples/karpenter/provisioners/default_provisioner_with_launch_templates.yaml
@@ -1,12 +1,12 @@
 apiVersion: karpenter.sh/v1alpha5
 kind: Provisioner
 metadata:
-  name: default
+  name: default-lt
 spec:
   requirements:
     - key: "topology.kubernetes.io/zone"
       operator: In
-      values: ["eu-west-1b"]                               #Update the correct region and zones
+      values: [${azs}]                               #Update the correct region and zones
     - key: "karpenter.sh/capacity-type"
       operator: In
       values: ["spot", "on-demand"]
@@ -20,9 +20,14 @@ spec:
     resources:
       cpu: 1000
   provider:
-    launchTemplate: "karpenter-aws001-preprod-dev-eks"     # Used by Karpenter Nodes
+    launchTemplate: "karpenter-${eks-cluster-id}"     # Used by Karpenter Nodes
     subnetSelector:
       Name: "${eks-vpc_name}-private*"
-    securityGroupSelector:
-      kubernetes.io/cluster/aws-dev-spark-eks: owned
+  labels:
+    type: karpenter
+    provisioner: default-lt
+  taints:
+    - key: default-lt
+      value: 'true'
+      effect: NoSchedule
   ttlSecondsAfterEmpty: 120

--- a/examples/karpenter/provisioners/gpu_provisioner.yaml
+++ b/examples/karpenter/provisioners/gpu_provisioner.yaml
@@ -6,11 +6,18 @@ spec:
   requirements:
     - key: node.kubernetes.io/instance-type
       operator: In
-      values: ["p3.8xlarge", "p3.16xlarge"]
+      values: ['p3.8xlarge', 'p3.16xlarge']
   taints:
     - key: nvidia.com/gpu
       value: true
       effect: “NoSchedule”
   provider:
-    instanceProfile: "aws001-preprod-dev-eks-self-managed-ondemand" # self-managed IAM Instance profile Name
+    instanceProfile: ${iam-instance-profile-id}
+  labels:
+    type: karpenter
+    provisioner: gpu
+  taints:
+    - key: gpu
+      value: 'true'
+      effect: NoSchedule
   ttlSecondsAfterEmpty: 60

--- a/examples/karpenter/provisioners/sample_deployment_lt.yaml
+++ b/examples/karpenter/provisioners/sample_deployment_lt.yaml
@@ -1,15 +1,16 @@
+#Same deployment app but target Karpenter createed with the launch-template provisioner
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: ecsdemo-nodejs
+  name: ecsdemo-nodejs-lt
   labels:
-    app: ecsdemo-nodejs
+    app: ecsdemo-nodejs-lt
   namespace: default
 spec:
   replicas: 3
   selector:
     matchLabels:
-      app: ecsdemo-nodejs
+      app: ecsdemo-nodejs-lt
   strategy:
     rollingUpdate:
       maxSurge: 25%
@@ -18,12 +19,12 @@ spec:
   template:
     metadata:
       labels:
-        app: ecsdemo-nodejs
+        app: ecsdemo-nodejs-lt
     spec:
       containers:
         - image: brentley/ecsdemo-nodejs:latest
           imagePullPolicy: Always
-          name: ecsdemo-nodejs
+          name: ecsdemo-nodejs-lt
           ports:
             - containerPort: 3000
               protocol: TCP
@@ -34,11 +35,11 @@ spec:
             limits:
               memory: '512Mi'
               cpu: '1024m'
-      #Deploy this app on the Karpenter nodes created by the default provisioner
+      #Deploy this app on the Karpenter nodes created by the default-lt provisioner
       nodeSelector:
-        type: karpenter
-        provisioner: default
+        type: 'karpenter'
+        provisioner: 'default-lt'
       tolerations:
-        - key: 'default'
+        - key: 'default-lt'
           operator: 'Exists'
           effect: 'NoSchedule'


### PR DESCRIPTION

### What does this PR do?

- This PR allow the Karpenter example to work as expected
- Deploy 2 karpenter provisioners default and default-lt (with launch template)
- Allow workload sample to deploy on default or default-lt
- Fix Create Internet Gateway
- Fix #623 



### Motivation

<!-- What inspired you to submit this pull request? -->


### More

- [ ] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
