### PR TITLE
chore: Add upgrade guide to capture changes and documentation for v5.0 changes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
       - id: detect-aws-credentials
         args: ['--allow-missing-credentials']
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.73.0
+    rev: v1.74.1
     hooks:
       - id: terraform_fmt
       - id: terraform_docs

--- a/UPGRADE-5.0.md
+++ b/UPGRADE-5.0.md
@@ -1,0 +1,92 @@
+# Upgrade from v4.x to v5.x
+
+Please consult the `examples` directory for reference example configurations. If you find a bug, please open an issue with supporting configuration to reproduce.
+
+#### ⚠️ This guide is under active development. As tasks for v5.0 are implemented, the associated upgrade guidance/changes are documented here. See [here](https://github.com/aws-ia/terraform-aws-eks-blueprints/milestone/1) to track progress of v5.0 implementation.
+
+## List of backwards incompatible changes
+
+-
+
+## Additional changes
+
+### Added
+
+-
+
+### Modified
+
+-
+
+### Removed
+
+-
+
+### Variable and output changes
+
+1. Removed variables:
+
+    -
+
+2. Renamed variables:
+
+    -
+
+3. Added variables:
+
+    -
+
+4. Removed outputs:
+
+    -
+
+5. Renamed outputs:
+
+    -
+
+6. Added outputs:
+
+    -
+
+## Upgrade Migrations
+
+### Before - v4.x Example
+
+```hcl
+module "eks_blueprints" {
+  source = "github.com/aws-ia/terraform-aws-eks-blueprints?ref=v4.4.0"
+
+  # TODO
+
+}
+```
+
+### After - v5.x Example
+
+```hcl
+module "eks_blueprints" {
+  source = "github.com/aws-ia/terraform-aws-eks-blueprints?ref=v5.0.0"
+
+  # TODO
+
+}
+```
+
+### Diff of Before vs After
+
+```diff
+module "eks_blueprints" {
+-  source = "github.com/aws-ia/terraform-aws-eks-blueprints?ref=v4.4.0"
++  source = "github.com/aws-ia/terraform-aws-eks-blueprints?ref=v5.0.0"
+
+  # TODO
+}
+```
+
+### State Move Commands
+
+In conjunction with the changes above, users can elect to move their external capacity provider(s) under this module using the following move command. Command is shown using the values from the example shown above, please update to suit your configuration names:
+
+```sh
+terraform state mv 'xxx' 'yyy'
+```


### PR DESCRIPTION
### What does this PR do?
- Add upgrade guide to capture changes and documentation for v5.0 changes

### Motivation
- Provides empty template to populate with changes while v5.0 tasks are completed. Each PR for v5.0 should also include its necessary upgrade documentation which is captured in this document

### More

- [ ] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
