### PR TITLE
fix: markdown links, check markdowns on PR

### DIFF
--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -7,6 +7,12 @@ on:
     paths:
       - "**/*.md"
 
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "**/*.md"
+      
 jobs:
   markdown-link-check:
     runs-on: ubuntu-latest

--- a/docs/add-ons/external-secrets.md
+++ b/docs/add-ons/external-secrets.md
@@ -28,7 +28,7 @@ You can optionally customize the Helm chart that deploys the operator via the fo
 
 The following properties are made available for use when managing the add-on via GitOps.
 
-Refer to [locals.tf](modules/kubernetes-addons/external-secrets/locals.tf) for latest config. GitOps with ArgoCD Add-on repo is located [here](https://github.com/aws-samples/eks-blueprints-add-ons/blob/main/chart/values.yaml).
+Refer to [locals.tf](https://github.com/aws-ia/terraform-aws-eks-blueprints/blob/main/modules/kubernetes-addons/external-secrets/locals.tf) for latest config. GitOps with ArgoCD Add-on repo is located [here](https://github.com/aws-samples/eks-blueprints-add-ons/blob/main/chart/values.yaml).
 
 ```hcl
   argocd_gitops_config = {


### PR DESCRIPTION
### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
- fix broken link in docs.
- adjust markdown link action to run on PRs against main only when .md files modified.

### Motivation

<!-- What inspired you to submit this pull request? -->
- broken main check - https://github.com/aws-ia/terraform-aws-eks-blueprints/runs/7149823004?check_suite_focus=true
- it make sense to check this on PR before changes to main (unless I am missing something here).

### More

- [ ] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
