### PR TITLE
Updates to the GitLab CI example.

### DIFF
--- a/examples/ci-cd/gitlab-ci-cd/.gitlab-ci.yml
+++ b/examples/ci-cd/gitlab-ci-cd/.gitlab-ci.yml
@@ -81,7 +81,7 @@ tf-plan:
     - changes:
         - "*.tf"
   script:
-    - gitlab-terraform plan 
+    - gitlab-terraform plan
     - gitlab-terraform plan-json
 
 tf-apply:

--- a/examples/ci-cd/gitlab-ci-cd/README.md
+++ b/examples/ci-cd/gitlab-ci-cd/README.md
@@ -31,7 +31,7 @@ git@github.com:aws-ia/terraform-aws-eks-blueprints.git
 
 Manually trigger the `tf-apply` to provision the resources
 
-## Step 5: Verify whether the state file update happened in your project (Infrastructure->Terraform-states). 
+## Step 5: Verify whether the state file update happened in your project (Infrastructure->Terraform-states).
 
 ## Step 6: (Optional) Manually Install, Configure and Run GitLab Agent for Kubernetes (“Agent”, for short) is your active in-cluster.
 


### PR DESCRIPTION
### What does this PR do?

This PR updates the GitLab CI workflow so it can run any example from the repository. The documentation is also updated to reflect the changes.


### Motivation

DataLab customer wanted to test provisioning an EKS cluster using EKS Blueprints and GitLab CI.


### More

- [Y ] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ NA] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ NA] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ NA Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ Y] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
