### PR TITLE
feat(argocd): add insecure parameter for argocd apps

### DIFF
--- a/docs/add-ons/argocd.md
+++ b/docs/add-ons/argocd.md
@@ -100,6 +100,7 @@ argocd_applications     = {
     project             = "default"
     add_on_application  = true              # Indicates the root add-on application.
     ssh_key_secret_name = "github-ssh-key"  # Needed for private repos
+    insecure            = false # Set to true to disable the server's certificate verification
   }
 }
 ```

--- a/modules/kubernetes-addons/argocd/main.tf
+++ b/modules/kubernetes-addons/argocd/main.tf
@@ -112,7 +112,7 @@ resource "kubernetes_secret" "argocd_gitops" {
   }
 
   data = {
-    insecure = lookup(each.value, "insecure", false)
+    insecure      = lookup(each.value, "insecure", false)
     sshPrivateKey = data.aws_secretsmanager_secret_version.ssh_key_version[each.key].secret_string
     type          = "git"
     url           = each.value.repo_url

--- a/modules/kubernetes-addons/argocd/main.tf
+++ b/modules/kubernetes-addons/argocd/main.tf
@@ -112,9 +112,10 @@ resource "kubernetes_secret" "argocd_gitops" {
   }
 
   data = {
+    insecure = lookup(each.value, "insecure", false)
+    sshPrivateKey = data.aws_secretsmanager_secret_version.ssh_key_version[each.key].secret_string
     type          = "git"
     url           = each.value.repo_url
-    sshPrivateKey = data.aws_secretsmanager_secret_version.ssh_key_version[each.key].secret_string
   }
 
   depends_on = [module.helm_addon]


### PR DESCRIPTION
### What does this PR do?

Added the optional insecure parameter for argocd apps. If you do not set the insecure parameter it will set to false by default. This does not break existing configurations.

### Motivation

When using private repositories in private networks you often do not want to manage the public server certificates in addition to the private ones. The risk is very low that a man-in-the-middle attack is performed. Therefore I added the `insecure` parameter which can be set when creating an Argo app.

Argo Docs on the insecure flag: https://argo-cd.readthedocs.io/en/stable/user-guide/private-repositories/#self-signed-untrusted-tls-certificates

This parameter resolves repo server errors like `error testing repository connectivity: ssh: handshake failed`.

### More

- [x] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- ~~[ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR~~
  - not required in my opinion because its just a minor optional variable
- ~~[ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)~~
  - no change in the add-ons section
- [x] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

#### Test report:

My config:

```bash
module "eks_blueprints_kubernetes_addons" {
  source = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons?ref=v4.2.1"
  ...
  argocd_applications = {
    argo-app = {
      path                = var.path
      repo_url            = var.repo_url
      create_namespace    = true
      add_on_application  = true
      ssh_key_secret_name = var.ssh_key_secret_name
      insecure            = true    
    }
  }
}
```


ArgoCD Repo Server Logs: 

```bash
time="2022-07-01T06:31:32Z" level=info msg="finished unary call with code OK" grpc.code=OK grpc.method=TestRepository grpc.request.deadline="2022-07-01T06:32:32Z" grpc.service=repository.RepoServerService grpc.start_time="2022-07-01T06:31:32Z" grpc.time_ms=392.957 span.kind=server system=grpc
```




