### PR TITLE
aws s3 object fix for NotImplemented error

### DIFF
--- a/examples/analytics/spark-k8s-operator/main.tf
+++ b/examples/analytics/spark-k8s-operator/main.tf
@@ -329,4 +329,10 @@ resource "aws_s3_object" "this" {
   acl          = "private"
   key          = "logs/"
   content_type = "application/x-directory"
+
+  depends_on = [
+    aws_s3_bucket_acl.this,
+    aws_s3_bucket_public_access_block.this,
+    aws_s3_bucket_server_side_encryption_configuration.this
+  ]
 }


### PR DESCRIPTION
### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->

- Fix for the following issue reported by Github Workflow

```
Error: Error uploading object to S3 bucket (spark-***20220711150809370300000001): NotImplemented: A header you provided implies functionality that is not implemented
	status code: 501, request id: RQPWNJMCVN624FBY, host id: vEsVLKBT21sGzQ828UnD1wBgc2VwNzhafLY5Ae7X2ilkcPyeXemTa8XAyrtUu3xjSQvDz8Bpclo=
  with aws_s3_object.this,
  on main.tf line 327, in resource "aws_s3_object" "this":
 327: resource "aws_s3_object" "this" {
```

### Motivation

<!-- What inspired you to submit this pull request? -->


### More

- [x] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
