### PR TITLE
fixes #659:  remove `experiments = [module_variable_optional_attrs]`

### DIFF
--- a/modules/irsa/variables.tf
+++ b/modules/irsa/variables.tf
@@ -38,7 +38,7 @@ variable "addon_context" {
     eks_oidc_issuer_url            = string
     eks_oidc_provider_arn          = string
     tags                           = map(string)
-    irsa_iam_role_path             = optional(string)
-    irsa_iam_permissions_boundary  = optional(string)
+    irsa_iam_role_path             = string
+    irsa_iam_permissions_boundary  = string
   })
 }

--- a/modules/irsa/versions.tf
+++ b/modules/irsa/versions.tf
@@ -1,8 +1,5 @@
 terraform {
   required_version = ">= 1.0.0"
-
-  experiments = [module_variable_optional_attrs]
-
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/modules/kubernetes-addons/helm-addon/variables.tf
+++ b/modules/kubernetes-addons/helm-addon/variables.tf
@@ -25,10 +25,10 @@ variable "irsa_config" {
   description = "Input configuration for IRSA module"
   type = object({
     kubernetes_namespace              = string
-    create_kubernetes_namespace       = optional(bool)
+    create_kubernetes_namespace       = bool
     kubernetes_service_account        = string
-    create_kubernetes_service_account = optional(bool)
-    irsa_iam_policies                 = optional(list(string))
+    create_kubernetes_service_account = bool
+    irsa_iam_policies                 = list(string)
   })
   default = null
 }
@@ -45,7 +45,7 @@ variable "addon_context" {
     eks_oidc_issuer_url            = string
     eks_oidc_provider_arn          = string
     tags                           = map(string)
-    irsa_iam_role_path             = optional(string)
-    irsa_iam_permissions_boundary  = optional(string)
+    irsa_iam_role_path             = string
+    irsa_iam_permissions_boundary  = string
   })
 }

--- a/modules/kubernetes-addons/helm-addon/versions.tf
+++ b/modules/kubernetes-addons/helm-addon/versions.tf
@@ -1,8 +1,5 @@
 terraform {
   required_version = ">= 1.0.0"
-
-  experiments = [module_variable_optional_attrs]
-
   required_providers {
     helm = {
       source  = "hashicorp/helm"

--- a/modules/launch-templates/locals.tf
+++ b/modules/launch-templates/locals.tf
@@ -1,8 +1,4 @@
-terraform {
-  # Optional attributes and the defaults function are
-  # both experimental, so we must opt in to the experiment.
-  experiments = [module_variable_optional_attrs]
-}
+terraform {}
 
 locals {
   launch_template_config = defaults(var.launch_template_config, {

--- a/modules/launch-templates/variables.tf
+++ b/modules/launch-templates/variables.tf
@@ -2,44 +2,44 @@ variable "launch_template_config" {
   description = "Launch template configuration"
   type = map(object({
     ami                    = string
-    launch_template_os     = optional(string)
+    launch_template_os     = string
     launch_template_prefix = string
-    instance_type          = optional(string)
-    capacity_type          = optional(string)
-    iam_instance_profile   = optional(string)
-    vpc_security_group_ids = optional(list(string)) # conflicts with network_interfaces
+    instance_type          = string
+    capacity_type          = string
+    iam_instance_profile   = string
+    vpc_security_group_ids = list(string) # conflicts with network_interfaces
 
-    network_interfaces = optional(list(object({
-      public_ip       = optional(bool)
-      security_groups = optional(list(string))
+    network_interfaces = list(object(
+      public_ip       = bool
+      security_groups = list(string)
     })))
 
     block_device_mappings = list(object({
       device_name           = string
       volume_type           = string
       volume_size           = string
-      delete_on_termination = optional(bool)
-      encrypted             = optional(bool)
-      kms_key_id            = optional(string)
-      iops                  = optional(string)
-      throughput            = optional(string)
+      delete_on_termination = bool
+      encrypted             = bool
+      kms_key_id            = string
+      iops                  = string
+      throughput            = string
     }))
 
-    format_mount_nvme_disk = optional(bool)
-    pre_userdata           = optional(string)
-    bootstrap_extra_args   = optional(string)
-    post_userdata          = optional(string)
-    kubelet_extra_args     = optional(string)
+    format_mount_nvme_disk = bool
+    pre_userdata           = string
+    bootstrap_extra_args   = string
+    post_userdata          = string
+    kubelet_extra_args     = string
 
-    enable_metadata_options     = optional(bool)
-    http_endpoint               = optional(string)
-    http_tokens                 = optional(string)
-    http_put_response_hop_limit = optional(number)
+    enable_metadata_options     = bool
+    http_endpoint               = string
+    http_tokens                 = string
+    http_put_response_hop_limit = number
 
-    service_ipv6_cidr = optional(string)
-    service_ipv4_cidr = optional(string)
+    service_ipv6_cidr = string
+    service_ipv4_cidr = string
 
-    monitoring = optional(bool)
+    monitoring = bool
   }))
 }
 


### PR DESCRIPTION
Signed-off-by: Fernando Miguel <github@FernandoMiguel.net>

### What does this PR do
Fixes: #659

### Motivation

That defaults function was part of the optional attributes experiment, and has been intentionally removed in the next phase of the experiment, which has (as of last week) been de-experimentalized and will be stable in the forthcoming v1.3.0.

### More

- [x] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
