### PR TITLE
Skip fully-private-eks example tests

### DIFF
--- a/.github/workflows/e2e-parallel-destroy.yml
+++ b/.github/workflows/e2e-parallel-destroy.yml
@@ -29,7 +29,7 @@ jobs:
           - example_path: examples/crossplane
           - example_path: examples/eks-cluster-with-new-vpc
           - example_path: examples/fargate-serverless
-          # - example_path: examples/fully-private-eks-cluster # temporarily skip this example 
+          # - example_path: examples/fully-private-eks-cluster # skipping until issue #711 is addressed
           - example_path: examples/game-tech/agones-game-controller
           - example_path: examples/gitops/argocd
           # - example_path: examples/ingress-controllers/nginx # ignoring due to https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/1629

--- a/.github/workflows/e2e-parallel-destroy.yml
+++ b/.github/workflows/e2e-parallel-destroy.yml
@@ -29,7 +29,7 @@ jobs:
           - example_path: examples/crossplane
           - example_path: examples/eks-cluster-with-new-vpc
           - example_path: examples/fargate-serverless
-          - example_path: examples/fully-private-eks-cluster
+          # - example_path: examples/fully-private-eks-cluster # temporarily skip this example 
           - example_path: examples/game-tech/agones-game-controller
           - example_path: examples/gitops/argocd
           # - example_path: examples/ingress-controllers/nginx # ignoring due to https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/1629

--- a/.github/workflows/e2e-parallel-full.yml
+++ b/.github/workflows/e2e-parallel-full.yml
@@ -29,7 +29,7 @@ jobs:
           - example_path: examples/crossplane
           - example_path: examples/eks-cluster-with-new-vpc
           - example_path: examples/fargate-serverless
-          # - example_path: examples/fully-private-eks-cluster # temporarily skip this example
+          # - example_path: examples/fully-private-eks-cluster # skipping until issue #711
           - example_path: examples/game-tech/agones-game-controller
           - example_path: examples/gitops/argocd
           # - example_path: examples/ingress-controllers/nginx # ignoring due to https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/1629

--- a/.github/workflows/e2e-parallel-full.yml
+++ b/.github/workflows/e2e-parallel-full.yml
@@ -29,7 +29,7 @@ jobs:
           - example_path: examples/crossplane
           - example_path: examples/eks-cluster-with-new-vpc
           - example_path: examples/fargate-serverless
-          - example_path: examples/fully-private-eks-cluster
+          # - example_path: examples/fully-private-eks-cluster # temporarily skip this example
           - example_path: examples/game-tech/agones-game-controller
           - example_path: examples/gitops/argocd
           # - example_path: examples/ingress-controllers/nginx # ignoring due to https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/1629

--- a/.github/workflows/plan-examples.py
+++ b/.github/workflows/plan-examples.py
@@ -11,7 +11,7 @@ def get_examples():
     exclude = {
         'examples/eks-cluster-with-external-dns',  # excluded until Rout53 is setup
         'examples/ci-cd/gitlab-ci-cd',  # excluded since GitLab auth, backend, etc. required
-        'examples/fully-private-eks-cluster/vpc', # excluded until part-2 of the enhancement is done (needs refactoring)
+        'examples/fully-private-eks-cluster/vpc', # skipping until issue #711 is addressed
         'examples/fully-private-eks-cluster/eks',
         'examples/fully-private-eks-cluster/add-ons'
     }

--- a/.github/workflows/plan-examples.py
+++ b/.github/workflows/plan-examples.py
@@ -11,7 +11,9 @@ def get_examples():
     exclude = {
         'examples/eks-cluster-with-external-dns',  # excluded until Rout53 is setup
         'examples/ci-cd/gitlab-ci-cd',  # excluded since GitLab auth, backend, etc. required
-        'examples/fully-private-eks-cluster' # excluded until part-2 of the enhancement is done (needs refactoring)
+        'examples/fully-private-eks-cluster/vpc', # excluded until part-2 of the enhancement is done (needs refactoring)
+        'examples/fully-private-eks-cluster/eks',
+        'examples/fully-private-eks-cluster/add-ons'
     }
 
     projects = {


### PR DESCRIPTION
### What does this PR do?

Last commit for this did not do this properly as the scripts globs the directory.


### Motivation

<!-- What inspired you to submit this pull request? -->


### More

- [ ] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
