### PR TITLE
hotfix: remove grafana secret from spark example until fixed

### DIFF
--- a/examples/analytics/spark-k8s-operator/main.tf
+++ b/examples/analytics/spark-k8s-operator/main.tf
@@ -202,7 +202,6 @@ module "eks_blueprints_kubernetes_addons" {
   # Open Source Grafana Add-on
   #---------------------------------------------------------------
   enable_grafana                     = true
-  grafana_admin_password_secret_name = ""
 
   tags = local.tags
 }

--- a/examples/analytics/spark-k8s-operator/main.tf
+++ b/examples/analytics/spark-k8s-operator/main.tf
@@ -41,7 +41,6 @@ locals {
   vpc_cidr                           = "10.0.0.0/16"
   azs                                = slice(data.aws_availability_zones.available.names, 0, 3)
   s3_prefix                          = "logs/"
-  grafana_admin_password_secret_name = "grafana"
 
   tags = {
     Blueprint  = local.name

--- a/examples/analytics/spark-k8s-operator/main.tf
+++ b/examples/analytics/spark-k8s-operator/main.tf
@@ -202,29 +202,11 @@ module "eks_blueprints_kubernetes_addons" {
   # Open Source Grafana Add-on
   #---------------------------------------------------------------
   enable_grafana                     = true
-  grafana_admin_password_secret_name = local.grafana_admin_password_secret_name
+  grafana_admin_password_secret_name = ""
 
   tags = local.tags
 }
 
-#---------------------------------------------------------------
-# Grafana Admin credentials resources
-# Login to AWS secrets manager with the same role as Terraform to extract the Grafana admin password with the secret name as "grafana"
-#---------------------------------------------------------------
-resource "random_password" "grafana" {
-  length           = 16
-  special          = true
-  override_special = "!#$%&*()-_=+[]{}<>:?"
-}
-
-resource "aws_secretsmanager_secret" "grafana" {
-  name = local.grafana_admin_password_secret_name
-}
-
-resource "aws_secretsmanager_secret_version" "grafana" {
-  secret_id     = aws_secretsmanager_secret.grafana.id
-  secret_string = random_password.grafana.result
-}
 
 module "managed_prometheus" {
   source  = "terraform-aws-modules/managed-service-prometheus/aws"

--- a/examples/analytics/spark-k8s-operator/main.tf
+++ b/examples/analytics/spark-k8s-operator/main.tf
@@ -201,7 +201,7 @@ module "eks_blueprints_kubernetes_addons" {
   #---------------------------------------------------------------
   # Open Source Grafana Add-on
   #---------------------------------------------------------------
-  enable_grafana                     = true
+  enable_grafana = true
 
   tags = local.tags
 }

--- a/examples/analytics/spark-k8s-operator/main.tf
+++ b/examples/analytics/spark-k8s-operator/main.tf
@@ -38,9 +38,9 @@ locals {
   name   = basename(path.cwd)
   region = "us-west-2"
 
-  vpc_cidr                           = "10.0.0.0/16"
-  azs                                = slice(data.aws_availability_zones.available.names, 0, 3)
-  s3_prefix                          = "logs/"
+  vpc_cidr  = "10.0.0.0/16"
+  azs       = slice(data.aws_availability_zones.available.names, 0, 3)
+  s3_prefix = "logs/"
 
   tags = {
     Blueprint  = local.name


### PR DESCRIPTION
### What does this PR do?

- Removing grafana secret manager password from spark example. 
<!-- A brief description of the change being made with this pull request. -->


### Motivation

<!-- What inspired you to submit this pull request? -->
- Post https://github.com/aws-ia/terraform-aws-eks-blueprints/pull/735 there are pre-commit issues and failures with tf plan and apply to the spark example due to the implementation to the secret manager handling. This is currently blocking other on-going work. 
- https://github.com/aws-ia/terraform-aws-eks-blueprints/runs/7239480579?check_suite_focus=true
- https://github.com/aws-ia/terraform-aws-eks-blueprints/runs/7239282268?check_suite_focus=true
- Tried to hotfix it by changing code to use implicit dependency between resource to `grafana_admin_password_secret_name` - lead to the following error:
```
 Error: Invalid count argument
│
│   on ../../../modules/kubernetes-addons/grafana/data.tf line 3, in data "aws_secretsmanager_secret" "admin_password":
│    3:   count = var.grafana_admin_password_secret_name == "" ? 0 : 1
│
│ The "count" value depends on resource attributes that cannot be determined until apply, so Terraform cannot predict how many instances will be created. To work around this, use the -target argument to first
│ apply only the resources that the count depends on.
``` 

Removing for now until fixed, also enabled status checkes to be required before merging.



### More

- [ ] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
