### PR TITLE
Add missing permissions needed for EFS CSI

### DIFF
--- a/modules/kubernetes-addons/aws-efs-csi-driver/data.tf
+++ b/modules/kubernetes-addons/aws-efs-csi-driver/data.tf
@@ -5,8 +5,10 @@ data "aws_iam_policy_document" "aws_efs_csi_driver" {
     resources = ["*"]
 
     actions = [
+      "ec2:DescribeAvailabilityZones",
       "elasticfilesystem:DescribeAccessPoints",
       "elasticfilesystem:DescribeFileSystems",
+      "elasticfilesystem:DescribeMountTargets"
     ]
   }
 


### PR DESCRIPTION
### What does this PR do?

Add missing ec2:DescribeAvailabilityZones and elasticfilesystem:DescribeMountTargets iam permissions.

### Motivation

ec2:DescribeAvailabilityZones and elasticfilesystem:DescribeMountTargets are needed according to [this](https://github.com/kubernetes-sigs/aws-efs-csi-driver/issues/489#issuecomment-912585225).

### More

- [X] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
