### PR TITLE
fix: iamlive in csm mode

### DIFF
--- a/.github/workflows/e2e-parallel-full.yml
+++ b/.github/workflows/e2e-parallel-full.yml
@@ -61,14 +61,14 @@ jobs:
           role-duration-seconds: 3600
           role-session-name: GithubActions-Session
 
-      - name: Iamlive Setup
+      - name: Iamlive Setup & Run
         run: |
           #!/bin/bash
           set -eox pipefail
           wget -O iamlive.tar.gz "https://github.com/iann0036/iamlive/releases/download/${{ env.IAMLIVE_VERSION }}/iamlive-${{ env.IAMLIVE_VERSION }}-linux-amd64.tar.gz"
           tar -xzf iamlive.tar.gz
           chmod +x iamlive
-          IAMLIVE_PID=$(./iamlive --mode proxy --bind-addr 0.0.0.0:10080 --output-file ${HOME}/policy.json --refresh-rate 1 --sort-alphabetical --force-wildcard-resource --background)
+          IAMLIVE_PID=$(./iamlive --mode csm --output-file ${HOME}/policy.json --refresh-rate 1 --sort-alphabetical --force-wildcard-resource --background)
           echo "iamlive_pid=$IAMLIVE_PID" >> $GITHUB_ENV
 
       - name: Setup Terraform
@@ -81,10 +81,9 @@ jobs:
         working-directory: ${{ matrix.example_path }}
         run: |
           terraform init -upgrade=true
-          export HTTP_PROXY=http://127.0.0.1:10080
-          export HTTPS_PROXY=http://127.0.0.1:10080
-          export AWS_CA_BUNDLE="${HOME}/.iamlive/ca.pem"
-          export NO_PROXY=eks.amazonaws.com,github.io,fairwinds.com,crossplane.io,github.com,agones.dev,karpenter.sh,githubusercontent.com,storage.googleapis.com
+          export AWS_CSM_ENABLED=true
+          export AWS_CSM_PORT=31000
+          export AWS_CSM_HOST=127.0.0.1
           terraform apply -target=module.vpc -no-color -input=false -auto-approve
           terraform apply -target=module.eks_blueprints -no-color -input=false -auto-approve
           terraform apply -target=module.eks_blueprints_kubernetes_addons -no-color -input=false -auto-approve
@@ -95,10 +94,9 @@ jobs:
         working-directory: ${{ matrix.example_path }}
         run: |
           terraform init -upgrade=true
-          export HTTP_PROXY=http://127.0.0.1:10080
-          export HTTPS_PROXY=http://127.0.0.1:10080
-          export AWS_CA_BUNDLE="${HOME}/.iamlive/ca.pem"
-          export NO_PROXY=eks.amazonaws.com,github.io,fairwinds.com,crossplane.io,github.com,agones.dev,karpenter.sh,githubusercontent.com,storage.googleapis.com
+          export AWS_CSM_ENABLED=true
+          export AWS_CSM_PORT=31000
+          export AWS_CSM_HOST=127.0.0.1
           terraform destroy -target=module.eks_blueprints_kubernetes_addons  -no-color -input=false -auto-approve
           terraform destroy -target=module.eks_blueprints  -no-color -input=false -auto-approve
           terraform destroy -no-color -input=false -auto-approve


### PR DESCRIPTION
### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
- Changes Iamlive to run in CSM mode instead of Proxy

### Motivation
- Some actions may [fail](https://github.com/iann0036/iamlive/issues/54) in proxy mode, as of now we set wildcard for resource with a big warning, and it is possible to run terraform with CSM with this change.
<!-- What inspired you to submit this pull request? -->


### More

- [ ] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
