### PR TITLE
Allows users to pass thier own secrets to Grafana admin

### DIFF
--- a/docs/add-ons/grafana.md
+++ b/docs/add-ons/grafana.md
@@ -8,22 +8,18 @@ You can add more data sources using the [values.yaml](https://github.com/grafana
 
 ## Usage
 
-[Grafana](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/modules/kubernetes-addons/spark-k8s-operator) can be deployed by enabling the add-on via the following.
+[Grafana](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/modules/kubernetes-addons/spark-k8s-operator) can be deployed by enabling the add-on via the following. This example shows the usage of the Secrets Manager to create a new secret for Grafana adminPassword.
 
-`grafana_admin_password_secret_name` is an optional parameter however it's recommended for security best practise.
-Checkout the above usage example to create secrets on the fly using Terraform.
-You can leave this blank and pass `adminPassword` chart value through `values.yaml` when you use secrets other than Secrets manager.
-
+This option sets a default `adminPassword` by the helm chart which can be extracted from kubernetes `secrets` with the name as `grafana`.   
 ```
 enable_grafana = true
-grafana_admin_password_secret_name = <aws_secrets_manager_secret_name> # optional
 ```
 
 You can optionally customize the Helm chart that deploys `Grafana` via the following configuration.
+Also, provide the `adminPassword` using set_sensitive values as shown in the example
 
 ```
   enable_grafana = true
-  grafana_admin_password_secret_name = "<aws_secrets_manager_secret_name>"
   grafana_irsa_policies = [] # Optional to add additional policies to IRSA
 
 # Optional  karpenter_helm_config
@@ -35,6 +31,12 @@ You can optionally customize the Helm chart that deploys `Grafana` via the follo
     namespace   = "grafana"
     description = "Grafana Helm Chart deployment configuration"
     values = [templatefile("${path.module}/values.yaml", {})]
+    set_sensitive = [
+      {
+        name  = "adminPassword"
+        value = "<YOUR_SECURE_PASSWORD_FOR_GARFANA_ADMIN>"
+      }
+    ]
   }
 
 ```

--- a/docs/add-ons/grafana.md
+++ b/docs/add-ons/grafana.md
@@ -10,7 +10,7 @@ You can add more data sources using the [values.yaml](https://github.com/grafana
 
 [Grafana](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/modules/kubernetes-addons/spark-k8s-operator) can be deployed by enabling the add-on via the following. This example shows the usage of the Secrets Manager to create a new secret for Grafana adminPassword.
 
-This option sets a default `adminPassword` by the helm chart which can be extracted from kubernetes `secrets` with the name as `grafana`.   
+This option sets a default `adminPassword` by the helm chart which can be extracted from kubernetes `secrets` with the name as `grafana`.  
 ```
 enable_grafana = true
 ```

--- a/examples/analytics/spark-k8s-operator/main.tf
+++ b/examples/analytics/spark-k8s-operator/main.tf
@@ -4,7 +4,7 @@ provider "aws" {
 
 provider "kubernetes" {
   host                   = data.aws_eks_cluster.cluster.endpoint
-  cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
+  cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority[0].data)
   token                  = data.aws_eks_cluster_auth.cluster.token
 }
 
@@ -12,7 +12,7 @@ provider "helm" {
   kubernetes {
     host                   = data.aws_eks_cluster.cluster.endpoint
     token                  = data.aws_eks_cluster_auth.cluster.token
-    cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
+    cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority[0].data)
   }
 }
 

--- a/examples/analytics/spark-k8s-operator/main.tf
+++ b/examples/analytics/spark-k8s-operator/main.tf
@@ -3,29 +3,25 @@ provider "aws" {
 }
 
 provider "kubernetes" {
-  host                   = module.eks_blueprints.eks_cluster_endpoint
-  cluster_ca_certificate = base64decode(module.eks_blueprints.eks_cluster_certificate_authority_data)
-
-  exec {
-    api_version = "client.authentication.k8s.io/v1beta1"
-    command     = "aws"
-    # This requires the awscli to be installed locally where Terraform is executed
-    args = ["eks", "get-token", "--cluster-name", module.eks_blueprints.eks_cluster_id]
-  }
+  host                   = data.aws_eks_cluster.cluster.endpoint
+  cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
+  token                  = data.aws_eks_cluster_auth.cluster.token
 }
 
 provider "helm" {
   kubernetes {
-    host                   = module.eks_blueprints.eks_cluster_endpoint
-    cluster_ca_certificate = base64decode(module.eks_blueprints.eks_cluster_certificate_authority_data)
-
-    exec {
-      api_version = "client.authentication.k8s.io/v1beta1"
-      command     = "aws"
-      # This requires the awscli to be installed locally where Terraform is executed
-      args = ["eks", "get-token", "--cluster-name", module.eks_blueprints.eks_cluster_id]
-    }
+    host                   = data.aws_eks_cluster.cluster.endpoint
+    token                  = data.aws_eks_cluster_auth.cluster.token
+    cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
   }
+}
+
+data "aws_eks_cluster" "cluster" {
+  name = module.eks_blueprints.eks_cluster_id
+}
+
+data "aws_eks_cluster_auth" "cluster" {
+  name = module.eks_blueprints.eks_cluster_id
 }
 
 data "aws_availability_zones" "available" {}
@@ -38,10 +34,9 @@ locals {
   name   = basename(path.cwd)
   region = "us-west-2"
 
-  vpc_cidr                           = "10.0.0.0/16"
-  azs                                = slice(data.aws_availability_zones.available.names, 0, 3)
-  s3_prefix                          = "logs/"
-  grafana_admin_password_secret_name = "grafana"
+  vpc_cidr  = "10.0.0.0/16"
+  azs       = slice(data.aws_availability_zones.available.names, 0, 3)
+  s3_prefix = "logs/"
 
   tags = {
     Blueprint  = local.name
@@ -201,11 +196,23 @@ module "eks_blueprints_kubernetes_addons" {
   #---------------------------------------------------------------
   # Open Source Grafana Add-on
   #---------------------------------------------------------------
-  enable_grafana                     = true
-  grafana_admin_password_secret_name = local.grafana_admin_password_secret_name
+  enable_grafana = true
+
+  # This example shows how to set default password for grafana using SecretsManager and Helm Set sensitive values.
+  grafana_helm_config = {
+    set_sensitive = [
+      {
+        name  = "adminPassword"
+        value = data.aws_secretsmanager_secret_version.admin_password_version.secret_string
+      }
+    ]
+  }
 
   tags = local.tags
+
 }
+
+
 
 #---------------------------------------------------------------
 # Grafana Admin credentials resources
@@ -218,12 +225,19 @@ resource "random_password" "grafana" {
 }
 
 resource "aws_secretsmanager_secret" "grafana" {
-  name = local.grafana_admin_password_secret_name
+  name                    = "grafana"
+  recovery_window_in_days = 0 # Set to zero for this example to force delete during Terraform destroy
 }
 
 resource "aws_secretsmanager_secret_version" "grafana" {
   secret_id     = aws_secretsmanager_secret.grafana.id
   secret_string = random_password.grafana.result
+}
+
+data "aws_secretsmanager_secret_version" "admin_password_version" {
+  secret_id = aws_secretsmanager_secret.grafana.id
+
+  depends_on = [aws_secretsmanager_secret_version.grafana]
 }
 
 module "managed_prometheus" {
@@ -306,7 +320,7 @@ resource "aws_s3_bucket_public_access_block" "this" {
 }
 
 # Creating an s3 bucket prefix. Ensure you copy spark event logs under this path to visualize the dags
-resource "aws_s3_bucket_object" "this" {
+resource "aws_s3_object" "this" {
   bucket = aws_s3_bucket.this.id
   acl    = "private"
   key    = local.s3_prefix

--- a/examples/analytics/spark-k8s-operator/main.tf
+++ b/examples/analytics/spark-k8s-operator/main.tf
@@ -221,7 +221,7 @@ resource "random_password" "grafana" {
   special          = true
   override_special = "!#$%&*()-_=+[]{}<>:?"
 }
-
+#tfsec:ignore:aws-ssm-secret-use-customer-key
 resource "aws_secretsmanager_secret" "grafana" {
   name                    = "grafana"
   recovery_window_in_days = 0 # Set to zero for this example to force delete during Terraform destroy

--- a/examples/analytics/spark-k8s-operator/main.tf
+++ b/examples/analytics/spark-k8s-operator/main.tf
@@ -198,7 +198,7 @@ module "eks_blueprints_kubernetes_addons" {
   #---------------------------------------------------------------
   enable_grafana = true
 
-  # This example shows how to set default password for grafana using SecretsManager and Helm Set sensitive values.
+  # This example shows how to set default password for grafana using SecretsManager and Helm Chart set_sensitive values.
   grafana_helm_config = {
     set_sensitive = [
       {
@@ -211,8 +211,6 @@ module "eks_blueprints_kubernetes_addons" {
   tags = local.tags
 
 }
-
-
 
 #---------------------------------------------------------------
 # Grafana Admin credentials resources

--- a/examples/analytics/spark-k8s-operator/versions.tf
+++ b/examples/analytics/spark-k8s-operator/versions.tf
@@ -14,6 +14,10 @@ terraform {
       source  = "hashicorp/helm"
       version = ">= 2.4.1"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = "3.3.2"
+    }
   }
 
   # ##  Used for end-to-end testing on project; update to suit your needs

--- a/modules/kubernetes-addons/README.md
+++ b/modules/kubernetes-addons/README.md
@@ -177,7 +177,6 @@
 | <a name="input_external_dns_private_zone"></a> [external\_dns\_private\_zone](#input\_external\_dns\_private\_zone) | Determines if referenced Route53 zone is private. | `bool` | `false` | no |
 | <a name="input_external_secrets_helm_config"></a> [external\_secrets\_helm\_config](#input\_external\_secrets\_helm\_config) | External Secrets operator Helm Chart config | `any` | `{}` | no |
 | <a name="input_fargate_fluentbit_addon_config"></a> [fargate\_fluentbit\_addon\_config](#input\_fargate\_fluentbit\_addon\_config) | Fargate fluentbit add-on config | `any` | `{}` | no |
-| <a name="input_grafana_admin_password_secret_name"></a> [grafana\_admin\_password\_secret\_name](#input\_grafana\_admin\_password\_secret\_name) | Grafana Admin password Secrets Manager secret name | `string` | `""` | no |
 | <a name="input_grafana_helm_config"></a> [grafana\_helm\_config](#input\_grafana\_helm\_config) | Kubernetes Grafana Helm Chart config | `any` | `null` | no |
 | <a name="input_grafana_irsa_policies"></a> [grafana\_irsa\_policies](#input\_grafana\_irsa\_policies) | IAM policy ARNs for grafana IRSA | `list(string)` | `[]` | no |
 | <a name="input_ingress_nginx_helm_config"></a> [ingress\_nginx\_helm\_config](#input\_ingress\_nginx\_helm\_config) | Ingress Nginx Helm Chart config | `any` | `{}` | no |

--- a/modules/kubernetes-addons/grafana/README.md
+++ b/modules/kubernetes-addons/grafana/README.md
@@ -30,15 +30,12 @@ This add-on configures [Grafana Helm Chart](https://github.com/grafana/helm-char
 |------|------|
 | [aws_iam_policy.grafana](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy_document.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [aws_secretsmanager_secret.admin_password](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret) | data source |
-| [aws_secretsmanager_secret_version.admin_password_version](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret_version) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_addon_context"></a> [addon\_context](#input\_addon\_context) | Input configuration for the addon | <pre>object({<br>    aws_caller_identity_account_id = string<br>    aws_caller_identity_arn        = string<br>    aws_eks_cluster_endpoint       = string<br>    aws_partition_id               = string<br>    aws_region_name                = string<br>    eks_cluster_id                 = string<br>    eks_oidc_issuer_url            = string<br>    eks_oidc_provider_arn          = string<br>    tags                           = map(string)<br>    irsa_iam_role_path             = string<br>    irsa_iam_permissions_boundary  = string<br>  })</pre> | n/a | yes |
-| <a name="input_grafana_admin_password_secret_name"></a> [grafana\_admin\_password\_secret\_name](#input\_grafana\_admin\_password\_secret\_name) | Grafana Admin password secrets manager secret name | `string` | `""` | no |
 | <a name="input_helm_config"></a> [helm\_config](#input\_helm\_config) | Helm provider config for Grafana. | `any` | `{}` | no |
 | <a name="input_irsa_policies"></a> [irsa\_policies](#input\_irsa\_policies) | Additional IAM policies for a IAM role for service accounts | `list(string)` | `[]` | no |
 | <a name="input_manage_via_gitops"></a> [manage\_via\_gitops](#input\_manage\_via\_gitops) | Determines if the add-on should be managed via GitOps. | `bool` | `false` | no |

--- a/modules/kubernetes-addons/grafana/data.tf
+++ b/modules/kubernetes-addons/grafana/data.tf
@@ -1,14 +1,3 @@
-
-data "aws_secretsmanager_secret" "admin_password" {
-  count = var.grafana_admin_password_secret_name == "" ? 0 : 1
-  name  = var.grafana_admin_password_secret_name
-}
-
-data "aws_secretsmanager_secret_version" "admin_password_version" {
-  count     = var.grafana_admin_password_secret_name == "" ? 0 : 1
-  secret_id = data.aws_secretsmanager_secret.admin_password[0].id
-}
-
 data "aws_iam_policy_document" "this" {
   statement {
     sid       = "AllowReadingMetricsFromCloudWatch"

--- a/modules/kubernetes-addons/grafana/locals.tf
+++ b/modules/kubernetes-addons/grafana/locals.tf
@@ -32,13 +32,6 @@ locals {
     }
   ]
 
-  set_sensitive = var.grafana_admin_password_secret_name != "" ? [
-    {
-      name  = "adminPassword"
-      value = data.aws_secretsmanager_secret_version.admin_password_version[0].secret_string
-    }
-  ] : []
-
   irsa_config = {
     kubernetes_namespace              = local.helm_config["namespace"]
     kubernetes_service_account        = local.name

--- a/modules/kubernetes-addons/grafana/main.tf
+++ b/modules/kubernetes-addons/grafana/main.tf
@@ -1,11 +1,10 @@
 module "helm_addon" {
-  source               = "../helm-addon"
-  manage_via_gitops    = var.manage_via_gitops
-  set_values           = local.set_values
-  set_sensitive_values = local.set_sensitive
-  helm_config          = local.helm_config
-  irsa_config          = local.irsa_config
-  addon_context        = var.addon_context
+  source            = "../helm-addon"
+  manage_via_gitops = var.manage_via_gitops
+  set_values        = local.set_values
+  helm_config       = local.helm_config
+  irsa_config       = local.irsa_config
+  addon_context     = var.addon_context
 }
 
 resource "aws_iam_policy" "grafana" {

--- a/modules/kubernetes-addons/grafana/values.yaml
+++ b/modules/kubernetes-addons/grafana/values.yaml
@@ -29,7 +29,7 @@ nodeSelector:
 
 
 adminUser: admin
-# Use secrets manager to set the Admin password securely. Secrets name used for this addon is grafana_admin_password_secret_name
+# Set this password using set_sensitive values
 #adminPassword:
 
 persistence:

--- a/modules/kubernetes-addons/grafana/variables.tf
+++ b/modules/kubernetes-addons/grafana/variables.tf
@@ -16,12 +16,6 @@ variable "irsa_policies" {
   default     = []
 }
 
-variable "grafana_admin_password_secret_name" {
-  description = "Grafana Admin password secrets manager secret name"
-  type        = string
-  default     = ""
-}
-
 variable "addon_context" {
   description = "Input configuration for the addon"
   type = object({

--- a/modules/kubernetes-addons/main.tf
+++ b/modules/kubernetes-addons/main.tf
@@ -192,7 +192,6 @@ module "grafana" {
   source                             = "./grafana"
   helm_config                        = var.grafana_helm_config
   irsa_policies                      = var.grafana_irsa_policies
-  grafana_admin_password_secret_name = var.grafana_admin_password_secret_name
   manage_via_gitops                  = var.argocd_manage_add_ons
   addon_context                      = local.addon_context
 }

--- a/modules/kubernetes-addons/main.tf
+++ b/modules/kubernetes-addons/main.tf
@@ -188,12 +188,12 @@ module "fargate_fluentbit" {
 }
 
 module "grafana" {
-  count                              = var.enable_grafana ? 1 : 0
-  source                             = "./grafana"
-  helm_config                        = var.grafana_helm_config
-  irsa_policies                      = var.grafana_irsa_policies
-  manage_via_gitops                  = var.argocd_manage_add_ons
-  addon_context                      = local.addon_context
+  count             = var.enable_grafana ? 1 : 0
+  source            = "./grafana"
+  helm_config       = var.grafana_helm_config
+  irsa_policies     = var.grafana_irsa_policies
+  manage_via_gitops = var.argocd_manage_add_ons
+  addon_context     = local.addon_context
 }
 
 module "ingress_nginx" {

--- a/modules/kubernetes-addons/variables.tf
+++ b/modules/kubernetes-addons/variables.tf
@@ -946,9 +946,3 @@ variable "grafana_irsa_policies" {
   type        = list(string)
   default     = []
 }
-
-variable "grafana_admin_password_secret_name" {
-  description = "Grafana Admin password Secrets Manager secret name"
-  type        = string
-  default     = ""
-}


### PR DESCRIPTION
### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->

- Allows users to pass their secret to grafana adminPassword field through set_sensitive values
- Example added to create a new secret with Secrets Manager and pass that to Helm Chart


### Motivation

<!-- What inspired you to submit this pull request? -->


### More

- [x] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [x] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
