### PR TITLE
ArgoCD admin password update

### DIFF
--- a/examples/gitops/argocd/versions.tf
+++ b/examples/gitops/argocd/versions.tf
@@ -14,6 +14,10 @@ terraform {
       source  = "hashicorp/helm"
       version = ">= 2.4.1"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = "3.3.2"
+    }
   }
 
   # ##  Used for end-to-end testing on project; update to suit your needs

--- a/modules/kubernetes-addons/README.md
+++ b/modules/kubernetes-addons/README.md
@@ -88,7 +88,6 @@
 | <a name="input_amazon_prometheus_workspace_endpoint"></a> [amazon\_prometheus\_workspace\_endpoint](#input\_amazon\_prometheus\_workspace\_endpoint) | AWS Managed Prometheus WorkSpace Endpoint | `string` | `null` | no |
 | <a name="input_amazon_prometheus_workspace_region"></a> [amazon\_prometheus\_workspace\_region](#input\_amazon\_prometheus\_workspace\_region) | AWS Managed Prometheus WorkSpace Region | `string` | `null` | no |
 | <a name="input_argo_rollouts_helm_config"></a> [argo\_rollouts\_helm\_config](#input\_argo\_rollouts\_helm\_config) | Argo Rollouts Helm Chart config | `any` | `null` | no |
-| <a name="input_argocd_admin_password_secret_name"></a> [argocd\_admin\_password\_secret\_name](#input\_argocd\_admin\_password\_secret\_name) | Name for a secret stored in AWS Secrets Manager that contains the admin password | `string` | `""` | no |
 | <a name="input_argocd_applications"></a> [argocd\_applications](#input\_argocd\_applications) | Argo CD Applications config to bootstrap the cluster | `any` | `{}` | no |
 | <a name="input_argocd_helm_config"></a> [argocd\_helm\_config](#input\_argocd\_helm\_config) | Argo CD Kubernetes add-on config | `any` | `{}` | no |
 | <a name="input_argocd_manage_add_ons"></a> [argocd\_manage\_add\_ons](#input\_argocd\_manage\_add\_ons) | Enable managing add-on configuration via ArgoCD | `bool` | `false` | no |

--- a/modules/kubernetes-addons/argocd/README.md
+++ b/modules/kubernetes-addons/argocd/README.md
@@ -40,9 +40,7 @@ Application definitions, configurations, and environments should be declarative 
 | [kubectl_manifest.argocd_kustomize_application](https://registry.terraform.io/providers/gavinbunney/kubectl/latest/docs/resources/manifest) | resource |
 | [kubernetes_namespace_v1.this](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace_v1) | resource |
 | [kubernetes_secret.argocd_gitops](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
-| [aws_secretsmanager_secret.admin_password](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret) | data source |
 | [aws_secretsmanager_secret.ssh_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret) | data source |
-| [aws_secretsmanager_secret_version.admin_password_version](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret_version) | data source |
 | [aws_secretsmanager_secret_version.ssh_key_version](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret_version) | data source |
 
 ## Inputs
@@ -51,7 +49,6 @@ Application definitions, configurations, and environments should be declarative 
 |------|-------------|------|---------|:--------:|
 | <a name="input_addon_config"></a> [addon\_config](#input\_addon\_config) | Configuration for managing add-ons via ArgoCD | `any` | `{}` | no |
 | <a name="input_addon_context"></a> [addon\_context](#input\_addon\_context) | Input configuration for the addon | <pre>object({<br>    aws_caller_identity_account_id = string<br>    aws_caller_identity_arn        = string<br>    aws_eks_cluster_endpoint       = string<br>    aws_partition_id               = string<br>    aws_region_name                = string<br>    eks_cluster_id                 = string<br>    eks_oidc_issuer_url            = string<br>    eks_oidc_provider_arn          = string<br>    tags                           = map(string)<br>  })</pre> | n/a | yes |
-| <a name="input_admin_password_secret_name"></a> [admin\_password\_secret\_name](#input\_admin\_password\_secret\_name) | Name for a secret stored in AWS Secrets Manager that contains the admin password for ArgoCD. | `string` | `""` | no |
 | <a name="input_applications"></a> [applications](#input\_applications) | ArgoCD Application config used to bootstrap a cluster. | `any` | `{}` | no |
 | <a name="input_helm_config"></a> [helm\_config](#input\_helm\_config) | ArgoCD Helm Chart Config values | `any` | `{}` | no |
 

--- a/modules/kubernetes-addons/argocd/data.tf
+++ b/modules/kubernetes-addons/argocd/data.tf
@@ -1,18 +1,4 @@
 # ---------------------------------------------------------------------------------------------------------------------
-# Admin Password
-# ---------------------------------------------------------------------------------------------------------------------
-
-data "aws_secretsmanager_secret" "admin_password" {
-  count = var.admin_password_secret_name == "" ? 0 : 1
-  name  = var.admin_password_secret_name
-}
-
-data "aws_secretsmanager_secret_version" "admin_password_version" {
-  count     = var.admin_password_secret_name == "" ? 0 : 1
-  secret_id = data.aws_secretsmanager_secret.admin_password[0].id
-}
-
-# ---------------------------------------------------------------------------------------------------------------------
 # SSH Key
 # ---------------------------------------------------------------------------------------------------------------------
 

--- a/modules/kubernetes-addons/argocd/locals.tf
+++ b/modules/kubernetes-addons/argocd/locals.tf
@@ -1,14 +1,6 @@
 locals {
   default_helm_values = [templatefile("${path.module}/values.yaml", {})]
 
-  # Admin Password
-  set_sensitive = var.admin_password_secret_name != "" ? [
-    {
-      name  = "configs.secret.argocdServerAdminPassword"
-      value = data.aws_secretsmanager_secret_version.admin_password_version[0].secret_string
-    }
-  ] : []
-
   name      = "argo-cd"
   namespace = "argocd"
 

--- a/modules/kubernetes-addons/argocd/main.tf
+++ b/modules/kubernetes-addons/argocd/main.tf
@@ -1,9 +1,8 @@
 module "helm_addon" {
-  source               = "../helm-addon"
-  helm_config          = local.helm_config
-  irsa_config          = null
-  set_sensitive_values = local.set_sensitive
-  addon_context        = var.addon_context
+  source        = "../helm-addon"
+  helm_config   = local.helm_config
+  irsa_config   = null
+  addon_context = var.addon_context
 
   depends_on = [kubernetes_namespace_v1.this]
 }

--- a/modules/kubernetes-addons/argocd/variables.tf
+++ b/modules/kubernetes-addons/argocd/variables.tf
@@ -10,12 +10,6 @@ variable "applications" {
   default     = {}
 }
 
-variable "admin_password_secret_name" {
-  description = "Name for a secret stored in AWS Secrets Manager that contains the admin password for ArgoCD."
-  type        = string
-  default     = ""
-}
-
 variable "addon_config" {
   description = "Configuration for managing add-ons via ArgoCD"
   type        = any

--- a/modules/kubernetes-addons/main.tf
+++ b/modules/kubernetes-addons/main.tf
@@ -64,13 +64,12 @@ module "agones" {
 }
 
 module "argocd" {
-  count                      = var.enable_argocd ? 1 : 0
-  source                     = "./argocd"
-  helm_config                = var.argocd_helm_config
-  applications               = var.argocd_applications
-  admin_password_secret_name = var.argocd_admin_password_secret_name
-  addon_config               = { for k, v in local.argocd_addon_config : k => v if v != null }
-  addon_context              = local.addon_context
+  count         = var.enable_argocd ? 1 : 0
+  source        = "./argocd"
+  helm_config   = var.argocd_helm_config
+  applications  = var.argocd_applications
+  addon_config  = { for k, v in local.argocd_addon_config : k => v if v != null }
+  addon_context = local.addon_context
 }
 
 module "argo_rollouts" {

--- a/modules/kubernetes-addons/variables.tf
+++ b/modules/kubernetes-addons/variables.tf
@@ -638,12 +638,6 @@ variable "argocd_applications" {
   default     = {}
 }
 
-variable "argocd_admin_password_secret_name" {
-  description = "Name for a secret stored in AWS Secrets Manager that contains the admin password"
-  type        = string
-  default     = ""
-}
-
 variable "argocd_manage_add_ons" {
   description = "Enable managing add-on configuration via ArgoCD"
   type        = bool


### PR DESCRIPTION
### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->

- Allowing users to pass ArgoCD Admin password using set_sensitive values
-  Example to show how to create a Secrets Manager password and use it for ArgoCD 

### Motivation

Fixes #728 

<!-- What inspired you to submit this pull request? -->


### More

- [ ] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
