### PR TITLE
feat(cluster-autoscaler): allow user to upgrade cluster-autoscaler

### DIFF
--- a/modules/kubernetes-addons/cluster-autoscaler/main.tf
+++ b/modules/kubernetes-addons/cluster-autoscaler/main.tf
@@ -17,8 +17,9 @@ module "helm_addon" {
     namespace   = local.namespace
     description = "Cluster AutoScaler helm Chart deployment configuration."
     values = [templatefile("${path.module}/values.yaml", {
-      aws_region     = var.addon_context.aws_region_name,
+      aws_region     = var.addon_context.aws_region_name
       eks_cluster_id = var.addon_context.eks_cluster_id
+      image_tag      = "v${var.eks_cluster_version}.0"
     })]
     },
     var.helm_config
@@ -32,11 +33,7 @@ module "helm_addon" {
     {
       name  = "rbac.serviceAccount.name"
       value = local.service_account
-    },
-    {
-      name  = "image.tag"
-      value = "v${var.eks_cluster_version}.0"
-    },
+    }
   ]
 
   irsa_config = {

--- a/modules/kubernetes-addons/cluster-autoscaler/values.yaml
+++ b/modules/kubernetes-addons/cluster-autoscaler/values.yaml
@@ -5,6 +5,9 @@ autoDiscovery:
 extraArgs:
   aws-use-static-instance-list: true
 
+image:
+  tag: ${image_tag}
+
 resources:
   limits:
     cpu: 200m


### PR DESCRIPTION
Previously `image.tag` was set through `set_values`
Due to this we were unable to upgrade cluster-autoscaler
* redifine cluster-autoscaler image.tag on `values.yaml`
* remove `set_values`


### What does this PR do?

Define default value for `cluster-autoscaler` based on cluster version and let user override this value

### Motivation

Resolv #714 

### More

- [ ] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
