### PR TITLE
Support exiting Grafana workspace

### DIFF
--- a/examples/observability/adot-amp-grafana-for-haproxy/README.md
+++ b/examples/observability/adot-amp-grafana-for-haproxy/README.md
@@ -14,7 +14,7 @@ Amazon Managed Prometheus configured as a default data source on Managed Grafana
 
 The Grafana API key is currently handled in this example through a variable until [native support is provided](https://github.com/hashicorp/terraform-provider-aws/issues/25100).
 Users can store the retrieved key in a `terraform.tfvars` file with the variable name like `grafana_api_key="xxx"`, or set the value through an environment variable
-like `export TF_VAR_grafana_api_key="xxx"`when working with the example. However, in a current production environment, users should use an external secret store such as AWS Secrets Manager and use the
+like `export TF_VAR_grafana_api_key="xxx"` when working with the example. However, in a current production environment, users should use an external secret store such as AWS Secrets Manager and use the
 [aws_secretsmanager_secret](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret) data source to retrieve the API key.
 
 ## Prerequisites
@@ -41,6 +41,8 @@ terraform apply -target=module.managed_grafana # required to retrieve API key be
 ```
 
 Enter `yes` at command prompt to apply
+
+Alternatively, you can reuse an existing Managed Grafana workspace. In this case, you can add `grafana_endpoint="https://xxx/"` to your `terraform.tfvars` or use an evironment variable `export TF_VAR_grafana_endpoint=""https://xxx/""`
 
 2. Generate a Grafana API Key
 

--- a/examples/observability/adot-amp-grafana-for-haproxy/main.tf
+++ b/examples/observability/adot-amp-grafana-for-haproxy/main.tf
@@ -29,7 +29,7 @@ provider "helm" {
 }
 
 provider "grafana" {
-  url  = "https://${module.managed_grafana.workspace_endpoint}"
+  url  = var.grafana_endpoint
   auth = var.grafana_api_key
 }
 

--- a/examples/observability/adot-amp-grafana-for-haproxy/main.tf
+++ b/examples/observability/adot-amp-grafana-for-haproxy/main.tf
@@ -29,7 +29,7 @@ provider "helm" {
 }
 
 provider "grafana" {
-  url  = var.grafana_endpoint
+  url  = try(var.grafana_endpoint, "https://${module.managed_grafana.workspace_endpoint}")
   auth = var.grafana_api_key
 }
 

--- a/examples/observability/adot-amp-grafana-for-haproxy/variables.tf
+++ b/examples/observability/adot-amp-grafana-for-haproxy/variables.tf
@@ -1,3 +1,9 @@
+variable "grafana_endpoint" {
+  description = "Grafana endpoint"
+  type        = string
+  default     = "https://example.com"
+}
+
 variable "grafana_api_key" {
   description = "API key for authorizing the Grafana provider to make changes to Amazon Managed Grafana"
   type        = string

--- a/examples/observability/adot-amp-grafana-for-haproxy/variables.tf
+++ b/examples/observability/adot-amp-grafana-for-haproxy/variables.tf
@@ -1,7 +1,7 @@
 variable "grafana_endpoint" {
   description = "Grafana endpoint"
   type        = string
-  default     = "https://example.com"
+  default     = ""
 }
 
 variable "grafana_api_key" {

--- a/examples/observability/adot-amp-grafana-for-haproxy/variables.tf
+++ b/examples/observability/adot-amp-grafana-for-haproxy/variables.tf
@@ -1,7 +1,7 @@
 variable "grafana_endpoint" {
   description = "Grafana endpoint"
   type        = string
-  default     = ""
+  default     = null
 }
 
 variable "grafana_api_key" {

--- a/examples/observability/adot-amp-grafana-for-java/README.md
+++ b/examples/observability/adot-amp-grafana-for-java/README.md
@@ -42,6 +42,8 @@ terraform apply -target=module.managed_grafana # required to retrieve API key be
 
 Enter `yes` at command prompt to apply
 
+Alternatively, you can reuse an existing Managed Grafana workspace. In this case, you can add `grafana_endpoint="https://xxx/"` to your `terraform.tfvars` or use an evironment variable `export TF_VAR_grafana_endpoint=""https://xxx/""`
+
 2. Generate a Grafana API Key
 
 - Give admin access to the SSO user you set up when creating the Amazon Managed Grafana Workspace:

--- a/examples/observability/adot-amp-grafana-for-java/main.tf
+++ b/examples/observability/adot-amp-grafana-for-java/main.tf
@@ -29,7 +29,7 @@ provider "helm" {
 }
 
 provider "grafana" {
-  url  = var.grafana_endpoint
+  url  = try(var.grafana_endpoint, "https://${module.managed_grafana.workspace_endpoint}")
   auth = var.grafana_api_key
 }
 

--- a/examples/observability/adot-amp-grafana-for-java/variables.tf
+++ b/examples/observability/adot-amp-grafana-for-java/variables.tf
@@ -1,7 +1,7 @@
 variable "grafana_endpoint" {
   description = "Grafana endpoint"
   type        = string
-  default     = "https://example.com"
+  default     = ""
 }
 
 variable "grafana_api_key" {

--- a/examples/observability/adot-amp-grafana-for-java/variables.tf
+++ b/examples/observability/adot-amp-grafana-for-java/variables.tf
@@ -1,7 +1,7 @@
 variable "grafana_endpoint" {
   description = "Grafana endpoint"
   type        = string
-  default     = ""
+  default     = null
 }
 
 variable "grafana_api_key" {

--- a/examples/observability/adot-amp-grafana-for-memcached/README.md
+++ b/examples/observability/adot-amp-grafana-for-memcached/README.md
@@ -42,6 +42,8 @@ terraform apply -target=module.managed_grafana # required to retrieve API key be
 
 Enter `yes` at command prompt to apply
 
+Alternatively, you can reuse an existing Managed Grafana workspace. In this case, you can add `grafana_endpoint="https://xxx/"` to your `terraform.tfvars` or use an evironment variable `export TF_VAR_grafana_endpoint=""https://xxx/""`
+
 2. Generate a Grafana API Key
 
 - Give admin access to the SSO user you set up when creating the Amazon Managed Grafana Workspace:

--- a/examples/observability/adot-amp-grafana-for-memcached/main.tf
+++ b/examples/observability/adot-amp-grafana-for-memcached/main.tf
@@ -29,7 +29,7 @@ provider "helm" {
 }
 
 provider "grafana" {
-  url  = var.grafana_endpoint
+  url  = try(var.grafana_endpoint, "https://${module.managed_grafana.workspace_endpoint}")
   auth = var.grafana_api_key
 }
 

--- a/examples/observability/adot-amp-grafana-for-memcached/variables.tf
+++ b/examples/observability/adot-amp-grafana-for-memcached/variables.tf
@@ -1,7 +1,7 @@
 variable "grafana_endpoint" {
   description = "Grafana endpoint"
   type        = string
-  default     = "https://example.com"
+  default     = ""
 }
 
 variable "grafana_api_key" {

--- a/examples/observability/adot-amp-grafana-for-memcached/variables.tf
+++ b/examples/observability/adot-amp-grafana-for-memcached/variables.tf
@@ -1,7 +1,7 @@
 variable "grafana_endpoint" {
   description = "Grafana endpoint"
   type        = string
-  default     = ""
+  default     = null
 }
 
 variable "grafana_api_key" {

--- a/examples/observability/adot-amp-grafana-for-nginx/README.md
+++ b/examples/observability/adot-amp-grafana-for-nginx/README.md
@@ -42,6 +42,8 @@ terraform apply -target=module.managed_grafana # required to retrieve API key be
 
 Enter `yes` at command prompt to apply
 
+Alternatively, you can reuse an existing Managed Grafana workspace. In this case, you can add `grafana_endpoint="https://xxx/"` to your `terraform.tfvars` or use an evironment variable `export TF_VAR_grafana_endpoint=""https://xxx/""`
+
 2. Generate a Grafana API Key
 
 - Give admin access to the SSO user you set up when creating the Amazon Managed Grafana Workspace:

--- a/examples/observability/adot-amp-grafana-for-nginx/main.tf
+++ b/examples/observability/adot-amp-grafana-for-nginx/main.tf
@@ -29,7 +29,7 @@ provider "helm" {
 }
 
 provider "grafana" {
-  url  = var.grafana_endpoint
+  url  = try(var.grafana_endpoint, "https://${module.managed_grafana.workspace_endpoint}")
   auth = var.grafana_api_key
 }
 

--- a/examples/observability/adot-amp-grafana-for-nginx/variables.tf
+++ b/examples/observability/adot-amp-grafana-for-nginx/variables.tf
@@ -1,7 +1,7 @@
 variable "grafana_endpoint" {
   description = "Grafana endpoint"
   type        = string
-  default     = "https://example.com"
+  default     = ""
 }
 
 variable "grafana_api_key" {

--- a/examples/observability/adot-amp-grafana-for-nginx/variables.tf
+++ b/examples/observability/adot-amp-grafana-for-nginx/variables.tf
@@ -1,7 +1,7 @@
 variable "grafana_endpoint" {
   description = "Grafana endpoint"
   type        = string
-  default     = ""
+  default     = null
 }
 
 variable "grafana_api_key" {


### PR DESCRIPTION
### What does this PR do?

We have provided support for using an existing workspace in the other [observability examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/blob/main/examples/observability/adot-amp-grafana-for-java/variables.tf#L1-L5). This PR adds the missing support for that in the haxproxy example 


### More

- [x ] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [x] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
