### PR TITLE
feat: Add example for VPC-CNI custom networking

### DIFF
--- a/.github/workflows/e2e-parallel-destroy.yml
+++ b/.github/workflows/e2e-parallel-destroy.yml
@@ -40,6 +40,7 @@ jobs:
           - example_path: examples/node-groups/self-managed-node-groups
           - example_path: examples/node-groups/windows-node-groups
           - example_path: examples/stateful
+          - example_path: examples/vpc-cni-custom-networking
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/e2e-parallel-full.yml
+++ b/.github/workflows/e2e-parallel-full.yml
@@ -44,6 +44,7 @@ jobs:
           - example_path: examples/node-groups/self-managed-node-groups
           - example_path: examples/node-groups/windows-node-groups
           - example_path: examples/stateful
+          - example_path: examples/vpc-cni-custom-networking
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ If you are interested in contributing to EKS Blueprints, see the [Contribution g
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_aws_eks"></a> [aws\_eks](#module\_aws\_eks) | terraform-aws-modules/eks/aws | v18.17.0 |
+| <a name="module_aws_eks"></a> [aws\_eks](#module\_aws\_eks) | terraform-aws-modules/eks/aws | v18.26.3 |
 | <a name="module_aws_eks_fargate_profiles"></a> [aws\_eks\_fargate\_profiles](#module\_aws\_eks\_fargate\_profiles) | ./modules/aws-eks-fargate-profiles | n/a |
 | <a name="module_aws_eks_managed_node_groups"></a> [aws\_eks\_managed\_node\_groups](#module\_aws\_eks\_managed\_node\_groups) | ./modules/aws-eks-managed-node-groups | n/a |
 | <a name="module_aws_eks_self_managed_node_groups"></a> [aws\_eks\_self\_managed\_node\_groups](#module\_aws\_eks\_self\_managed\_node\_groups) | ./modules/aws-eks-self-managed-node-groups | n/a |
@@ -180,6 +180,7 @@ If you are interested in contributing to EKS Blueprints, see the [Contribution g
 | <a name="input_cluster_service_ipv6_cidr"></a> [cluster\_service\_ipv6\_cidr](#input\_cluster\_service\_ipv6\_cidr) | The IPV6 Service CIDR block to assign Kubernetes service IP addresses | `string` | `null` | no |
 | <a name="input_cluster_timeouts"></a> [cluster\_timeouts](#input\_cluster\_timeouts) | Create, update, and delete timeout configurations for the cluster | `map(string)` | `{}` | no |
 | <a name="input_cluster_version"></a> [cluster\_version](#input\_cluster\_version) | Kubernetes `<major>.<minor>` version to use for the EKS cluster (i.e.: `1.22`) | `string` | `"1.22"` | no |
+| <a name="input_control_plane_subnet_ids"></a> [control\_plane\_subnet\_ids](#input\_control\_plane\_subnet\_ids) | A list of subnet IDs where the EKS cluster control plane (ENIs) will be provisioned. Used for expanding the pool of subnets used by nodes/node groups without replacing the EKS control plane | `list(string)` | `[]` | no |
 | <a name="input_create_cloudwatch_log_group"></a> [create\_cloudwatch\_log\_group](#input\_create\_cloudwatch\_log\_group) | Determines whether a log group is created by this module for the cluster logs. If not, AWS will automatically create one if logging is enabled | `bool` | `false` | no |
 | <a name="input_create_cluster_security_group"></a> [create\_cluster\_security\_group](#input\_create\_cluster\_security\_group) | Toggle to create or assign cluster security group | `bool` | `true` | no |
 | <a name="input_create_eks"></a> [create\_eks](#input\_create\_eks) | Create EKS cluster | `bool` | `true` | no |

--- a/examples/vpc-cni-custom-networking/README.md
+++ b/examples/vpc-cni-custom-networking/README.md
@@ -34,7 +34,6 @@ terraform apply
 
 Enter `yes` at command prompt to apply
 
-
 ## Validate
 
 The following command will update the `kubeconfig` on your local machine and allow you to interact with your EKS Cluster using `kubectl` to validate the deployment.

--- a/examples/vpc-cni-custom-networking/README.md
+++ b/examples/vpc-cni-custom-networking/README.md
@@ -128,5 +128,7 @@ kubectl describe pod aws-node-ttg4h -n kube-system
 To teardown and remove the resources created in this example:
 
 ```sh
+terraform destroy -target=kubectl_manifest.eni_config -target=module.eks_blueprints_kubernetes_addons -auto-approve
+terraform destroy -target=module.eks_blueprints -auto-approve
 terraform destroy -auto-approve
 ```

--- a/examples/vpc-cni-custom-networking/README.md
+++ b/examples/vpc-cni-custom-networking/README.md
@@ -1,0 +1,133 @@
+# EKS Cluster w/ VPC-CNI Custom Networking
+
+This example shows how to provision an EKS cluster with:
+- AWS VPC-CNI custom networking to assign IPs to pods from subnets outside of those used by the nodes
+- AWS VPC-CNI prefix delegation to allow higher pod densities - this is useful since the custom networking removes one ENI from use for pod IP assignment which lowers the number of pods that can be assigned to the node. Enabling prefix delegation allows for prefixes to be assigned to the ENIs to ensure the node resources can be fully utilized through higher pod densitities. See the user data section below for managing the max pods assigned to the node.
+- Dedicated /28 subnets for the EKS cluster control plane. Making changes to the subnets used by the control plane is a destructive operation - it is recommended to use dedicated subnets for the control plane that are separate from the data plane to allow for future growth through the addition of subnets without disruption to the cluster.
+
+To disable prefix delegation from this example:
+
+1. Remove the `--cni-prefix-delegation-enabled` flag from the user data script
+2. Remove the environment environment variables `ENABLE_PREFIX_DELEGATION=true` and `WARM_PREFIX_TARGET=1` assignment from the `aws-node` daemonset (set in the `null_resource.kubectl_set_env` resource in this example)
+
+## Reference Documentation:
+
+- [Documentation](https://docs.aws.amazon.com/eks/latest/userguide/cni-custom-network.html)
+- [Best Practices Guide](https://aws.github.io/aws-eks-best-practices/reliability/docs/networkmanagement/#cni-custom-networking)
+
+## Prerequisites:
+
+Ensure that you have the following tools installed locally:
+
+1. [aws cli](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html)
+2. [kubectl](https://Kubernetes.io/docs/tasks/tools/)
+3. [terraform](https://learn.hashicorp.com/tutorials/terraform/install-cli)
+
+## Deploy
+
+To provision this example:
+
+```sh
+terraform init
+terraform apply
+```
+
+Enter `yes` at command prompt to apply
+
+
+## Validate
+
+The following command will update the `kubeconfig` on your local machine and allow you to interact with your EKS Cluster using `kubectl` to validate the deployment.
+
+1. Run `update-kubeconfig` command:
+
+```sh
+aws eks --region <REGION> update-kubeconfig --name <CLUSTER_NAME>
+```
+
+2. List the nodes running currently
+
+```sh
+kubectl get nodes
+
+# Output should look similar to below
+NAME                                       STATUS   ROLES    AGE   VERSION
+ip-10-0-34-74.us-west-2.compute.internal   Ready    <none>   86s   v1.22.9-eks-810597c
+```
+
+3. Inspect the nodes settings and check for the max allocatable pods - should be 110 in this scenario with m5.xlarge:
+
+```sh
+kubectl describe node ip-10-0-34-74.us-west-2.compute.internal
+
+# Output should look similar to below (truncated for brevity)
+  Capacity:
+    attachable-volumes-aws-ebs:  25
+    cpu:                         4
+    ephemeral-storage:           104845292Ki
+    hugepages-1Gi:               0
+    hugepages-2Mi:               0
+    memory:                      15919124Ki
+    pods:                        110 # <- this should be 110 and not 58
+  Allocatable:
+    attachable-volumes-aws-ebs:  25
+    cpu:                         3920m
+    ephemeral-storage:           95551679124
+    hugepages-1Gi:               0
+    hugepages-2Mi:               0
+    memory:                      14902292Ki
+    pods:                        110 # <- this should be 110 and not 58
+```
+
+4. List out the pods running currently:
+
+```sh
+kubectl get pods -A -o wide
+
+# Output should look similar to below
+NAMESPACE     NAME                       READY   STATUS    RESTARTS   AGE   IP            NODE                                       NOMINATED NODE   READINESS GATES
+kube-system   aws-node-ttg4h             1/1     Running   0          52s   10.0.34.74    ip-10-0-34-74.us-west-2.compute.internal   <none>           <none>
+kube-system   coredns-657694c6f4-8s5k6   1/1     Running   0          2m    10.99.135.1   ip-10-0-34-74.us-west-2.compute.internal   <none>           <none>
+kube-system   coredns-657694c6f4-ntzcp   1/1     Running   0          2m    10.99.135.0   ip-10-0-34-74.us-west-2.compute.internal   <none>           <none>
+kube-system   kube-proxy-wnzjd           1/1     Running   0          53s   10.0.34.74    ip-10-0-34-74.us-west-2.compute.internal   <none>           <none>
+```
+
+5. Inspect one of the `aws-node-*` (AWS VPC CNI) pods to ensure prefix delegation is enabled and warm prefix target is 1:
+
+```sh
+kubectl describe pod aws-node-ttg4h -n kube-system
+
+# Output should look similar below (truncated for brevity)
+  Environment:
+    ADDITIONAL_ENI_TAGS:                    {}
+    AWS_VPC_CNI_NODE_PORT_SUPPORT:          true
+    AWS_VPC_ENI_MTU:                        9001
+    AWS_VPC_K8S_CNI_CONFIGURE_RPFILTER:     false
+    AWS_VPC_K8S_CNI_CUSTOM_NETWORK_CFG:     true # <- this should be set to true
+    AWS_VPC_K8S_CNI_EXTERNALSNAT:           false
+    AWS_VPC_K8S_CNI_LOGLEVEL:               DEBUG
+    AWS_VPC_K8S_CNI_LOG_FILE:               /host/var/log/aws-routed-eni/ipamd.log
+    AWS_VPC_K8S_CNI_RANDOMIZESNAT:          prng
+    AWS_VPC_K8S_CNI_VETHPREFIX:             eni
+    AWS_VPC_K8S_PLUGIN_LOG_FILE:            /var/log/aws-routed-eni/plugin.log
+    AWS_VPC_K8S_PLUGIN_LOG_LEVEL:           DEBUG
+    DISABLE_INTROSPECTION:                  false
+    DISABLE_METRICS:                        false
+    DISABLE_NETWORK_RESOURCE_PROVISIONING:  false
+    ENABLE_IPv4:                            true
+    ENABLE_IPv6:                            false
+    ENABLE_POD_ENI:                         false
+    ENABLE_PREFIX_DELEGATION:               true # <- this should be set to true
+    MY_NODE_NAME:                            (v1:spec.nodeName)
+    WARM_ENI_TARGET:                        1 # <- this should be set to 1
+    WARM_PREFIX_TARGET:                     1
+    ...
+```
+
+## Destroy
+
+To teardown and remove the resources created in this example:
+
+```sh
+terraform destroy -auto-approve
+```

--- a/examples/vpc-cni-custom-networking/main.tf
+++ b/examples/vpc-cni-custom-networking/main.tf
@@ -1,0 +1,263 @@
+provider "aws" {
+  region = local.region
+}
+
+provider "kubernetes" {
+  host                   = module.eks_blueprints.eks_cluster_endpoint
+  cluster_ca_certificate = base64decode(module.eks_blueprints.eks_cluster_certificate_authority_data)
+  token                  = data.aws_eks_cluster_auth.this.token
+}
+
+provider "helm" {
+  kubernetes {
+    host                   = module.eks_blueprints.eks_cluster_endpoint
+    cluster_ca_certificate = base64decode(module.eks_blueprints.eks_cluster_certificate_authority_data)
+    token                  = data.aws_eks_cluster_auth.this.token
+  }
+}
+
+provider "kubectl" {
+  apply_retry_count      = 10
+  host                   = module.eks_blueprints.eks_cluster_endpoint
+  cluster_ca_certificate = base64decode(module.eks_blueprints.eks_cluster_certificate_authority_data)
+  load_config_file       = false
+  token                  = data.aws_eks_cluster_auth.this.token
+}
+
+data "aws_eks_cluster_auth" "this" {
+  name = module.eks_blueprints.eks_cluster_id
+}
+
+data "aws_caller_identity" "current" {}
+data "aws_availability_zones" "available" {}
+
+locals {
+  name   = basename(path.cwd)
+  region = "us-west-2"
+
+  cluster_version = "1.22"
+
+  azs                  = slice(data.aws_availability_zones.available.names, 0, 3)
+  vpc_cidr             = "10.0.0.0/16"
+  primary_subnet_cidrs = [for k, v in local.azs : cidrsubnet(local.vpc_cidr, 4, k)]
+
+  secondary_vpc_cidr     = "10.99.0.0/16"
+  secondary_subnet_cidrs = [for k, v in local.azs : cidrsubnet(local.secondary_vpc_cidr, 2, k)]
+
+  tags = {
+    Blueprint  = local.name
+    GithubRepo = "github.com/aws-ia/terraform-aws-eks-blueprints"
+  }
+}
+
+#---------------------------------------------------------------
+# EKS Blueprints
+#---------------------------------------------------------------
+
+module "eks_blueprints" {
+  source = "../.."
+
+  cluster_name    = local.name
+  cluster_version = local.cluster_version
+
+  vpc_id                   = module.vpc.vpc_id
+  private_subnet_ids       = slice(module.vpc.private_subnets, 0, 3)
+  control_plane_subnet_ids = module.vpc.intra_subnets
+
+  # https://github.com/aws-ia/terraform-aws-eks-blueprints/issues/485
+  # https://github.com/aws-ia/terraform-aws-eks-blueprints/issues/494
+  cluster_kms_key_additional_admin_arns = [data.aws_caller_identity.current.arn]
+
+  managed_node_groups = {
+    custom_networking = {
+      node_group_name = "custom-net"
+
+      min_size     = 1
+      max_size     = 3
+      desired_size = 2
+
+      custom_ami_id  = data.aws_ssm_parameter.eks_optimized_ami.value
+      instance_types = ["m5.xlarge"]
+
+      create_launch_template = true
+      launch_template_os     = "amazonlinux2eks"
+
+      # https://docs.aws.amazon.com/eks/latest/userguide/choosing-instance-type.html#determine-max-pods
+      pre_userdata = <<-EOT
+        MAX_PODS=$(/etc/eks/max-pods-calculator.sh \
+        --instance-type-from-imds \
+        --cni-version ${trimprefix(data.aws_eks_addon_version.latest["vpc-cni"].version, "v")} \
+        --cni-prefix-delegation-enabled \
+        --cni-custom-networking-enabled \
+        )
+      EOT
+
+      # These settings opt out of the default behavior and use the maximum number of pods, with a cap of 110 due to
+      # Kubernetes guidance https://kubernetes.io/docs/setup/best-practices/cluster-large/
+      # See more info here https://docs.aws.amazon.com/eks/latest/userguide/cni-increase-ip-addresses.html
+      kubelet_extra_args   = "--max-pods=$${MAX_PODS}"
+      bootstrap_extra_args = "--use-max-pods false"
+    }
+  }
+
+  tags = local.tags
+}
+
+module "eks_blueprints_kubernetes_addons" {
+  source = "../../modules/kubernetes-addons"
+
+  eks_cluster_id       = module.eks_blueprints.eks_cluster_id
+  eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint
+  eks_oidc_provider    = module.eks_blueprints.oidc_provider
+  eks_cluster_version  = module.eks_blueprints.eks_cluster_version
+
+  enable_amazon_eks_vpc_cni = true
+  amazon_eks_vpc_cni_config = {
+    # Version 1.6.3-eksbuild.2 or later of the Amazon VPC CNI is required for custom networking
+    # Version 1.9.0 or later (for version 1.20 or earlier clusters or 1.21 or later clusters configured for IPv4)
+    # or 1.10.1 or later (for version 1.21 or later clusters configured for IPv6) of the Amazon VPC CNI for prefix delegation
+    addon_version     = data.aws_eks_addon_version.latest["vpc-cni"].version
+    resolve_conflicts = "OVERWRITE"
+  }
+
+  tags = local.tags
+
+  depends_on = [
+    # Modify VPC CNI ahead of addons
+    null_resource.kubectl_set_env
+  ]
+}
+
+data "aws_eks_addon_version" "latest" {
+  for_each = toset(["vpc-cni"])
+
+  addon_name         = each.value
+  kubernetes_version = module.eks_blueprints.eks_cluster_version
+  most_recent        = true
+}
+
+#---------------------------------------------------------------
+# Modify VPC CNI deployment
+#---------------------------------------------------------------
+
+locals {
+  kubeconfig = yamlencode({
+    apiVersion      = "v1"
+    kind            = "Config"
+    current-context = "terraform"
+    clusters = [{
+      name = module.eks_blueprints.eks_cluster_id
+      cluster = {
+        certificate-authority-data = module.eks_blueprints.eks_cluster_certificate_authority_data
+        server                     = module.eks_blueprints.eks_cluster_endpoint
+      }
+    }]
+    contexts = [{
+      name = "terraform"
+      context = {
+        cluster = module.eks_blueprints.eks_cluster_id
+        user    = "terraform"
+      }
+    }]
+    users = [{
+      name = "terraform"
+      user = {
+        token = data.aws_eks_cluster_auth.this.token
+      }
+    }]
+  })
+}
+
+resource "null_resource" "kubectl_set_env" {
+  triggers = {}
+
+  provisioner "local-exec" {
+    interpreter = ["/bin/bash", "-c"]
+    environment = {
+      KUBECONFIG = base64encode(local.kubeconfig)
+    }
+
+    # Reference https://aws.github.io/aws-eks-best-practices/reliability/docs/networkmanagement/#cni-custom-networking
+    # Reference https://docs.aws.amazon.com/eks/latest/userguide/cni-increase-ip-addresses.html
+    command = <<-EOT
+      # Custom networking
+      kubectl set env daemonset aws-node -n kube-system AWS_VPC_K8S_CNI_CUSTOM_NETWORK_CFG=true --kubeconfig <(echo $KUBECONFIG | base64 --decode)
+      kubectl set env daemonset aws-node -n kube-system ENI_CONFIG_LABEL_DEF=failure-domain.beta.kubernetes.io/zone --kubeconfig <(echo $KUBECONFIG | base64 --decode)
+
+
+      # Prefix delegation
+      kubectl set env daemonset aws-node -n kube-system ENABLE_PREFIX_DELEGATION=true --kubeconfig <(echo $KUBECONFIG | base64 --decode)
+      kubectl set env daemonset aws-node -n kube-system WARM_PREFIX_TARGET=1 --kubeconfig <(echo $KUBECONFIG | base64 --decode)
+    EOT
+  }
+}
+
+#---------------------------------------------------------------
+# VPC-CNI Custom Networking ENIConfig
+#---------------------------------------------------------------
+
+resource "kubectl_manifest" "eni_config" {
+  for_each = zipmap(local.azs, slice(module.vpc.private_subnets, 3, 6))
+
+  yaml_body = yamlencode({
+    apiVersion = "crd.k8s.amazonaws.com/v1alpha1"
+    kind       = "ENIConfig"
+    metadata = {
+      name = each.key
+    }
+    spec = {
+      securityGroups = [
+        module.eks_blueprints.cluster_primary_security_group_id,
+        module.eks_blueprints.worker_node_security_group_id,
+      ]
+      subnet = each.value
+    }
+  })
+}
+
+#---------------------------------------------------------------
+# Supporting Resources
+#---------------------------------------------------------------
+
+data "aws_ssm_parameter" "eks_optimized_ami" {
+  name = "/aws/service/eks/optimized-ami/${local.cluster_version}/amazon-linux-2/recommended/image_id"
+}
+
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "~> 3.0"
+
+  name = local.name
+  cidr = local.vpc_cidr
+
+  secondary_cidr_blocks = [local.secondary_vpc_cidr] # can add up to 5 total CIDR blocks
+
+  azs             = local.azs
+  private_subnets = concat(local.primary_subnet_cidrs, local.secondary_subnet_cidrs)
+  public_subnets  = [for k, v in local.azs : cidrsubnet(local.vpc_cidr, 8, k + 48)]
+  intra_subnets   = [for k, v in local.azs : cidrsubnet(local.vpc_cidr, 8, k + 52)]
+
+  enable_nat_gateway   = true
+  single_nat_gateway   = true
+  enable_dns_hostnames = true
+
+  # Manage so we can name
+  manage_default_network_acl    = true
+  default_network_acl_tags      = { Name = "${local.name}-default" }
+  manage_default_route_table    = true
+  default_route_table_tags      = { Name = "${local.name}-default" }
+  manage_default_security_group = true
+  default_security_group_tags   = { Name = "${local.name}-default" }
+
+  public_subnet_tags = {
+    "kubernetes.io/cluster/${local.name}" = "shared"
+    "kubernetes.io/role/elb"              = 1
+  }
+
+  private_subnet_tags = {
+    "kubernetes.io/cluster/${local.name}" = "shared"
+    "kubernetes.io/role/internal-elb"     = 1
+  }
+
+  tags = local.tags
+}

--- a/examples/vpc-cni-custom-networking/outputs.tf
+++ b/examples/vpc-cni-custom-networking/outputs.tf
@@ -1,0 +1,4 @@
+output "configure_kubectl" {
+  description = "Configure kubectl: make sure you're logged in with the correct AWS profile and run the following command to update your kubeconfig"
+  value       = module.eks_blueprints.configure_kubectl
+}

--- a/examples/vpc-cni-custom-networking/versions.tf
+++ b/examples/vpc-cni-custom-networking/versions.tf
@@ -1,0 +1,33 @@
+terraform {
+  required_version = ">= 1.0.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.72"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.10"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = ">= 2.4.1"
+    }
+    kubectl = {
+      source  = "gavinbunney/kubectl"
+      version = ">= 1.14"
+    }
+    null = {
+      source  = "hashicorp/null"
+      version = ">= 3.0"
+    }
+  }
+
+  # ##  Used for end-to-end testing on project; update to suit your needs
+  # backend "s3" {
+  #   bucket = "terraform-ssp-github-actions-state"
+  #   region = "us-west-2"
+  #   key    = "e2e/vpc-cni-custom-networking/terraform.tfstate"
+  # }
+}

--- a/main.tf
+++ b/main.tf
@@ -17,8 +17,9 @@ module "kms" {
 # ---------------------------------------------------------------------------------------------------------------------
 module "aws_eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "v18.17.0"
-  create  = var.create_eks
+  version = "v18.26.3"
+
+  create = var.create_eks
 
   cluster_name     = var.cluster_name
   cluster_version  = var.cluster_version
@@ -36,6 +37,7 @@ module "aws_eks" {
 
   # EKS Cluster VPC Config
   subnet_ids                           = var.private_subnet_ids
+  control_plane_subnet_ids             = var.control_plane_subnet_ids
   cluster_endpoint_private_access      = var.cluster_endpoint_private_access
   cluster_endpoint_public_access       = var.cluster_endpoint_public_access
   cluster_endpoint_public_access_cidrs = var.cluster_endpoint_public_access_cidrs

--- a/variables.tf
+++ b/variables.tf
@@ -24,6 +24,12 @@ variable "public_subnet_ids" {
   default     = []
 }
 
+variable "control_plane_subnet_ids" {
+  description = "A list of subnet IDs where the EKS cluster control plane (ENIs) will be provisioned. Used for expanding the pool of subnets used by nodes/node groups without replacing the EKS control plane"
+  type        = list(string)
+  default     = []
+}
+
 #-------------------------------
 # EKS module variables (terraform-aws-modules/eks/aws)
 #-------------------------------


### PR DESCRIPTION
### What does this PR do?
- Adds an example demonstrating how to enable [AWS VPC-CNI custom networking](https://docs.aws.amazon.com/eks/latest/userguide/cni-custom-network.html)
- Updates `terraform-aws-eks` module to v18.26.3 which is latest - update is to allow use of dedicated control plane subnets which are recommended for expanding data plane without cluster disruption

### Motivation
- Closes #474

### More

- [x] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [x] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
