### PR TITLE
Generate IAM Policy with all required Actions

### DIFF
--- a/.github/workflows/e2e-parallel-full.yml
+++ b/.github/workflows/e2e-parallel-full.yml
@@ -118,4 +118,31 @@ jobs:
           kill ${{ env.iamlive_pid }}
           while $(kill -0 ${{ env.iamlive_pid }} 2>/dev/null); do sleep 1; done;
           cat ${HOME}/policy.json
-          aws s3 cp ${HOME}/policy.json s3://terraform-eks-blueprints-iam-policies-examples/${{ matrix.example_path }}.json
+          aws s3 cp ${HOME}/policy.json s3://eks-blueprints-iam-policies/${{ matrix.example_path }}.json
+
+    post_deploy:
+      if: ${{ always() }}
+      needs: [deploy]
+      permissions:
+        id-token: write
+        contents: read
+      name: Merge Policies and Print Final IAM Policy
+      runs-on: ubuntu-latest
+      steps:
+        # Be careful not to change this to explicit checkout from PR ref/code, as below we run a python code that may change from the PR code.
+        - name: Checkout
+          uses: actions/checkout@v3
+
+        - name: Configure AWS credentials from Test account
+          uses: aws-actions/configure-aws-credentials@v1
+          with:
+            role-to-assume: ${{ secrets.ROLE_TO_ASSUME }}
+            aws-region: us-west-2
+            role-duration-seconds: 3600
+            role-session-name: GithubActions-Session
+
+        - name: Merge iamlive IAM policies and Print Final Policy
+          id: dirs
+          run: |
+            pip3 install boto3
+            python3 .github/workflows/iam-policy-generator.py

--- a/.github/workflows/e2e-parallel-full.yml
+++ b/.github/workflows/e2e-parallel-full.yml
@@ -57,6 +57,19 @@ jobs:
           role-duration-seconds: 3600
           role-session-name: GithubActions-Session
 
+      - name: Iamlive Setup
+        run: |
+          #!/bin/bash
+          set -e
+          set -o pipefail
+          set -x
+          export IAMLIVE_VERSION=v0.48.0
+          wget -O iamlive.tar.gz "https://github.com/iann0036/iamlive/releases/download/${IAMLIVE_VERSION}/iamlive-${IAMLIVE_VERSION}-linux-amd64.tar.gz"
+          tar -xzf iamlive.tar.gz
+          chmod +x iamlive
+          IAMLIVE_PID=$(./iamlive --mode proxy --bind-addr 0.0.0.0:10080 --output-file ${HOME}/policy.json --refresh-rate 1 --sort-alphabetical --force-wildcard-resource --background)
+          echo "iamlive_pid=$IAMLIVE_PID" >> $GITHUB_ENV
+
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v2
         with:
@@ -67,6 +80,10 @@ jobs:
         working-directory: ${{ matrix.example_path }}
         run: |
           terraform init -upgrade=true
+          export HTTP_PROXY=http://127.0.0.1:10080
+          export HTTPS_PROXY=http://127.0.0.1:10080
+          export AWS_CA_BUNDLE="${HOME}/.iamlive/ca.pem"
+          export NO_PROXY=eks.amazonaws.com,github.io,fairwinds.com,crossplane.io,github.com,agones.dev,karpenter.sh,githubusercontent.com,storage.googleapis.com
           terraform apply -target=module.vpc -no-color -input=false -auto-approve
           terraform apply -target=module.eks_blueprints -no-color -input=false -auto-approve
           terraform apply -target=module.eks_blueprints_kubernetes_addons -no-color -input=false -auto-approve
@@ -77,6 +94,10 @@ jobs:
         working-directory: ${{ matrix.example_path }}
         run: |
           terraform init -upgrade=true
+          export HTTP_PROXY=http://127.0.0.1:10080
+          export HTTPS_PROXY=http://127.0.0.1:10080
+          export AWS_CA_BUNDLE="${HOME}/.iamlive/ca.pem"
+          export NO_PROXY=eks.amazonaws.com,github.io,fairwinds.com,crossplane.io,github.com,agones.dev,karpenter.sh,githubusercontent.com,storage.googleapis.com
           terraform destroy -target=module.eks_blueprints_kubernetes_addons  -no-color -input=false -auto-approve
           terraform destroy -target=module.eks_blueprints  -no-color -input=false -auto-approve
           terraform destroy -no-color -input=false -auto-approve
@@ -86,4 +107,15 @@ jobs:
         run: |
           echo "Terraform Apply step failed...Please check the logs of the Terraform Apply step."
           echo "Failing the job to avoid false positives."
+          kill ${{ env.iamlive_pid }}
+          while $(kill -0 ${{ env.iamlive_pid }} 2>/dev/null); do sleep 1; done;
+          cat ${HOME}/policy.json
           exit 1
+
+      - name: Iamlive Print & Upload Policy
+        if: ${{ always() }}
+        run: |
+          kill ${{ env.iamlive_pid }}
+          while $(kill -0 ${{ env.iamlive_pid }} 2>/dev/null); do sleep 1; done;
+          cat ${HOME}/policy.json
+          aws s3 cp ${HOME}/policy.json s3://terraform-eks-blueprints-iam-policies-examples/${{ matrix.example_path }}.json

--- a/.github/workflows/iam-policy-generator.py
+++ b/.github/workflows/iam-policy-generator.py
@@ -1,0 +1,34 @@
+import json
+import boto3
+
+iam_actions = []
+s3 = boto3.resource('s3')
+bucket_name = 'terraform-eks-blueprints-iam-policies-examples'
+bucket = s3.Bucket(bucket_name)
+bucket_files = [x.key for x in bucket.objects.all()]
+
+# Read all the files from the bucket
+for file in bucket_files:
+    obj = s3.Object(bucket_name, file)
+    f = obj.get()['Body'].read()
+    data = json.loads(f)
+    # Merge all policies actions, keep them unique with 'set'
+    for statement in data['Statement']:
+        iam_actions = list(set(iam_actions + statement['Action']))
+
+# Skeleton IAM policy template , wild card all resources for now.
+template = {
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+            ],
+            "Resource": "*"
+        }
+    ]
+}
+
+# Apply merged actions to the skeleton IAM policy
+template['Statement'][0]['Action'] = sorted(iam_actions)
+print(json.dumps(template, indent=4))


### PR DESCRIPTION
### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
- Generates IAM policy using [iamlive](https://github.com/iann0036/iamlive) 
  - During e2e parallel workflow, each example will have iamlive running and it will print out the result, once done will upload the result to s3 bucket
  - At the end of the workflow, the workflow will run a python script reading each of the files in the bucket (each policy generated ) and will merge it into a single policy, and will print it out.

### Motivation

<!-- What inspired you to submit this pull request? -->
- https://github.com/aws-ia/terraform-aws-eks-blueprints/issues/562
- Customers may want to have explicit list of IAM actions required per example or/and for overall using EKS Blueprints.

### More

- [X] Yes, I have tested the PR using my local account setup  (https://github.com/Zvikan/terraform-aws-eks-blueprints/runs/7204477652?check_suite_focus=true)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
