### PR TITLE
fix: unique NTH event rules names per cluster id

### DIFF
--- a/modules/kubernetes-addons/aws-node-termination-handler/locals.tf
+++ b/modules/kubernetes-addons/aws-node-termination-handler/locals.tf
@@ -49,31 +49,31 @@ locals {
   event_rules = flatten([
     length(var.autoscaling_group_names) > 0 ?
     [{
-      name          = "NTHASGTermRule",
+      name          = substr("NTHASGTermRule-${var.addon_context.eks_cluster_id}", 0, 63),
       event_pattern = <<EOF
 {"source":["aws.autoscaling"],"detail-type":["EC2 Instance-terminate Lifecycle Action"]}
 EOF
     }] : [],
     {
-      name          = "NTHSpotTermRule",
+      name          = substr("NTHSpotTermRule-${var.addon_context.eks_cluster_id}", 0, 63),
       event_pattern = <<EOF
 {"source": ["aws.ec2"],"detail-type": ["EC2 Spot Instance Interruption Warning"]}
 EOF
     },
     {
-      name          = "NTHRebalanceRule",
+      name          = substr("NTHRebalanceRule-${var.addon_context.eks_cluster_id}", 0, 63),
       event_pattern = <<EOF
 {"source": ["aws.ec2"],"detail-type": ["EC2 Instance Rebalance Recommendation"]}
 EOF
     },
     {
-      name          = "NTHInstanceStateChangeRule",
+      name          = substr("NTHInstanceStateChangeRule-${var.addon_context.eks_cluster_id}", 0, 63),
       event_pattern = <<EOF
 {"source": ["aws.ec2"],"detail-type": ["EC2 Instance State-change Notification"]}
 EOF
     },
     {
-      name          = "NTHScheduledChangeRule",
+      name          = substr("NTHScheduledChangeRule-${var.addon_context.eks_cluster_id}", 0, 63),
       event_pattern = <<EOF
 {"source": ["aws.health"],"detail-type": ["AWS Health Event"]}
 EOF


### PR DESCRIPTION
### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
- Adjust NTH event rules names to be unique using cluster id and ensuring string is limited to 64 chars per [docs](https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_Rule.html) 

### Motivation

<!-- What inspired you to submit this pull request? -->
- https://github.com/aws-ia/terraform-aws-eks-blueprints/issues/708
- https://github.com/aws-ia/terraform-aws-eks-blueprints/runs/7237688237?check_suite_focus=true
### More

- [ ] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
