### PR TITLE
feat: Add launch_template_tags variable for additional launch template tags

### DIFF
--- a/docs/node-groups.md
+++ b/docs/node-groups.md
@@ -136,6 +136,10 @@ The below example demonstrates advanced configuration options for a managed node
           Name        = "m4-on-demand"
           subnet_type = "private"
         }
+        launch_template_tags = {
+          SomeAwsProviderDefaultTag1: "TRUE"
+          SomeAwsProviderDefaultTag2: "TRUE"
+        }
       }
     }
 ```
@@ -189,6 +193,10 @@ The below example demonstrates advanced configuration options using GPU instance
         Name        = "m5x-on-demand"
         subnet_type = "private"
       }
+      launch_template_tags = {
+        SomeAwsProviderDefaultTag1: "TRUE"
+        SomeAwsProviderDefaultTag2: "TRUE"
+      }
     }
 
     #---------------------------------------------------------#
@@ -236,6 +244,10 @@ The below example demonstrates advanced configuration options using GPU instance
         Name        = "m6g-on-demand"
         subnet_type = "private"
       }
+      launch_template_tags = {
+        SomeAwsProviderDefaultTag1: "TRUE"
+        SomeAwsProviderDefaultTag2: "TRUE"
+      }
     }
 
     #---------------------------------------------------------#
@@ -274,6 +286,10 @@ The below example demonstrates advanced configuration options using GPU instance
         ExtraTag    = "m6g-on-demand"
         Name        = "m6g-on-demand"
         subnet_type = "private"
+      }
+      launch_template_tags = {
+        SomeAwsProviderDefaultTag1: "TRUE"
+        SomeAwsProviderDefaultTag2: "TRUE"
       }
     }
 
@@ -319,6 +335,10 @@ The below example demonstrates advanced configuration options using GPU instance
         ExtraTag    = "m5x-on-demand"
         Name        = "m5x-on-demand"
         subnet_type = "private"
+      }
+      launch_template_tags = {
+        SomeAwsProviderDefaultTag1: "TRUE"
+        SomeAwsProviderDefaultTag2: "TRUE"
       }
     }
 
@@ -402,6 +422,10 @@ The below example demonstrates advanced configuration options using GPU instance
         ExtraTag    = "mng-custom-ami"
         Name        = "mng-custom-ami"
         subnet_type = "private"
+      }
+      launch_template_tags = {
+        SomeAwsProviderDefaultTag1: "TRUE"
+        SomeAwsProviderDefaultTag2: "TRUE"
       }
     }
 ```
@@ -554,6 +578,10 @@ The below example demonstrates advanced configuration options for a self-managed
           ExtraTag    = "m5x-on-demand"
           Name        = "m5x-on-demand"
           subnet_type = "private"
+        }
+        launch_template_tags = {
+          SomeAwsProviderDefaultTag1: "TRUE"
+          SomeAwsProviderDefaultTag2: "TRUE"
         }
         additional_iam_policies = []
       },

--- a/modules/aws-eks-managed-node-groups/locals.tf
+++ b/modules/aws-eks-managed-node-groups/locals.tf
@@ -27,9 +27,10 @@ locals {
     release_version      = ""
     force_update_version = null
 
-    k8s_labels      = {}
-    k8s_taints      = []
-    additional_tags = {}
+    k8s_labels           = {}
+    k8s_taints           = []
+    additional_tags      = {}
+    launch_template_tags = {}
 
     remote_access           = false
     ec2_ssh_key             = null

--- a/modules/aws-eks-managed-node-groups/managed-launch-templates.tf
+++ b/modules/aws-eks-managed-node-groups/managed-launch-templates.tf
@@ -45,9 +45,12 @@ resource "aws_launch_template" "managed_node_groups" {
     }
   }
 
-  tag_specifications {
-    resource_type = "instance"
-    tags          = local.common_tags
+  dynamic "tag_specifications" {
+    for_each = toset(["instance", "volume", "network-interface"])
+    content {
+      resource_type = tag_specifications.key
+      tags          = merge(local.common_tags, local.managed_node_group["launch_template_tags"])
+    }
   }
 
   network_interfaces {


### PR DESCRIPTION
### What does this PR do?

add "launch_template_ignore_changes" option

### Motivation

If I add a tag to `additional_tags`, it will be added to all of them, but there was a situation where I wanted to add an arbitrary tag only to the specifications_tags of launch_template_tag, and I want to make it supported.

eg.

```
locals {
  shared_tags = {
    Terraform   = "true"
    Service       = "Original_Food_Shop"
  }
}

provider "aws" {
  region = var.aws_region
  default_tags {
    tags = local.shared_tags
  }
}

...
managed_node_groups = {
  mg_m5 = {
    node_group_name      = "managed-ondemand"
    instance_types       = ["m5.large"]
    subnet_ids           = module.vpc.private_subnets
    min_size             = 2
    launch_template_tags = local.shared_tags
  }
}
...
```

### More

- [ ] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [x] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [x] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
