### PR TITLE
chore: amazon_eks_vpc_cni_config addon_version v1.10.1-eksbuild.1 -> v1.11.2-eksbuild.1, argocd 4.9.1 -> 4.9.14

### DIFF
--- a/docs/add-ons/managed-add-ons.md
+++ b/docs/add-ons/managed-add-ons.md
@@ -26,7 +26,7 @@ Checkout this [doc](https://docs.aws.amazon.com/eks/latest/userguide/managing-vp
   #Optional
   amazon_eks_vpc_cni_config = {
     addon_name               = "vpc-cni"
-    addon_version            = "v1.10.1-eksbuild.1"
+    addon_version            = "v1.11.2-eksbuild.1"
     service_account          = "aws-node"
     resolve_conflicts        = "OVERWRITE"
     namespace                = "kube-system"

--- a/modules/kubernetes-addons/argocd/locals.tf
+++ b/modules/kubernetes-addons/argocd/locals.tf
@@ -8,7 +8,7 @@ locals {
     name             = local.name
     chart            = local.name
     repository       = "https://argoproj.github.io/argo-helm"
-    version          = "4.9.1"
+    version          = "4.9.14"
     namespace        = local.namespace
     timeout          = 1200
     create_namespace = true


### PR DESCRIPTION
### What does this PR do?

amazon_eks_vpc_cni_config addon_version v1.10.1-eksbuild.1 -> v1.11.2-eksbuild.1

### Motivation

addon_version v1.11.2-eksbuild.1 is better then v1.10.1-eksbuild.1


### More

- [x] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [x] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
