### PR TITLE
feat: Add timeouts variable.

### DIFF
--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -12,7 +12,7 @@ on:
       - main
     paths:
       - "**/*.md"
-      
+
 jobs:
   markdown-link-check:
     runs-on: ubuntu-latest

--- a/modules/irsa/README.md
+++ b/modules/irsa/README.md
@@ -55,6 +55,7 @@ No modules.
 | <a name="input_irsa_iam_policies"></a> [irsa\_iam\_policies](#input\_irsa\_iam\_policies) | IAM Policies for IRSA IAM role | `list(string)` | `[]` | no |
 | <a name="input_kubernetes_namespace"></a> [kubernetes\_namespace](#input\_kubernetes\_namespace) | Kubernetes Namespace name | `string` | n/a | yes |
 | <a name="input_kubernetes_service_account"></a> [kubernetes\_service\_account](#input\_kubernetes\_service\_account) | Kubernetes Service Account Name | `string` | n/a | yes |
+| <a name="input_timeouts"></a> [timeouts](#input\_timeouts) | Define maximum timeout for creating, updating, and deleting resources | `map(string)` | `{}` | no |
 
 ## Outputs
 

--- a/modules/irsa/locals.tf
+++ b/modules/irsa/locals.tf
@@ -1,0 +1,6 @@
+locals {
+  timeouts = {
+    create = lookup(var.timeouts, "create", "10m")
+    delete = lookup(var.timeouts, "delete", "10m")
+  }
+}

--- a/modules/irsa/main.tf
+++ b/modules/irsa/main.tf
@@ -3,6 +3,10 @@ resource "kubernetes_namespace_v1" "irsa" {
   metadata {
     name = var.kubernetes_namespace
   }
+
+  timeouts {
+    delete = local.timeouts.delete
+  }
 }
 
 resource "kubernetes_service_account_v1" "irsa" {
@@ -14,6 +18,10 @@ resource "kubernetes_service_account_v1" "irsa" {
   }
 
   automount_service_account_token = true
+
+  timeouts {
+    create = local.timeouts.create
+  }
 }
 
 resource "aws_iam_role" "irsa" {

--- a/modules/irsa/variables.tf
+++ b/modules/irsa/variables.tf
@@ -42,3 +42,9 @@ variable "addon_context" {
     irsa_iam_permissions_boundary  = optional(string)
   })
 }
+
+variable "timeouts" {
+  description = "Define maximum timeout for creating, updating, and deleting resources"
+  type        = map(string)
+  default     = {}
+}

--- a/modules/kubernetes-addons/README.md
+++ b/modules/kubernetes-addons/README.md
@@ -208,6 +208,7 @@
 | <a name="input_tetrate_istio_install_istiod"></a> [tetrate\_istio\_install\_istiod](#input\_tetrate\_istio\_install\_istiod) | Install Istio `istiod` Helm Chart | `bool` | `true` | no |
 | <a name="input_tetrate_istio_istiod_helm_config"></a> [tetrate\_istio\_istiod\_helm\_config](#input\_tetrate\_istio\_istiod\_helm\_config) | Istio `istiod` Helm Chart config | `any` | `{}` | no |
 | <a name="input_tetrate_istio_version"></a> [tetrate\_istio\_version](#input\_tetrate\_istio\_version) | Istio version | `string` | `""` | no |
+| <a name="input_timeouts"></a> [timeouts](#input\_timeouts) | Define maximum timeout for creating, updating, and deleting resources | `map(string)` | `{}` | no |
 | <a name="input_traefik_helm_config"></a> [traefik\_helm\_config](#input\_traefik\_helm\_config) | Traefik Helm Chart config | `any` | `{}` | no |
 | <a name="input_vault_helm_config"></a> [vault\_helm\_config](#input\_vault\_helm\_config) | HashiCorp Vault Helm Chart config | `any` | `null` | no |
 | <a name="input_velero_backup_s3_bucket"></a> [velero\_backup\_s3\_bucket](#input\_velero\_backup\_s3\_bucket) | Bucket name for velero bucket | `string` | `""` | no |

--- a/modules/kubernetes-addons/adot-collector-haproxy/README.md
+++ b/modules/kubernetes-addons/adot-collector-haproxy/README.md
@@ -42,6 +42,7 @@ It provides the following resources:
 | <a name="input_amazon_prometheus_workspace_endpoint"></a> [amazon\_prometheus\_workspace\_endpoint](#input\_amazon\_prometheus\_workspace\_endpoint) | Amazon Managed Prometheus Workspace Endpoint | `string` | `null` | no |
 | <a name="input_amazon_prometheus_workspace_region"></a> [amazon\_prometheus\_workspace\_region](#input\_amazon\_prometheus\_workspace\_region) | Amazon Managed Prometheus Workspace's Region | `string` | `null` | no |
 | <a name="input_helm_config"></a> [helm\_config](#input\_helm\_config) | Helm Config for Prometheus | `any` | `{}` | no |
+| <a name="input_timeouts"></a> [timeouts](#input\_timeouts) | Define maximum timeout for creating, updating, and deleting resources | `map(string)` | `{}` | no |
 
 ## Outputs
 

--- a/modules/kubernetes-addons/adot-collector-haproxy/main.tf
+++ b/modules/kubernetes-addons/adot-collector-haproxy/main.tf
@@ -59,4 +59,5 @@ module "helm_addon" {
   }
 
   addon_context = var.addon_context
+  timeouts      = var.timeouts
 }

--- a/modules/kubernetes-addons/adot-collector-haproxy/variables.tf
+++ b/modules/kubernetes-addons/adot-collector-haproxy/variables.tf
@@ -32,3 +32,9 @@ variable "addon_context" {
     tags                           = map(string)
   })
 }
+
+variable "timeouts" {
+  description = "Define maximum timeout for creating, updating, and deleting resources"
+  type        = map(string)
+  default     = {}
+}

--- a/modules/kubernetes-addons/adot-collector-java/README.md
+++ b/modules/kubernetes-addons/adot-collector-java/README.md
@@ -42,6 +42,7 @@ It provides the following resources:
 | <a name="input_amazon_prometheus_workspace_endpoint"></a> [amazon\_prometheus\_workspace\_endpoint](#input\_amazon\_prometheus\_workspace\_endpoint) | Amazon Managed Prometheus Workspace Endpoint | `string` | `null` | no |
 | <a name="input_amazon_prometheus_workspace_region"></a> [amazon\_prometheus\_workspace\_region](#input\_amazon\_prometheus\_workspace\_region) | Amazon Managed Prometheus Workspace's Region | `string` | `null` | no |
 | <a name="input_helm_config"></a> [helm\_config](#input\_helm\_config) | Helm Config for Prometheus | `any` | `{}` | no |
+| <a name="input_timeouts"></a> [timeouts](#input\_timeouts) | Define maximum timeout for creating, updating, and deleting resources | `map(string)` | `{}` | no |
 
 ## Outputs
 

--- a/modules/kubernetes-addons/adot-collector-java/main.tf
+++ b/modules/kubernetes-addons/adot-collector-java/main.tf
@@ -59,4 +59,5 @@ module "helm_addon" {
   }
 
   addon_context = var.addon_context
+  timeouts      = var.timeouts
 }

--- a/modules/kubernetes-addons/adot-collector-java/variables.tf
+++ b/modules/kubernetes-addons/adot-collector-java/variables.tf
@@ -32,3 +32,9 @@ variable "addon_context" {
     tags                           = map(string)
   })
 }
+
+variable "timeouts" {
+  description = "Define maximum timeout for creating, updating, and deleting resources"
+  type        = map(string)
+  default     = {}
+}

--- a/modules/kubernetes-addons/adot-collector-memcached/README.md
+++ b/modules/kubernetes-addons/adot-collector-memcached/README.md
@@ -42,6 +42,7 @@ It provides the following resources:
 | <a name="input_amazon_prometheus_workspace_endpoint"></a> [amazon\_prometheus\_workspace\_endpoint](#input\_amazon\_prometheus\_workspace\_endpoint) | Amazon Managed Prometheus Workspace Endpoint | `string` | `null` | no |
 | <a name="input_amazon_prometheus_workspace_region"></a> [amazon\_prometheus\_workspace\_region](#input\_amazon\_prometheus\_workspace\_region) | Amazon Managed Prometheus Workspace's Region | `string` | `null` | no |
 | <a name="input_helm_config"></a> [helm\_config](#input\_helm\_config) | Helm Config for Prometheus | `any` | `{}` | no |
+| <a name="input_timeouts"></a> [timeouts](#input\_timeouts) | Define maximum timeout for creating, updating, and deleting resources | `map(string)` | `{}` | no |
 
 ## Outputs
 

--- a/modules/kubernetes-addons/adot-collector-memcached/main.tf
+++ b/modules/kubernetes-addons/adot-collector-memcached/main.tf
@@ -59,4 +59,5 @@ module "helm_addon" {
   }
 
   addon_context = var.addon_context
+  timeouts      = var.timeouts
 }

--- a/modules/kubernetes-addons/adot-collector-memcached/variables.tf
+++ b/modules/kubernetes-addons/adot-collector-memcached/variables.tf
@@ -32,3 +32,9 @@ variable "addon_context" {
     tags                           = map(string)
   })
 }
+
+variable "timeouts" {
+  description = "Define maximum timeout for creating, updating, and deleting resources"
+  type        = map(string)
+  default     = {}
+}

--- a/modules/kubernetes-addons/adot-collector-nginx/README.md
+++ b/modules/kubernetes-addons/adot-collector-nginx/README.md
@@ -42,6 +42,7 @@ It provides the following resources:
 | <a name="input_amazon_prometheus_workspace_endpoint"></a> [amazon\_prometheus\_workspace\_endpoint](#input\_amazon\_prometheus\_workspace\_endpoint) | Amazon Managed Prometheus Workspace Endpoint | `string` | `null` | no |
 | <a name="input_amazon_prometheus_workspace_region"></a> [amazon\_prometheus\_workspace\_region](#input\_amazon\_prometheus\_workspace\_region) | Amazon Managed Prometheus Workspace's Region | `string` | `null` | no |
 | <a name="input_helm_config"></a> [helm\_config](#input\_helm\_config) | Helm Config for Prometheus | `any` | `{}` | no |
+| <a name="input_timeouts"></a> [timeouts](#input\_timeouts) | Define maximum timeout for creating, updating, and deleting resources | `map(string)` | `{}` | no |
 
 ## Outputs
 

--- a/modules/kubernetes-addons/adot-collector-nginx/main.tf
+++ b/modules/kubernetes-addons/adot-collector-nginx/main.tf
@@ -59,4 +59,5 @@ module "helm_addon" {
   }
 
   addon_context = var.addon_context
+  timeouts      = var.timeouts
 }

--- a/modules/kubernetes-addons/adot-collector-nginx/variables.tf
+++ b/modules/kubernetes-addons/adot-collector-nginx/variables.tf
@@ -32,3 +32,9 @@ variable "addon_context" {
     tags                           = map(string)
   })
 }
+
+variable "timeouts" {
+  description = "Define maximum timeout for creating, updating, and deleting resources"
+  type        = map(string)
+  default     = {}
+}

--- a/modules/kubernetes-addons/agones/README.md
+++ b/modules/kubernetes-addons/agones/README.md
@@ -57,6 +57,7 @@ gcr.io/agones-images/agones-allocator:1.15.0-rc
 | <a name="input_eks_worker_security_group_id"></a> [eks\_worker\_security\_group\_id](#input\_eks\_worker\_security\_group\_id) | EKS Worker Security Group ID | `string` | n/a | yes |
 | <a name="input_helm_config"></a> [helm\_config](#input\_helm\_config) | Helm provider config for Agones GameServer | `any` | `{}` | no |
 | <a name="input_manage_via_gitops"></a> [manage\_via\_gitops](#input\_manage\_via\_gitops) | Determines if the add-on should be managed via GitOps. | `bool` | `false` | no |
+| <a name="input_timeouts"></a> [timeouts](#input\_timeouts) | Define maximum timeout for creating, updating, and deleting resources | `map(string)` | `{}` | no |
 
 ## Outputs
 

--- a/modules/kubernetes-addons/agones/main.tf
+++ b/modules/kubernetes-addons/agones/main.tf
@@ -4,6 +4,7 @@ module "helm_addon" {
   helm_config       = local.helm_config
   irsa_config       = null
   addon_context     = var.addon_context
+  timeouts          = var.timeouts
 
   depends_on = [kubernetes_namespace_v1.this]
 }

--- a/modules/kubernetes-addons/agones/variables.tf
+++ b/modules/kubernetes-addons/agones/variables.tf
@@ -29,3 +29,9 @@ variable "addon_context" {
     tags                           = map(string)
   })
 }
+
+variable "timeouts" {
+  description = "Define maximum timeout for creating, updating, and deleting resources"
+  type        = map(string)
+  default     = {}
+}

--- a/modules/kubernetes-addons/argo-rollouts/README.md
+++ b/modules/kubernetes-addons/argo-rollouts/README.md
@@ -39,6 +39,7 @@ Argo Rollouts (optionally) integrates with ingress controllers and service meshe
 | <a name="input_addon_context"></a> [addon\_context](#input\_addon\_context) | Input configuration for the addon | <pre>object({<br>    aws_caller_identity_account_id = string<br>    aws_caller_identity_arn        = string<br>    aws_eks_cluster_endpoint       = string<br>    aws_partition_id               = string<br>    aws_region_name                = string<br>    eks_cluster_id                 = string<br>    eks_oidc_issuer_url            = string<br>    eks_oidc_provider_arn          = string<br>    tags                           = map(string)<br>  })</pre> | n/a | yes |
 | <a name="input_helm_config"></a> [helm\_config](#input\_helm\_config) | Helm provider config for the Argo Rollouts | `any` | `{}` | no |
 | <a name="input_manage_via_gitops"></a> [manage\_via\_gitops](#input\_manage\_via\_gitops) | Determines if the add-on should be managed via GitOps. | `bool` | `false` | no |
+| <a name="input_timeouts"></a> [timeouts](#input\_timeouts) | Define maximum timeout for creating, updating, and deleting resources | `map(string)` | `{}` | no |
 
 ## Outputs
 

--- a/modules/kubernetes-addons/argo-rollouts/main.tf
+++ b/modules/kubernetes-addons/argo-rollouts/main.tf
@@ -4,6 +4,7 @@ module "helm_addon" {
   helm_config       = local.helm_config
   irsa_config       = null
   addon_context     = var.addon_context
+  timeouts          = var.timeouts
 
   depends_on = [kubernetes_namespace_v1.this]
 }

--- a/modules/kubernetes-addons/argo-rollouts/variables.tf
+++ b/modules/kubernetes-addons/argo-rollouts/variables.tf
@@ -24,3 +24,9 @@ variable "addon_context" {
     tags                           = map(string)
   })
 }
+
+variable "timeouts" {
+  description = "Define maximum timeout for creating, updating, and deleting resources"
+  type        = map(string)
+  default     = {}
+}

--- a/modules/kubernetes-addons/argocd/README.md
+++ b/modules/kubernetes-addons/argocd/README.md
@@ -54,6 +54,7 @@ Application definitions, configurations, and environments should be declarative 
 | <a name="input_admin_password_secret_name"></a> [admin\_password\_secret\_name](#input\_admin\_password\_secret\_name) | Name for a secret stored in AWS Secrets Manager that contains the admin password for ArgoCD. | `string` | `""` | no |
 | <a name="input_applications"></a> [applications](#input\_applications) | ArgoCD Application config used to bootstrap a cluster. | `any` | `{}` | no |
 | <a name="input_helm_config"></a> [helm\_config](#input\_helm\_config) | ArgoCD Helm Chart Config values | `any` | `{}` | no |
+| <a name="input_timeouts"></a> [timeouts](#input\_timeouts) | Define maximum timeout for creating, updating, and deleting resources | `map(string)` | `{}` | no |
 
 ## Outputs
 

--- a/modules/kubernetes-addons/argocd/main.tf
+++ b/modules/kubernetes-addons/argocd/main.tf
@@ -4,6 +4,7 @@ module "helm_addon" {
   irsa_config          = null
   set_sensitive_values = local.set_sensitive
   addon_context        = var.addon_context
+  timeouts             = var.timeouts
 
   depends_on = [kubernetes_namespace_v1.this]
 }

--- a/modules/kubernetes-addons/argocd/variables.tf
+++ b/modules/kubernetes-addons/argocd/variables.tf
@@ -36,3 +36,9 @@ variable "addon_context" {
     tags                           = map(string)
   })
 }
+
+variable "timeouts" {
+  description = "Define maximum timeout for creating, updating, and deleting resources"
+  type        = map(string)
+  default     = {}
+}

--- a/modules/kubernetes-addons/aws-cloudwatch-metrics/README.md
+++ b/modules/kubernetes-addons/aws-cloudwatch-metrics/README.md
@@ -34,6 +34,7 @@ No resources.
 | <a name="input_helm_config"></a> [helm\_config](#input\_helm\_config) | Helm provider config aws-cloudwatch-metrics. | `any` | `{}` | no |
 | <a name="input_irsa_policies"></a> [irsa\_policies](#input\_irsa\_policies) | Additional IAM policies for a IAM role for service accounts | `list(string)` | `[]` | no |
 | <a name="input_manage_via_gitops"></a> [manage\_via\_gitops](#input\_manage\_via\_gitops) | Determines if the add-on should be managed via GitOps. | `bool` | `false` | no |
+| <a name="input_timeouts"></a> [timeouts](#input\_timeouts) | Define maximum timeout for creating, updating, and deleting resources | `map(string)` | `{}` | no |
 
 ## Outputs
 

--- a/modules/kubernetes-addons/aws-cloudwatch-metrics/main.tf
+++ b/modules/kubernetes-addons/aws-cloudwatch-metrics/main.tf
@@ -5,4 +5,5 @@ module "helm_addon" {
   helm_config       = local.helm_config
   irsa_config       = local.irsa_config
   addon_context     = var.addon_context
+  timeouts          = var.timeouts
 }

--- a/modules/kubernetes-addons/aws-cloudwatch-metrics/variables.tf
+++ b/modules/kubernetes-addons/aws-cloudwatch-metrics/variables.tf
@@ -32,3 +32,9 @@ variable "addon_context" {
     irsa_iam_permissions_boundary  = string
   })
 }
+
+variable "timeouts" {
+  description = "Define maximum timeout for creating, updating, and deleting resources"
+  type        = map(string)
+  default     = {}
+}

--- a/modules/kubernetes-addons/aws-coredns/README.md
+++ b/modules/kubernetes-addons/aws-coredns/README.md
@@ -75,6 +75,7 @@ To provision the self managed addon for CoreDNS, you can reference the following
 | <a name="input_enable_amazon_eks_coredns"></a> [enable\_amazon\_eks\_coredns](#input\_enable\_amazon\_eks\_coredns) | Enable Amazon EKS CoreDNS add-on | `bool` | `false` | no |
 | <a name="input_enable_self_managed_coredns"></a> [enable\_self\_managed\_coredns](#input\_enable\_self\_managed\_coredns) | Enable self-managed CoreDNS add-on | `bool` | `false` | no |
 | <a name="input_helm_config"></a> [helm\_config](#input\_helm\_config) | Helm provider config for the aws\_efs\_csi\_driver | `any` | `{}` | no |
+| <a name="input_timeouts"></a> [timeouts](#input\_timeouts) | Define maximum timeout for creating, updating, and deleting resources | `map(string)` | `{}` | no |
 
 ## Outputs
 

--- a/modules/kubernetes-addons/aws-coredns/main.tf
+++ b/modules/kubernetes-addons/aws-coredns/main.tf
@@ -65,4 +65,5 @@ module "helm_addon" {
 
   # Blueprints
   addon_context = var.addon_context
+  timeouts      = var.timeouts
 }

--- a/modules/kubernetes-addons/aws-coredns/variables.tf
+++ b/modules/kubernetes-addons/aws-coredns/variables.tf
@@ -36,3 +36,9 @@ variable "helm_config" {
   default     = {}
   type        = any
 }
+
+variable "timeouts" {
+  description = "Define maximum timeout for creating, updating, and deleting resources"
+  type        = map(string)
+  default     = {}
+}

--- a/modules/kubernetes-addons/aws-ebs-csi-driver/README.md
+++ b/modules/kubernetes-addons/aws-ebs-csi-driver/README.md
@@ -37,6 +37,7 @@ The EBS CSI driver provides a CSI interface used by container orchestrators to m
 |------|-------------|------|---------|:--------:|
 | <a name="input_addon_config"></a> [addon\_config](#input\_addon\_config) | Amazon EKS Managed Add-on config for EBS CSI Driver | `any` | `{}` | no |
 | <a name="input_addon_context"></a> [addon\_context](#input\_addon\_context) | Input configuration for the addon | <pre>object({<br>    aws_caller_identity_account_id = string<br>    aws_caller_identity_arn        = string<br>    aws_eks_cluster_endpoint       = string<br>    aws_partition_id               = string<br>    aws_region_name                = string<br>    eks_cluster_id                 = string<br>    eks_oidc_issuer_url            = string<br>    eks_oidc_provider_arn          = string<br>    tags                           = map(string)<br>    irsa_iam_role_path             = string<br>    irsa_iam_permissions_boundary  = string<br>  })</pre> | n/a | yes |
+| <a name="input_timeouts"></a> [timeouts](#input\_timeouts) | Define maximum timeout for creating, updating, and deleting resources | `map(string)` | `{}` | no |
 
 ## Outputs
 

--- a/modules/kubernetes-addons/aws-ebs-csi-driver/main.tf
+++ b/modules/kubernetes-addons/aws-ebs-csi-driver/main.tf
@@ -27,6 +27,7 @@ module "irsa_addon" {
   kubernetes_service_account        = "ebs-csi-controller-sa"
   irsa_iam_policies                 = concat([aws_iam_policy.aws_ebs_csi_driver[0].arn], try(var.addon_config.additional_iam_policies, []))
   addon_context                     = var.addon_context
+  timeouts                          = var.timeouts
 }
 
 resource "aws_iam_policy" "aws_ebs_csi_driver" {

--- a/modules/kubernetes-addons/aws-ebs-csi-driver/variables.tf
+++ b/modules/kubernetes-addons/aws-ebs-csi-driver/variables.tf
@@ -20,3 +20,9 @@ variable "addon_context" {
     irsa_iam_permissions_boundary  = string
   })
 }
+
+variable "timeouts" {
+  description = "Define maximum timeout for creating, updating, and deleting resources"
+  type        = map(string)
+  default     = {}
+}

--- a/modules/kubernetes-addons/aws-efs-csi-driver/README.md
+++ b/modules/kubernetes-addons/aws-efs-csi-driver/README.md
@@ -35,6 +35,7 @@
 | <a name="input_helm_config"></a> [helm\_config](#input\_helm\_config) | Helm provider config for the aws\_efs\_csi\_driver. | `any` | `{}` | no |
 | <a name="input_irsa_policies"></a> [irsa\_policies](#input\_irsa\_policies) | Additional IAM policies for a IAM role for service accounts | `list(string)` | `[]` | no |
 | <a name="input_manage_via_gitops"></a> [manage\_via\_gitops](#input\_manage\_via\_gitops) | Determines if the add-on should be managed via GitOps. | `bool` | `false` | no |
+| <a name="input_timeouts"></a> [timeouts](#input\_timeouts) | Define maximum timeout for creating, updating, and deleting resources | `map(string)` | `{}` | no |
 
 ## Outputs
 

--- a/modules/kubernetes-addons/aws-efs-csi-driver/main.tf
+++ b/modules/kubernetes-addons/aws-efs-csi-driver/main.tf
@@ -5,6 +5,7 @@ module "helm_addon" {
   helm_config       = local.helm_config
   irsa_config       = local.irsa_config
   addon_context     = var.addon_context
+  timeouts          = var.timeouts
 }
 
 resource "aws_iam_policy" "aws_efs_csi_driver" {

--- a/modules/kubernetes-addons/aws-efs-csi-driver/variables.tf
+++ b/modules/kubernetes-addons/aws-efs-csi-driver/variables.tf
@@ -32,3 +32,9 @@ variable "addon_context" {
     irsa_iam_permissions_boundary  = string
   })
 }
+
+variable "timeouts" {
+  description = "Define maximum timeout for creating, updating, and deleting resources"
+  type        = map(string)
+  default     = {}
+}

--- a/modules/kubernetes-addons/aws-for-fluentbit/README.md
+++ b/modules/kubernetes-addons/aws-for-fluentbit/README.md
@@ -48,6 +48,7 @@ See this [Helm Chart](https://github.com/aws/eks-charts/tree/master/stable/aws-f
 | <a name="input_helm_config"></a> [helm\_config](#input\_helm\_config) | Helm provider config aws\_for\_fluent\_bit. | `any` | `{}` | no |
 | <a name="input_irsa_policies"></a> [irsa\_policies](#input\_irsa\_policies) | Additional IAM policies for a IAM role for service accounts | `list(string)` | `[]` | no |
 | <a name="input_manage_via_gitops"></a> [manage\_via\_gitops](#input\_manage\_via\_gitops) | Determines if the add-on should be managed via GitOps. | `bool` | `false` | no |
+| <a name="input_timeouts"></a> [timeouts](#input\_timeouts) | Define maximum timeout for creating, updating, and deleting resources | `map(string)` | `{}` | no |
 
 ## Outputs
 

--- a/modules/kubernetes-addons/aws-for-fluentbit/main.tf
+++ b/modules/kubernetes-addons/aws-for-fluentbit/main.tf
@@ -5,6 +5,7 @@ module "helm_addon" {
   helm_config       = local.helm_config
   irsa_config       = local.irsa_config
   addon_context     = var.addon_context
+  timeouts          = var.timeouts
 }
 
 resource "aws_cloudwatch_log_group" "aws_for_fluent_bit" {

--- a/modules/kubernetes-addons/aws-for-fluentbit/variables.tf
+++ b/modules/kubernetes-addons/aws-for-fluentbit/variables.tf
@@ -50,3 +50,9 @@ variable "addon_context" {
     irsa_iam_permissions_boundary  = string
   })
 }
+
+variable "timeouts" {
+  description = "Define maximum timeout for creating, updating, and deleting resources"
+  type        = map(string)
+  default     = {}
+}

--- a/modules/kubernetes-addons/aws-load-balancer-controller/README.md
+++ b/modules/kubernetes-addons/aws-load-balancer-controller/README.md
@@ -89,6 +89,7 @@ Here is the link to get the AWS ELB [service annotations](https://kubernetes-sig
 | <a name="input_addon_context"></a> [addon\_context](#input\_addon\_context) | Input configuration for the addon. | <pre>object({<br>    aws_caller_identity_account_id = string<br>    aws_caller_identity_arn        = string<br>    aws_eks_cluster_endpoint       = string<br>    aws_partition_id               = string<br>    aws_region_name                = string<br>    eks_cluster_id                 = string<br>    eks_oidc_issuer_url            = string<br>    eks_oidc_provider_arn          = string<br>    tags                           = map(string)<br>    irsa_iam_role_path             = string<br>    irsa_iam_permissions_boundary  = string<br>    default_repository             = string<br>  })</pre> | n/a | yes |
 | <a name="input_helm_config"></a> [helm\_config](#input\_helm\_config) | Helm provider config for the aws\_load\_balancer\_controller. | `any` | `{}` | no |
 | <a name="input_manage_via_gitops"></a> [manage\_via\_gitops](#input\_manage\_via\_gitops) | Determines if the add-on should be managed via GitOps. | `bool` | `false` | no |
+| <a name="input_timeouts"></a> [timeouts](#input\_timeouts) | Define maximum timeout for creating, updating, and deleting resources | `map(string)` | `{}` | no |
 
 ## Outputs
 

--- a/modules/kubernetes-addons/aws-load-balancer-controller/main.tf
+++ b/modules/kubernetes-addons/aws-load-balancer-controller/main.tf
@@ -5,6 +5,7 @@ module "helm_addon" {
   helm_config       = local.helm_config
   irsa_config       = local.irsa_config
   addon_context     = var.addon_context
+  timeouts          = var.timeouts
 }
 
 resource "aws_iam_policy" "aws_load_balancer_controller" {

--- a/modules/kubernetes-addons/aws-load-balancer-controller/variables.tf
+++ b/modules/kubernetes-addons/aws-load-balancer-controller/variables.tf
@@ -27,3 +27,9 @@ variable "addon_context" {
     default_repository             = string
   })
 }
+
+variable "timeouts" {
+  description = "Define maximum timeout for creating, updating, and deleting resources"
+  type        = map(string)
+  default     = {}
+}

--- a/modules/kubernetes-addons/aws-node-termination-handler/README.md
+++ b/modules/kubernetes-addons/aws-node-termination-handler/README.md
@@ -47,6 +47,7 @@ This project ensures that the Kubernetes control plane responds appropriately to
 | <a name="input_autoscaling_group_names"></a> [autoscaling\_group\_names](#input\_autoscaling\_group\_names) | EKS Node Group ASG names | `list(string)` | n/a | yes |
 | <a name="input_helm_config"></a> [helm\_config](#input\_helm\_config) | AWS Node Termination Handler Helm Chart Configuration | `any` | `{}` | no |
 | <a name="input_irsa_policies"></a> [irsa\_policies](#input\_irsa\_policies) | Additional IAM policies for a IAM role for service accounts | `list(string)` | `[]` | no |
+| <a name="input_timeouts"></a> [timeouts](#input\_timeouts) | Define maximum timeout for creating, updating, and deleting resources | `map(string)` | `{}` | no |
 
 ## Outputs
 

--- a/modules/kubernetes-addons/aws-node-termination-handler/main.tf
+++ b/modules/kubernetes-addons/aws-node-termination-handler/main.tf
@@ -4,6 +4,7 @@ module "helm_addon" {
   irsa_config   = local.irsa_config
   addon_context = var.addon_context
   set_values    = local.set_values
+  timeouts      = var.timeouts
 }
 
 resource "aws_autoscaling_lifecycle_hook" "aws_node_termination_handler_hook" {

--- a/modules/kubernetes-addons/aws-node-termination-handler/variables.tf
+++ b/modules/kubernetes-addons/aws-node-termination-handler/variables.tf
@@ -31,3 +31,9 @@ variable "irsa_policies" {
   type        = list(string)
   default     = []
 }
+
+variable "timeouts" {
+  description = "Define maximum timeout for creating, updating, and deleting resources"
+  type        = map(string)
+  default     = {}
+}

--- a/modules/kubernetes-addons/aws-privateca-issuer/README.md
+++ b/modules/kubernetes-addons/aws-privateca-issuer/README.md
@@ -44,6 +44,7 @@ See the [aws-pca-issuer documentation](https://cert-manager.github.io/aws-privat
 | <a name="input_helm_config"></a> [helm\_config](#input\_helm\_config) | AWS PCA Issuer Helm Config | `any` | `{}` | no |
 | <a name="input_irsa_policies"></a> [irsa\_policies](#input\_irsa\_policies) | Additional IAM policies for a IAM role for service accounts | `list(string)` | `[]` | no |
 | <a name="input_manage_via_gitops"></a> [manage\_via\_gitops](#input\_manage\_via\_gitops) | Determines if the add-on should be managed via GitOps. | `bool` | `false` | no |
+| <a name="input_timeouts"></a> [timeouts](#input\_timeouts) | Define maximum timeout for creating, updating, and deleting resources | `map(string)` | `{}` | no |
 
 ## Outputs
 

--- a/modules/kubernetes-addons/aws-privateca-issuer/main.tf
+++ b/modules/kubernetes-addons/aws-privateca-issuer/main.tf
@@ -5,6 +5,7 @@ module "helm_addon" {
   helm_config       = local.helm_config
   irsa_config       = local.irsa_config
   addon_context     = var.addon_context
+  timeouts          = var.timeouts
 }
 
 resource "aws_iam_policy" "aws_privateca_issuer" {

--- a/modules/kubernetes-addons/aws-privateca-issuer/variables.tf
+++ b/modules/kubernetes-addons/aws-privateca-issuer/variables.tf
@@ -37,3 +37,9 @@ variable "irsa_policies" {
   type        = list(string)
   default     = []
 }
+
+variable "timeouts" {
+  description = "Define maximum timeout for creating, updating, and deleting resources"
+  type        = map(string)
+  default     = {}
+}

--- a/modules/kubernetes-addons/aws-vpc-cni/README.md
+++ b/modules/kubernetes-addons/aws-vpc-cni/README.md
@@ -38,6 +38,7 @@ The Amazon VPC CNI plugin for Kubernetes is the networking plugin for pod networ
 | <a name="input_addon_config"></a> [addon\_config](#input\_addon\_config) | Amazon EKS Managed Add-on | `any` | `{}` | no |
 | <a name="input_addon_context"></a> [addon\_context](#input\_addon\_context) | Input configuration for the addon | <pre>object({<br>    aws_caller_identity_account_id = string<br>    aws_caller_identity_arn        = string<br>    aws_eks_cluster_endpoint       = string<br>    aws_partition_id               = string<br>    aws_region_name                = string<br>    eks_cluster_id                 = string<br>    eks_oidc_issuer_url            = string<br>    eks_oidc_provider_arn          = string<br>    tags                           = map(string)<br>    irsa_iam_role_path             = string<br>    irsa_iam_permissions_boundary  = string<br>  })</pre> | n/a | yes |
 | <a name="input_enable_ipv6"></a> [enable\_ipv6](#input\_enable\_ipv6) | Enable IPV6 CNI policy | `any` | `false` | no |
+| <a name="input_timeouts"></a> [timeouts](#input\_timeouts) | Define maximum timeout for creating, updating, and deleting resources | `map(string)` | `{}` | no |
 
 ## Outputs
 

--- a/modules/kubernetes-addons/aws-vpc-cni/main.tf
+++ b/modules/kubernetes-addons/aws-vpc-cni/main.tf
@@ -33,6 +33,7 @@ module "irsa_addon" {
     local.cni_ipv6_policy,
     try(var.addon_config.additional_iam_policies, [])
   )
+  timeouts = var.timeouts
 }
 
 resource "aws_iam_policy" "cni_ipv6_policy" {

--- a/modules/kubernetes-addons/aws-vpc-cni/variables.tf
+++ b/modules/kubernetes-addons/aws-vpc-cni/variables.tf
@@ -26,3 +26,9 @@ variable "addon_context" {
     irsa_iam_permissions_boundary  = string
   })
 }
+
+variable "timeouts" {
+  description = "Define maximum timeout for creating, updating, and deleting resources"
+  type        = map(string)
+  default     = {}
+}

--- a/modules/kubernetes-addons/cert-manager/README.md
+++ b/modules/kubernetes-addons/cert-manager/README.md
@@ -59,6 +59,7 @@ cert-manager docker image is available at this repo:
 | <a name="input_irsa_policies"></a> [irsa\_policies](#input\_irsa\_policies) | Additional IAM policies used for the add-on service account. | `list(string)` | `[]` | no |
 | <a name="input_letsencrypt_email"></a> [letsencrypt\_email](#input\_letsencrypt\_email) | Email address for expiration emails from Let's Encrypt. | `string` | `""` | no |
 | <a name="input_manage_via_gitops"></a> [manage\_via\_gitops](#input\_manage\_via\_gitops) | Determines if the add-on should be managed via GitOps. | `bool` | `false` | no |
+| <a name="input_timeouts"></a> [timeouts](#input\_timeouts) | Define maximum timeout for creating, updating, and deleting resources | `map(string)` | `{}` | no |
 
 ## Outputs
 

--- a/modules/kubernetes-addons/cert-manager/main.tf
+++ b/modules/kubernetes-addons/cert-manager/main.tf
@@ -5,6 +5,7 @@ module "helm_addon" {
   helm_config       = local.helm_config
   irsa_config       = local.irsa_config
   addon_context     = var.addon_context
+  timeouts          = var.timeouts
 }
 
 resource "helm_release" "cert_manager_ca" {

--- a/modules/kubernetes-addons/cert-manager/variables.tf
+++ b/modules/kubernetes-addons/cert-manager/variables.tf
@@ -49,3 +49,9 @@ variable "addon_context" {
     irsa_iam_role_path             = string
   })
 }
+
+variable "timeouts" {
+  description = "Define maximum timeout for creating, updating, and deleting resources"
+  type        = map(string)
+  default     = {}
+}

--- a/modules/kubernetes-addons/cluster-autoscaler/README.md
+++ b/modules/kubernetes-addons/cluster-autoscaler/README.md
@@ -35,6 +35,7 @@
 | <a name="input_eks_cluster_version"></a> [eks\_cluster\_version](#input\_eks\_cluster\_version) | The Kubernetes version for the cluster - used to match appropriate version for image used | `string` | n/a | yes |
 | <a name="input_helm_config"></a> [helm\_config](#input\_helm\_config) | Cluster Autoscaler Helm Config | `any` | `{}` | no |
 | <a name="input_manage_via_gitops"></a> [manage\_via\_gitops](#input\_manage\_via\_gitops) | Determines if the add-on should be managed via GitOps. | `bool` | `false` | no |
+| <a name="input_timeouts"></a> [timeouts](#input\_timeouts) | Define maximum timeout for creating, updating, and deleting resources | `map(string)` | `{}` | no |
 
 ## Outputs
 

--- a/modules/kubernetes-addons/cluster-autoscaler/main.tf
+++ b/modules/kubernetes-addons/cluster-autoscaler/main.tf
@@ -45,6 +45,7 @@ module "helm_addon" {
   }
 
   addon_context = var.addon_context
+  timeouts      = var.timeouts
 }
 
 data "aws_iam_policy_document" "cluster_autoscaler" {

--- a/modules/kubernetes-addons/cluster-autoscaler/variables.tf
+++ b/modules/kubernetes-addons/cluster-autoscaler/variables.tf
@@ -31,3 +31,9 @@ variable "addon_context" {
     irsa_iam_permissions_boundary  = string
   })
 }
+
+variable "timeouts" {
+  description = "Define maximum timeout for creating, updating, and deleting resources"
+  type        = map(string)
+  default     = {}
+}

--- a/modules/kubernetes-addons/cluster-proportional-autoscaler/README.md
+++ b/modules/kubernetes-addons/cluster-proportional-autoscaler/README.md
@@ -33,6 +33,7 @@ No resources.
 | <a name="input_addon_context"></a> [addon\_context](#input\_addon\_context) | Input configuration for the addon | <pre>object({<br>    aws_caller_identity_account_id = string<br>    aws_caller_identity_arn        = string<br>    aws_eks_cluster_endpoint       = string<br>    aws_partition_id               = string<br>    aws_region_name                = string<br>    eks_cluster_id                 = string<br>    eks_oidc_issuer_url            = string<br>    eks_oidc_provider_arn          = string<br>    tags                           = map(string)<br>    irsa_iam_role_path             = string<br>    irsa_iam_permissions_boundary  = string<br>  })</pre> | n/a | yes |
 | <a name="input_helm_config"></a> [helm\_config](#input\_helm\_config) | Helm provider config for the Karpenter | `any` | `{}` | no |
 | <a name="input_manage_via_gitops"></a> [manage\_via\_gitops](#input\_manage\_via\_gitops) | Determines if the add-on should be managed via GitOps. | `bool` | `false` | no |
+| <a name="input_timeouts"></a> [timeouts](#input\_timeouts) | Define maximum timeout for creating, updating, and deleting resources | `map(string)` | `{}` | no |
 
 ## Outputs
 

--- a/modules/kubernetes-addons/cluster-proportional-autoscaler/main.tf
+++ b/modules/kubernetes-addons/cluster-proportional-autoscaler/main.tf
@@ -5,4 +5,5 @@ module "helm_addon" {
   set_values        = local.set_values
   irsa_config       = null
   addon_context     = var.addon_context
+  timeouts          = var.timeouts
 }

--- a/modules/kubernetes-addons/cluster-proportional-autoscaler/variables.tf
+++ b/modules/kubernetes-addons/cluster-proportional-autoscaler/variables.tf
@@ -26,3 +26,9 @@ variable "addon_context" {
     irsa_iam_permissions_boundary  = string
   })
 }
+
+variable "timeouts" {
+  description = "Define maximum timeout for creating, updating, and deleting resources"
+  type        = map(string)
+  default     = {}
+}

--- a/modules/kubernetes-addons/crossplane/README.md
+++ b/modules/kubernetes-addons/crossplane/README.md
@@ -78,6 +78,7 @@ Refer to [docs](../../../docs/add-ons/crossplane.md) on how to deploy AWS Provid
 | <a name="input_aws_provider"></a> [aws\_provider](#input\_aws\_provider) | AWS Provider config for Crossplane | <pre>object({<br>    enable                   = bool<br>    provider_aws_version     = string<br>    additional_irsa_policies = list(string)<br>  })</pre> | n/a | yes |
 | <a name="input_helm_config"></a> [helm\_config](#input\_helm\_config) | Helm provider config for the Argo Rollouts | `any` | `{}` | no |
 | <a name="input_jet_aws_provider"></a> [jet\_aws\_provider](#input\_jet\_aws\_provider) | AWS Provider Jet AWS config for Crossplane | <pre>object({<br>    enable                   = bool<br>    provider_aws_version     = string<br>    additional_irsa_policies = list(string)<br>  })</pre> | n/a | yes |
+| <a name="input_timeouts"></a> [timeouts](#input\_timeouts) | Define maximum timeout for creating, updating, and deleting resources | `map(string)` | `{}` | no |
 
 ## Outputs
 

--- a/modules/kubernetes-addons/crossplane/main.tf
+++ b/modules/kubernetes-addons/crossplane/main.tf
@@ -10,6 +10,7 @@ module "helm_addon" {
   helm_config   = local.helm_config
   irsa_config   = null
   addon_context = var.addon_context
+  timeouts      = var.timeouts
 
   depends_on = [kubernetes_namespace_v1.crossplane]
 }

--- a/modules/kubernetes-addons/crossplane/variables.tf
+++ b/modules/kubernetes-addons/crossplane/variables.tf
@@ -48,3 +48,9 @@ variable "aws_partition" {
   description = "AWS Identifier of the current partition e.g., aws or aws-cn"
   type        = string
 }
+
+variable "timeouts" {
+  description = "Define maximum timeout for creating, updating, and deleting resources"
+  type        = map(string)
+  default     = {}
+}

--- a/modules/kubernetes-addons/csi-secrets-store-provider-aws/main.tf
+++ b/modules/kubernetes-addons/csi-secrets-store-provider-aws/main.tf
@@ -13,6 +13,7 @@ module "helm_addon" {
   manage_via_gitops = var.manage_via_gitops
   helm_config       = local.helm_config
   addon_context     = var.addon_context
+  timeouts          = var.timeouts
 
   depends_on = [kubernetes_namespace_v1.csi_secrets_store_provider_aws]
 }

--- a/modules/kubernetes-addons/csi-secrets-store-provider-aws/variables.tf
+++ b/modules/kubernetes-addons/csi-secrets-store-provider-aws/variables.tf
@@ -26,3 +26,9 @@ variable "addon_context" {
   })
   description = "Input configuration for the addon"
 }
+
+variable "timeouts" {
+  description = "Define maximum timeout for creating, updating, and deleting resources"
+  type        = map(string)
+  default     = {}
+}

--- a/modules/kubernetes-addons/external-dns/README.md
+++ b/modules/kubernetes-addons/external-dns/README.md
@@ -44,6 +44,7 @@ For complete project documentation, please visit the [ExternalDNS Github reposit
 | <a name="input_irsa_policies"></a> [irsa\_policies](#input\_irsa\_policies) | Additional IAM policies used for the add-on service account. | `list(string)` | n/a | yes |
 | <a name="input_manage_via_gitops"></a> [manage\_via\_gitops](#input\_manage\_via\_gitops) | Determines if the add-on should be managed via GitOps. | `bool` | `false` | no |
 | <a name="input_private_zone"></a> [private\_zone](#input\_private\_zone) | Determines if referenced Route53 hosted zone is private. | `bool` | `false` | no |
+| <a name="input_timeouts"></a> [timeouts](#input\_timeouts) | Define maximum timeout for creating, updating, and deleting resources | `map(string)` | `{}` | no |
 
 ## Outputs
 

--- a/modules/kubernetes-addons/external-dns/main.tf
+++ b/modules/kubernetes-addons/external-dns/main.tf
@@ -9,6 +9,7 @@ module "helm_addon" {
   set_values        = local.set_values
   addon_context     = var.addon_context
   manage_via_gitops = var.manage_via_gitops
+  timeouts          = var.timeouts
 }
 
 #------------------------------------

--- a/modules/kubernetes-addons/external-dns/variables.tf
+++ b/modules/kubernetes-addons/external-dns/variables.tf
@@ -42,3 +42,9 @@ variable "addon_context" {
     irsa_iam_permissions_boundary  = string
   })
 }
+
+variable "timeouts" {
+  description = "Define maximum timeout for creating, updating, and deleting resources"
+  type        = map(string)
+  default     = {}
+}

--- a/modules/kubernetes-addons/external-secrets/README.md
+++ b/modules/kubernetes-addons/external-secrets/README.md
@@ -35,6 +35,7 @@ External Secrets Operator is a Kubernetes operator that integrates external secr
 | <a name="input_addon_context"></a> [addon\_context](#input\_addon\_context) | Input configuration for the addon | <pre>object({<br>    aws_caller_identity_account_id = string<br>    aws_caller_identity_arn        = string<br>    aws_eks_cluster_endpoint       = string<br>    aws_partition_id               = string<br>    aws_region_name                = string<br>    eks_cluster_id                 = string<br>    eks_oidc_issuer_url            = string<br>    eks_oidc_provider_arn          = string<br>    tags                           = map(string)<br>  })</pre> | n/a | yes |
 | <a name="input_helm_config"></a> [helm\_config](#input\_helm\_config) | Helm provider config for External Secrets Operator | `any` | `{}` | no |
 | <a name="input_manage_via_gitops"></a> [manage\_via\_gitops](#input\_manage\_via\_gitops) | Determines if the add-on should be managed via GitOps | `bool` | `false` | no |
+| <a name="input_timeouts"></a> [timeouts](#input\_timeouts) | Define maximum timeout for creating, updating, and deleting resources | `map(string)` | `{}` | no |
 
 ## Outputs
 

--- a/modules/kubernetes-addons/external-secrets/main.tf
+++ b/modules/kubernetes-addons/external-secrets/main.tf
@@ -4,6 +4,7 @@ module "helm_addon" {
   helm_config       = local.helm_config
   irsa_config       = null
   addon_context     = var.addon_context
+  timeouts          = var.timeouts
 
   depends_on = [kubernetes_namespace_v1.this]
 }

--- a/modules/kubernetes-addons/external-secrets/variables.tf
+++ b/modules/kubernetes-addons/external-secrets/variables.tf
@@ -24,3 +24,9 @@ variable "addon_context" {
   })
   description = "Input configuration for the addon"
 }
+
+variable "timeouts" {
+  description = "Define maximum timeout for creating, updating, and deleting resources"
+  type        = map(string)
+  default     = {}
+}

--- a/modules/kubernetes-addons/helm-addon/README.md
+++ b/modules/kubernetes-addons/helm-addon/README.md
@@ -43,6 +43,7 @@ Helm Addon module can be used to provision a generic Helm Chart as an Add-On for
 | <a name="input_manage_via_gitops"></a> [manage\_via\_gitops](#input\_manage\_via\_gitops) | Determines if the add-on should be managed via GitOps | `bool` | `false` | no |
 | <a name="input_set_sensitive_values"></a> [set\_sensitive\_values](#input\_set\_sensitive\_values) | Forced set\_sensitive values | `any` | `[]` | no |
 | <a name="input_set_values"></a> [set\_values](#input\_set\_values) | Forced set values | `any` | `[]` | no |
+| <a name="input_timeouts"></a> [timeouts](#input\_timeouts) | Define maximum timeout for creating, updating, and deleting resources | `map(string)` | `{}` | no |
 
 ## Outputs
 

--- a/modules/kubernetes-addons/helm-addon/main.tf
+++ b/modules/kubernetes-addons/helm-addon/main.tf
@@ -67,4 +67,5 @@ module "irsa" {
   kubernetes_service_account        = var.irsa_config.kubernetes_service_account
   irsa_iam_policies                 = var.irsa_config.irsa_iam_policies
   addon_context                     = var.addon_context
+  timeouts                          = var.timeouts
 }

--- a/modules/kubernetes-addons/helm-addon/variables.tf
+++ b/modules/kubernetes-addons/helm-addon/variables.tf
@@ -49,3 +49,9 @@ variable "addon_context" {
     irsa_iam_permissions_boundary  = optional(string)
   })
 }
+
+variable "timeouts" {
+  description = "Define maximum timeout for creating, updating, and deleting resources"
+  type        = map(string)
+  default     = {}
+}

--- a/modules/kubernetes-addons/ingress-nginx/README.md
+++ b/modules/kubernetes-addons/ingress-nginx/README.md
@@ -38,6 +38,7 @@ For more details [Ingress-Nginx can be found here](https://kubernetes.github.io/
 | <a name="input_addon_context"></a> [addon\_context](#input\_addon\_context) | Input configuration for the addon | <pre>object({<br>    aws_caller_identity_account_id = string<br>    aws_caller_identity_arn        = string<br>    aws_eks_cluster_endpoint       = string<br>    aws_partition_id               = string<br>    aws_region_name                = string<br>    eks_cluster_id                 = string<br>    eks_oidc_issuer_url            = string<br>    eks_oidc_provider_arn          = string<br>    tags                           = map(string)<br>  })</pre> | n/a | yes |
 | <a name="input_helm_config"></a> [helm\_config](#input\_helm\_config) | Ingress NGINX Helm Configuration | `any` | `{}` | no |
 | <a name="input_manage_via_gitops"></a> [manage\_via\_gitops](#input\_manage\_via\_gitops) | Determines if the add-on should be managed via GitOps. | `bool` | `false` | no |
+| <a name="input_timeouts"></a> [timeouts](#input\_timeouts) | Define maximum timeout for creating, updating, and deleting resources | `map(string)` | `{}` | no |
 
 ## Outputs
 

--- a/modules/kubernetes-addons/ingress-nginx/main.tf
+++ b/modules/kubernetes-addons/ingress-nginx/main.tf
@@ -8,6 +8,7 @@ module "helm_addon" {
   helm_config       = local.helm_config
   irsa_config       = null
   addon_context     = var.addon_context
+  timeouts          = var.timeouts
 
   depends_on = [kubernetes_namespace_v1.this]
 }

--- a/modules/kubernetes-addons/ingress-nginx/variables.tf
+++ b/modules/kubernetes-addons/ingress-nginx/variables.tf
@@ -24,3 +24,9 @@ variable "addon_context" {
     tags                           = map(string)
   })
 }
+
+variable "timeouts" {
+  description = "Define maximum timeout for creating, updating, and deleting resources"
+  type        = map(string)
+  default     = {}
+}

--- a/modules/kubernetes-addons/karpenter/README.md
+++ b/modules/kubernetes-addons/karpenter/README.md
@@ -40,6 +40,7 @@ For more details checkout [Karpenter](https://karpenter.sh/docs/getting-started/
 | <a name="input_irsa_policies"></a> [irsa\_policies](#input\_irsa\_policies) | Additional IAM policies for a IAM role for service accounts | `list(string)` | `[]` | no |
 | <a name="input_manage_via_gitops"></a> [manage\_via\_gitops](#input\_manage\_via\_gitops) | Determines if the add-on should be managed via GitOps. | `bool` | `false` | no |
 | <a name="input_node_iam_instance_profile"></a> [node\_iam\_instance\_profile](#input\_node\_iam\_instance\_profile) | Karpenter Node IAM Instance profile id | `string` | `""` | no |
+| <a name="input_timeouts"></a> [timeouts](#input\_timeouts) | Define maximum timeout for creating, updating, and deleting resources | `map(string)` | `{}` | no |
 
 ## Outputs
 

--- a/modules/kubernetes-addons/karpenter/main.tf
+++ b/modules/kubernetes-addons/karpenter/main.tf
@@ -5,6 +5,7 @@ module "helm_addon" {
   set_values        = local.set_values
   irsa_config       = local.irsa_config
   addon_context     = var.addon_context
+  timeouts          = var.timeouts
 }
 
 resource "aws_iam_policy" "karpenter" {

--- a/modules/kubernetes-addons/karpenter/variables.tf
+++ b/modules/kubernetes-addons/karpenter/variables.tf
@@ -38,3 +38,9 @@ variable "addon_context" {
     irsa_iam_permissions_boundary  = string
   })
 }
+
+variable "timeouts" {
+  description = "Define maximum timeout for creating, updating, and deleting resources"
+  type        = map(string)
+  default     = {}
+}

--- a/modules/kubernetes-addons/keda/README.md
+++ b/modules/kubernetes-addons/keda/README.md
@@ -51,6 +51,7 @@ kubectl delete apiservice v1beta1.external.metrics.k8s.io
 | <a name="input_helm_config"></a> [helm\_config](#input\_helm\_config) | Helm provider config for the KEDA | `any` | `{}` | no |
 | <a name="input_irsa_policies"></a> [irsa\_policies](#input\_irsa\_policies) | IAM Policy ARN list for any IRSA policies | `list(string)` | `[]` | no |
 | <a name="input_manage_via_gitops"></a> [manage\_via\_gitops](#input\_manage\_via\_gitops) | Determines if the add-on should be managed via GitOps | `bool` | `false` | no |
+| <a name="input_timeouts"></a> [timeouts](#input\_timeouts) | Define maximum timeout for creating, updating, and deleting resources | `map(string)` | `{}` | no |
 
 ## Outputs
 

--- a/modules/kubernetes-addons/keda/main.tf
+++ b/modules/kubernetes-addons/keda/main.tf
@@ -5,6 +5,7 @@ module "helm_addon" {
   helm_config       = local.helm_config
   irsa_config       = local.irsa_config
   addon_context     = var.addon_context
+  timeouts          = var.timeouts
 }
 
 resource "aws_iam_policy" "keda_irsa" {

--- a/modules/kubernetes-addons/keda/variables.tf
+++ b/modules/kubernetes-addons/keda/variables.tf
@@ -32,3 +32,9 @@ variable "addon_context" {
     irsa_iam_permissions_boundary  = string
   })
 }
+
+variable "timeouts" {
+  description = "Define maximum timeout for creating, updating, and deleting resources"
+  type        = map(string)
+  default     = {}
+}

--- a/modules/kubernetes-addons/kubernetes-dashboard/README.md
+++ b/modules/kubernetes-addons/kubernetes-dashboard/README.md
@@ -39,6 +39,7 @@ This add-on bootstraps the Kubernetes Dashboard on the EKS cluster using a [helm
 | <a name="input_addon_context"></a> [addon\_context](#input\_addon\_context) | Input configuration for the addon | <pre>object({<br>    aws_caller_identity_account_id = string<br>    aws_caller_identity_arn        = string<br>    aws_eks_cluster_endpoint       = string<br>    aws_partition_id               = string<br>    aws_region_name                = string<br>    eks_cluster_id                 = string<br>    eks_oidc_issuer_url            = string<br>    eks_oidc_provider_arn          = string<br>    tags                           = map(string)<br>  })</pre> | n/a | yes |
 | <a name="input_helm_config"></a> [helm\_config](#input\_helm\_config) | Helm provider config for the Kubernetes Dashboard | `any` | `{}` | no |
 | <a name="input_manage_via_gitops"></a> [manage\_via\_gitops](#input\_manage\_via\_gitops) | Determines if the add-on should be managed via GitOps | `bool` | `false` | no |
+| <a name="input_timeouts"></a> [timeouts](#input\_timeouts) | Define maximum timeout for creating, updating, and deleting resources | `map(string)` | `{}` | no |
 
 ## Outputs
 

--- a/modules/kubernetes-addons/kubernetes-dashboard/main.tf
+++ b/modules/kubernetes-addons/kubernetes-dashboard/main.tf
@@ -4,6 +4,7 @@ module "helm_addon" {
   helm_config       = local.helm_config
   irsa_config       = null
   addon_context     = var.addon_context
+  timeouts          = var.timeouts
 
   depends_on = [kubernetes_namespace_v1.this]
 }

--- a/modules/kubernetes-addons/kubernetes-dashboard/variables.tf
+++ b/modules/kubernetes-addons/kubernetes-dashboard/variables.tf
@@ -24,3 +24,9 @@ variable "addon_context" {
     tags                           = map(string)
   })
 }
+
+variable "timeouts" {
+  description = "Define maximum timeout for creating, updating, and deleting resources"
+  type        = map(string)
+  default     = {}
+}

--- a/modules/kubernetes-addons/main.tf
+++ b/modules/kubernetes-addons/main.tf
@@ -6,6 +6,7 @@ module "aws_vpc_cni" {
   addon_config  = var.amazon_eks_vpc_cni_config
   addon_context = local.addon_context
   enable_ipv6   = var.enable_ipv6
+  timeouts      = var.timeouts
 }
 
 module "aws_coredns" {
@@ -36,6 +37,7 @@ module "aws_coredns" {
       image_registry = local.amazon_container_image_registry_uris[data.aws_region.current.name]
     }
   )
+  timeouts = var.timeouts
 }
 
 module "aws_kube_proxy" {
@@ -50,6 +52,7 @@ module "aws_ebs_csi_driver" {
   source        = "./aws-ebs-csi-driver"
   addon_config  = var.amazon_eks_aws_ebs_csi_driver_config
   addon_context = local.addon_context
+  timeouts      = var.timeouts
 }
 
 #-----------------Kubernetes Add-ons----------------------
@@ -61,6 +64,7 @@ module "agones" {
   eks_worker_security_group_id = var.eks_worker_security_group_id
   manage_via_gitops            = var.argocd_manage_add_ons
   addon_context                = local.addon_context
+  timeouts                     = var.timeouts
 }
 
 module "argocd" {
@@ -71,6 +75,7 @@ module "argocd" {
   admin_password_secret_name = var.argocd_admin_password_secret_name
   addon_config               = { for k, v in local.argocd_addon_config : k => v if v != null }
   addon_context              = local.addon_context
+  timeouts                   = var.timeouts
 }
 
 module "argo_rollouts" {
@@ -79,6 +84,7 @@ module "argo_rollouts" {
   helm_config       = var.argo_rollouts_helm_config
   manage_via_gitops = var.argocd_manage_add_ons
   addon_context     = local.addon_context
+  timeouts          = var.timeouts
 }
 
 module "aws_efs_csi_driver" {
@@ -87,6 +93,7 @@ module "aws_efs_csi_driver" {
   helm_config       = var.aws_efs_csi_driver_helm_config
   manage_via_gitops = var.argocd_manage_add_ons
   addon_context     = local.addon_context
+  timeouts          = var.timeouts
 }
 
 module "aws_for_fluent_bit" {
@@ -99,6 +106,7 @@ module "aws_for_fluent_bit" {
   cw_log_group_kms_key_arn = var.aws_for_fluentbit_cw_log_group_kms_key_arn
   manage_via_gitops        = var.argocd_manage_add_ons
   addon_context            = local.addon_context
+  timeouts                 = var.timeouts
 }
 
 module "aws_cloudwatch_metrics" {
@@ -108,6 +116,7 @@ module "aws_cloudwatch_metrics" {
   irsa_policies     = var.aws_cloudwatch_metrics_irsa_policies
   manage_via_gitops = var.argocd_manage_add_ons
   addon_context     = local.addon_context
+  timeouts          = var.timeouts
 }
 
 module "aws_load_balancer_controller" {
@@ -116,6 +125,7 @@ module "aws_load_balancer_controller" {
   helm_config       = var.aws_load_balancer_controller_helm_config
   manage_via_gitops = var.argocd_manage_add_ons
   addon_context     = merge(local.addon_context, { default_repository = local.amazon_container_image_registry_uris[data.aws_region.current.name] })
+  timeouts          = var.timeouts
 }
 
 module "aws_node_termination_handler" {
@@ -125,6 +135,7 @@ module "aws_node_termination_handler" {
   irsa_policies           = var.aws_node_termination_handler_irsa_policies
   autoscaling_group_names = var.auto_scaling_group_names
   addon_context           = local.addon_context
+  timeouts                = var.timeouts
 }
 
 module "cert_manager" {
@@ -137,6 +148,7 @@ module "cert_manager" {
   domain_names                = var.cert_manager_domain_names
   install_letsencrypt_issuers = var.cert_manager_install_letsencrypt_issuers
   letsencrypt_email           = var.cert_manager_letsencrypt_email
+  timeouts                    = var.timeouts
 }
 
 module "cluster_autoscaler" {
@@ -148,6 +160,7 @@ module "cluster_autoscaler" {
   helm_config         = var.cluster_autoscaler_helm_config
   manage_via_gitops   = var.argocd_manage_add_ons
   addon_context       = local.addon_context
+  timeouts            = var.timeouts
 }
 
 module "coredns_autoscaler" {
@@ -156,6 +169,7 @@ module "coredns_autoscaler" {
   helm_config       = var.coredns_autoscaler_helm_config
   manage_via_gitops = var.argocd_manage_add_ons
   addon_context     = local.addon_context
+  timeouts          = var.timeouts
 }
 
 module "crossplane" {
@@ -167,6 +181,7 @@ module "crossplane" {
   account_id       = data.aws_caller_identity.current.account_id
   aws_partition    = data.aws_partition.current.id
   addon_context    = local.addon_context
+  timeouts         = var.timeouts
 }
 
 module "external_dns" {
@@ -178,6 +193,7 @@ module "external_dns" {
   addon_context     = local.addon_context
   domain_name       = var.eks_cluster_domain
   private_zone      = var.external_dns_private_zone
+  timeouts          = var.timeouts
 }
 
 module "fargate_fluentbit" {
@@ -193,6 +209,7 @@ module "ingress_nginx" {
   helm_config       = var.ingress_nginx_helm_config
   manage_via_gitops = var.argocd_manage_add_ons
   addon_context     = local.addon_context
+  timeouts          = var.timeouts
 }
 
 module "karpenter" {
@@ -203,6 +220,7 @@ module "karpenter" {
   node_iam_instance_profile = var.karpenter_node_iam_instance_profile
   manage_via_gitops         = var.argocd_manage_add_ons
   addon_context             = local.addon_context
+  timeouts                  = var.timeouts
 }
 
 module "keda" {
@@ -212,6 +230,7 @@ module "keda" {
   irsa_policies     = var.keda_irsa_policies
   manage_via_gitops = var.argocd_manage_add_ons
   addon_context     = local.addon_context
+  timeouts          = var.timeouts
 }
 
 module "kubernetes_dashboard" {
@@ -220,6 +239,7 @@ module "kubernetes_dashboard" {
   helm_config       = var.kubernetes_dashboard_helm_config
   manage_via_gitops = var.argocd_manage_add_ons
   addon_context     = local.addon_context
+  timeouts          = var.timeouts
 }
 
 module "metrics_server" {
@@ -228,6 +248,7 @@ module "metrics_server" {
   helm_config       = var.metrics_server_helm_config
   manage_via_gitops = var.argocd_manage_add_ons
   addon_context     = local.addon_context
+  timeouts          = var.timeouts
 }
 
 module "ondat" {
@@ -256,6 +277,7 @@ module "prometheus" {
   amazon_prometheus_workspace_endpoint = var.amazon_prometheus_workspace_endpoint
   manage_via_gitops                    = var.argocd_manage_add_ons
   addon_context                        = local.addon_context
+  timeouts                             = var.timeouts
 }
 
 module "spark_k8s_operator" {
@@ -264,6 +286,7 @@ module "spark_k8s_operator" {
   helm_config       = var.spark_k8s_operator_helm_config
   manage_via_gitops = var.argocd_manage_add_ons
   addon_context     = local.addon_context
+  timeouts          = var.timeouts
 }
 
 module "tetrate_istio" {
@@ -290,6 +313,7 @@ module "traefik" {
   helm_config       = var.traefik_helm_config
   manage_via_gitops = var.argocd_manage_add_ons
   addon_context     = local.addon_context
+  timeouts          = var.timeouts
 }
 
 module "vault" {
@@ -310,6 +334,7 @@ module "vpa" {
   helm_config       = var.vpa_helm_config
   manage_via_gitops = var.argocd_manage_add_ons
   addon_context     = local.addon_context
+  timeouts          = var.timeouts
 }
 
 module "yunikorn" {
@@ -318,6 +343,7 @@ module "yunikorn" {
   helm_config       = var.yunikorn_helm_config
   manage_via_gitops = var.argocd_manage_add_ons
   addon_context     = local.addon_context
+  timeouts          = var.timeouts
 }
 
 module "csi_secrets_store_provider_aws" {
@@ -326,6 +352,7 @@ module "csi_secrets_store_provider_aws" {
   helm_config       = var.csi_secrets_store_provider_aws_helm_config
   manage_via_gitops = var.argocd_manage_add_ons
   addon_context     = local.addon_context
+  timeouts          = var.timeouts
 }
 
 module "secrets_store_csi_driver" {
@@ -334,6 +361,7 @@ module "secrets_store_csi_driver" {
   helm_config       = var.secrets_store_csi_driver_helm_config
   manage_via_gitops = var.argocd_manage_add_ons
   addon_context     = local.addon_context
+  timeouts          = var.timeouts
 }
 module "aws_privateca_issuer" {
   count                   = var.enable_aws_privateca_issuer ? 1 : 0
@@ -343,6 +371,7 @@ module "aws_privateca_issuer" {
   addon_context           = local.addon_context
   aws_privateca_acmca_arn = var.aws_privateca_acmca_arn
   irsa_policies           = var.aws_privateca_issuer_irsa_policies
+  timeouts                = var.timeouts
 }
 
 module "velero" {
@@ -353,6 +382,7 @@ module "velero" {
   addon_context     = local.addon_context
   irsa_policies     = var.velero_irsa_policies
   backup_s3_bucket  = var.velero_backup_s3_bucket
+  timeouts          = var.timeouts
 }
 
 module "opentelemetry_operator" {
@@ -374,6 +404,7 @@ module "opentelemetry_operator" {
   helm_config                   = var.opentelemetry_operator_helm_config
 
   addon_context = local.addon_context
+  timeouts      = var.timeouts
 }
 
 module "adot_collector_java" {
@@ -389,6 +420,7 @@ module "adot_collector_java" {
   depends_on = [
     module.opentelemetry_operator
   ]
+  timeouts = var.timeouts
 }
 
 module "adot_collector_haproxy" {
@@ -404,6 +436,7 @@ module "adot_collector_haproxy" {
   depends_on = [
     module.opentelemetry_operator
   ]
+  timeouts = var.timeouts
 }
 
 module "adot_collector_memcached" {
@@ -419,6 +452,7 @@ module "adot_collector_memcached" {
   depends_on = [
     module.opentelemetry_operator
   ]
+  timeouts = var.timeouts
 }
 
 module "adot_collector_nginx" {
@@ -434,6 +468,7 @@ module "adot_collector_nginx" {
   depends_on = [
     module.opentelemetry_operator
   ]
+  timeouts = var.timeouts
 }
 
 module "external_secrets" {
@@ -441,4 +476,5 @@ module "external_secrets" {
   source        = "./external-secrets"
   helm_config   = var.external_secrets_helm_config
   addon_context = local.addon_context
+  timeouts      = var.timeouts
 }

--- a/modules/kubernetes-addons/metrics-server/README.md
+++ b/modules/kubernetes-addons/metrics-server/README.md
@@ -33,6 +33,7 @@
 | <a name="input_addon_context"></a> [addon\_context](#input\_addon\_context) | Input configuration for the addon | <pre>object({<br>    aws_caller_identity_account_id = string<br>    aws_caller_identity_arn        = string<br>    aws_eks_cluster_endpoint       = string<br>    aws_partition_id               = string<br>    aws_region_name                = string<br>    eks_cluster_id                 = string<br>    eks_oidc_issuer_url            = string<br>    eks_oidc_provider_arn          = string<br>    tags                           = map(string)<br>  })</pre> | n/a | yes |
 | <a name="input_helm_config"></a> [helm\_config](#input\_helm\_config) | Helm provider config for Metrics Server | `any` | `{}` | no |
 | <a name="input_manage_via_gitops"></a> [manage\_via\_gitops](#input\_manage\_via\_gitops) | Determines if the add-on should be managed via GitOps | `bool` | `false` | no |
+| <a name="input_timeouts"></a> [timeouts](#input\_timeouts) | Define maximum timeout for creating, updating, and deleting resources | `map(string)` | `{}` | no |
 
 ## Outputs
 

--- a/modules/kubernetes-addons/metrics-server/main.tf
+++ b/modules/kubernetes-addons/metrics-server/main.tf
@@ -4,6 +4,7 @@ module "helm_addon" {
   helm_config       = local.helm_config
   irsa_config       = null
   addon_context     = var.addon_context
+  timeouts          = var.timeouts
 
   depends_on = [kubernetes_namespace_v1.this]
 }

--- a/modules/kubernetes-addons/metrics-server/variables.tf
+++ b/modules/kubernetes-addons/metrics-server/variables.tf
@@ -24,3 +24,9 @@ variable "addon_context" {
     tags                           = map(string)
   })
 }
+
+variable "timeouts" {
+  description = "Define maximum timeout for creating, updating, and deleting resources"
+  type        = map(string)
+  default     = {}
+}

--- a/modules/kubernetes-addons/opentelemetry-operator/README.md
+++ b/modules/kubernetes-addons/opentelemetry-operator/README.md
@@ -65,6 +65,7 @@ the ADOT Operator.
 | <a name="input_enable_amazon_eks_adot"></a> [enable\_amazon\_eks\_adot](#input\_enable\_amazon\_eks\_adot) | Enable Amazon EKS ADOT add-on | `bool` | `true` | no |
 | <a name="input_enable_opentelemetry_operator"></a> [enable\_opentelemetry\_operator](#input\_enable\_opentelemetry\_operator) | Enable opentelemetry operator addon | `bool` | `false` | no |
 | <a name="input_helm_config"></a> [helm\_config](#input\_helm\_config) | Helm provider config for ADOT Operator AddOn | `any` | `{}` | no |
+| <a name="input_timeouts"></a> [timeouts](#input\_timeouts) | Define maximum timeout for creating, updating, and deleting resources | `map(string)` | `{}` | no |
 
 ## Outputs
 

--- a/modules/kubernetes-addons/opentelemetry-operator/main.tf
+++ b/modules/kubernetes-addons/opentelemetry-operator/main.tf
@@ -294,6 +294,7 @@ module "helm_addon" {
   helm_config   = local.helm_config
   irsa_config   = null
   addon_context = var.addon_context
+  timeouts      = var.timeouts
 
   depends_on = [module.cert_manager]
 }

--- a/modules/kubernetes-addons/opentelemetry-operator/variables.tf
+++ b/modules/kubernetes-addons/opentelemetry-operator/variables.tf
@@ -37,3 +37,9 @@ variable "enable_opentelemetry_operator" {
   type        = bool
   default     = false
 }
+
+variable "timeouts" {
+  description = "Define maximum timeout for creating, updating, and deleting resources"
+  type        = map(string)
+  default     = {}
+}

--- a/modules/kubernetes-addons/prometheus/README.md
+++ b/modules/kubernetes-addons/prometheus/README.md
@@ -81,6 +81,7 @@ Repeat the above steps for other 4 images
 | <a name="input_enable_amazon_prometheus"></a> [enable\_amazon\_prometheus](#input\_enable\_amazon\_prometheus) | Enable AWS Managed Prometheus service | `bool` | `false` | no |
 | <a name="input_helm_config"></a> [helm\_config](#input\_helm\_config) | Helm Config for Prometheus | `any` | `{}` | no |
 | <a name="input_manage_via_gitops"></a> [manage\_via\_gitops](#input\_manage\_via\_gitops) | Determines if the add-on should be managed via GitOps. | `bool` | `false` | no |
+| <a name="input_timeouts"></a> [timeouts](#input\_timeouts) | Define maximum timeout for creating, updating, and deleting resources | `map(string)` | `{}` | no |
 
 ## Outputs
 

--- a/modules/kubernetes-addons/prometheus/main.tf
+++ b/modules/kubernetes-addons/prometheus/main.tf
@@ -63,6 +63,7 @@ module "helm_addon" {
 
   irsa_config   = null
   addon_context = var.addon_context
+  timeouts      = var.timeouts
 }
 
 resource "kubernetes_namespace_v1" "prometheus" {

--- a/modules/kubernetes-addons/prometheus/variables.tf
+++ b/modules/kubernetes-addons/prometheus/variables.tf
@@ -38,3 +38,9 @@ variable "addon_context" {
     irsa_iam_permissions_boundary  = string
   })
 }
+
+variable "timeouts" {
+  description = "Define maximum timeout for creating, updating, and deleting resources"
+  type        = map(string)
+  default     = {}
+}

--- a/modules/kubernetes-addons/secrets-store-csi-driver/main.tf
+++ b/modules/kubernetes-addons/secrets-store-csi-driver/main.tf
@@ -13,6 +13,7 @@ module "helm_addon" {
   manage_via_gitops = var.manage_via_gitops
   helm_config       = local.helm_config
   addon_context     = var.addon_context
+  timeouts          = var.timeouts
 
   depends_on = [kubernetes_namespace_v1.secrets_store_csi_driver]
 }

--- a/modules/kubernetes-addons/secrets-store-csi-driver/variables.tf
+++ b/modules/kubernetes-addons/secrets-store-csi-driver/variables.tf
@@ -26,3 +26,9 @@ variable "addon_context" {
   })
   description = "Input configuration for the addon"
 }
+
+variable "timeouts" {
+  description = "Define maximum timeout for creating, updating, and deleting resources"
+  type        = map(string)
+  default     = {}
+}

--- a/modules/kubernetes-addons/spark-k8s-operator/README.md
+++ b/modules/kubernetes-addons/spark-k8s-operator/README.md
@@ -36,6 +36,7 @@ It uses Kubernetes custom resources for specifying, running, and surfacing statu
 | <a name="input_addon_context"></a> [addon\_context](#input\_addon\_context) | Input configuration for the addon | <pre>object({<br>    aws_caller_identity_account_id = string<br>    aws_caller_identity_arn        = string<br>    aws_eks_cluster_endpoint       = string<br>    aws_partition_id               = string<br>    aws_region_name                = string<br>    eks_cluster_id                 = string<br>    eks_oidc_issuer_url            = string<br>    eks_oidc_provider_arn          = string<br>    tags                           = map(string)<br>  })</pre> | n/a | yes |
 | <a name="input_helm_config"></a> [helm\_config](#input\_helm\_config) | Helm provider config for Spark K8s Operator | `any` | `{}` | no |
 | <a name="input_manage_via_gitops"></a> [manage\_via\_gitops](#input\_manage\_via\_gitops) | Determines if the add-on should be managed via GitOps | `bool` | `false` | no |
+| <a name="input_timeouts"></a> [timeouts](#input\_timeouts) | Define maximum timeout for creating, updating, and deleting resources | `map(string)` | `{}` | no |
 
 ## Outputs
 

--- a/modules/kubernetes-addons/spark-k8s-operator/main.tf
+++ b/modules/kubernetes-addons/spark-k8s-operator/main.tf
@@ -4,6 +4,7 @@ module "helm_addon" {
   helm_config       = local.helm_config
   irsa_config       = null
   addon_context     = var.addon_context
+  timeouts          = var.timeouts
 
   depends_on = [kubernetes_namespace_v1.this]
 }

--- a/modules/kubernetes-addons/spark-k8s-operator/variables.tf
+++ b/modules/kubernetes-addons/spark-k8s-operator/variables.tf
@@ -24,3 +24,9 @@ variable "addon_context" {
     tags                           = map(string)
   })
 }
+
+variable "timeouts" {
+  description = "Define maximum timeout for creating, updating, and deleting resources"
+  type        = map(string)
+  default     = {}
+}

--- a/modules/kubernetes-addons/traefik/README.md
+++ b/modules/kubernetes-addons/traefik/README.md
@@ -37,6 +37,7 @@ Traefik is a modern HTTP reverse proxy and load balancer made to deploy microser
 | <a name="input_addon_context"></a> [addon\_context](#input\_addon\_context) | Input configuration for the addon | <pre>object({<br>    aws_caller_identity_account_id = string<br>    aws_caller_identity_arn        = string<br>    aws_eks_cluster_endpoint       = string<br>    aws_partition_id               = string<br>    aws_region_name                = string<br>    eks_cluster_id                 = string<br>    eks_oidc_issuer_url            = string<br>    eks_oidc_provider_arn          = string<br>    tags                           = map(string)<br>  })</pre> | n/a | yes |
 | <a name="input_helm_config"></a> [helm\_config](#input\_helm\_config) | Helm provider config for Traefik | `any` | `{}` | no |
 | <a name="input_manage_via_gitops"></a> [manage\_via\_gitops](#input\_manage\_via\_gitops) | Determines if the add-on should be managed via GitOps | `bool` | `false` | no |
+| <a name="input_timeouts"></a> [timeouts](#input\_timeouts) | Define maximum timeout for creating, updating, and deleting resources | `map(string)` | `{}` | no |
 
 ## Outputs
 

--- a/modules/kubernetes-addons/traefik/main.tf
+++ b/modules/kubernetes-addons/traefik/main.tf
@@ -4,6 +4,7 @@ module "helm_addon" {
   helm_config       = local.helm_config
   irsa_config       = null
   addon_context     = var.addon_context
+  timeouts          = var.timeouts
 
   depends_on = [kubernetes_namespace_v1.this]
 }

--- a/modules/kubernetes-addons/traefik/variables.tf
+++ b/modules/kubernetes-addons/traefik/variables.tf
@@ -24,3 +24,9 @@ variable "addon_context" {
     tags                           = map(string)
   })
 }
+
+variable "timeouts" {
+  description = "Define maximum timeout for creating, updating, and deleting resources"
+  type        = map(string)
+  default     = {}
+}

--- a/modules/kubernetes-addons/variables.tf
+++ b/modules/kubernetes-addons/variables.tf
@@ -902,3 +902,9 @@ variable "external_secrets_helm_config" {
   default     = {}
   description = "External Secrets operator Helm Chart config"
 }
+
+variable "timeouts" {
+  description = "Define maximum timeout for creating, updating, and deleting resources"
+  type        = map(string)
+  default     = {}
+}

--- a/modules/kubernetes-addons/velero/README.md
+++ b/modules/kubernetes-addons/velero/README.md
@@ -170,6 +170,7 @@ pod/nginx   1/1     Running   0          21s
 | <a name="input_helm_config"></a> [helm\_config](#input\_helm\_config) | Helm provider config for velero | `any` | `{}` | no |
 | <a name="input_irsa_policies"></a> [irsa\_policies](#input\_irsa\_policies) | Additional IAM policy ARNs for Velero IRSA | `list(string)` | `[]` | no |
 | <a name="input_manage_via_gitops"></a> [manage\_via\_gitops](#input\_manage\_via\_gitops) | Determines if the add-on should be managed via GitOps | `bool` | `false` | no |
+| <a name="input_timeouts"></a> [timeouts](#input\_timeouts) | Define maximum timeout for creating, updating, and deleting resources | `map(string)` | `{}` | no |
 
 ## Outputs
 

--- a/modules/kubernetes-addons/velero/main.tf
+++ b/modules/kubernetes-addons/velero/main.tf
@@ -52,6 +52,7 @@ module "helm_addon" {
 
   # Blueprints
   addon_context = var.addon_context
+  timeouts      = var.timeouts
 }
 
 # https://github.com/vmware-tanzu/velero-plugin-for-aws#option-1-set-permissions-with-an-iam-user

--- a/modules/kubernetes-addons/velero/variables.tf
+++ b/modules/kubernetes-addons/velero/variables.tf
@@ -38,3 +38,9 @@ variable "addon_context" {
     tags                           = map(string)
   })
 }
+
+variable "timeouts" {
+  description = "Define maximum timeout for creating, updating, and deleting resources"
+  type        = map(string)
+  default     = {}
+}

--- a/modules/kubernetes-addons/vpa/README.md
+++ b/modules/kubernetes-addons/vpa/README.md
@@ -42,6 +42,7 @@
 | <a name="input_addon_context"></a> [addon\_context](#input\_addon\_context) | Input configuration for the addon | <pre>object({<br>    aws_caller_identity_account_id = string<br>    aws_caller_identity_arn        = string<br>    aws_eks_cluster_endpoint       = string<br>    aws_partition_id               = string<br>    aws_region_name                = string<br>    eks_cluster_id                 = string<br>    eks_oidc_issuer_url            = string<br>    eks_oidc_provider_arn          = string<br>    tags                           = map(string)<br>  })</pre> | n/a | yes |
 | <a name="input_helm_config"></a> [helm\_config](#input\_helm\_config) | Helm provider config for VPA | `any` | `{}` | no |
 | <a name="input_manage_via_gitops"></a> [manage\_via\_gitops](#input\_manage\_via\_gitops) | Determines if the add-on should be managed via GitOps | `bool` | `false` | no |
+| <a name="input_timeouts"></a> [timeouts](#input\_timeouts) | Define maximum timeout for creating, updating, and deleting resources | `map(string)` | `{}` | no |
 
 ## Outputs
 

--- a/modules/kubernetes-addons/vpa/main.tf
+++ b/modules/kubernetes-addons/vpa/main.tf
@@ -4,6 +4,7 @@ module "helm_addon" {
   helm_config       = local.helm_config
   irsa_config       = null
   addon_context     = var.addon_context
+  timeouts          = var.timeouts
 
   depends_on = [kubernetes_namespace_v1.vpa]
 }

--- a/modules/kubernetes-addons/vpa/variables.tf
+++ b/modules/kubernetes-addons/vpa/variables.tf
@@ -24,3 +24,9 @@ variable "addon_context" {
     tags                           = map(string)
   })
 }
+
+variable "timeouts" {
+  description = "Define maximum timeout for creating, updating, and deleting resources"
+  type        = map(string)
+  default     = {}
+}

--- a/modules/kubernetes-addons/yunikorn/README.md
+++ b/modules/kubernetes-addons/yunikorn/README.md
@@ -41,6 +41,7 @@ Helm Chart Repo https://github.com/apache/incubator-yunikorn-release/tree/master
 | <a name="input_addon_context"></a> [addon\_context](#input\_addon\_context) | Input configuration for the addon | <pre>object({<br>    aws_caller_identity_account_id = string<br>    aws_caller_identity_arn        = string<br>    aws_eks_cluster_endpoint       = string<br>    aws_partition_id               = string<br>    aws_region_name                = string<br>    eks_cluster_id                 = string<br>    eks_oidc_issuer_url            = string<br>    eks_oidc_provider_arn          = string<br>    tags                           = map(string)<br>    irsa_iam_role_path             = string<br>    irsa_iam_permissions_boundary  = string<br>  })</pre> | n/a | yes |
 | <a name="input_helm_config"></a> [helm\_config](#input\_helm\_config) | Helm provider config for Yunikorn | `any` | `{}` | no |
 | <a name="input_manage_via_gitops"></a> [manage\_via\_gitops](#input\_manage\_via\_gitops) | Determines if the add-on should be managed via GitOps | `bool` | `false` | no |
+| <a name="input_timeouts"></a> [timeouts](#input\_timeouts) | Define maximum timeout for creating, updating, and deleting resources | `map(string)` | `{}` | no |
 
 ## Outputs
 

--- a/modules/kubernetes-addons/yunikorn/main.tf
+++ b/modules/kubernetes-addons/yunikorn/main.tf
@@ -4,6 +4,7 @@ module "helm_addon" {
   helm_config       = local.helm_config
   irsa_config       = null
   addon_context     = var.addon_context
+  timeouts          = var.timeouts
 
   depends_on = [kubernetes_namespace_v1.yunikorn]
 }

--- a/modules/kubernetes-addons/yunikorn/variables.tf
+++ b/modules/kubernetes-addons/yunikorn/variables.tf
@@ -26,3 +26,9 @@ variable "addon_context" {
     irsa_iam_permissions_boundary  = string
   })
 }
+
+variable "timeouts" {
+  description = "Define maximum timeout for creating, updating, and deleting resources"
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
### What does this PR do?

add "timeouts" option for kubernetes resources.

### Motivation

Due to a variety of factors, resource creation often does not complete within the default timeouts.

### More

- [ ] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [x] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

Perhaps the kubernetes_timeouts option is a better naming than the timeouts option?
https://github.com/aws-ia/terraform-aws-eks-blueprints/pull/734
