### PR TITLE
adding aws_auth_configmap parameters

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -83,6 +83,12 @@ module "aws_eks" {
   ] : var.cluster_encryption_config
 
   cluster_identity_providers = var.cluster_identity_providers
+
+  # Cluster auth
+  
+  # aws-auth configmap
+  manage_aws_auth_configmap = var.manage_aws_auth_configmap
+  create_aws_auth_configmap = var.create_aws_auth_configmap
 }
 
 # ---------------------------------------------------------------------------------------------------------------------

--- a/variables.tf
+++ b/variables.tf
@@ -57,6 +57,18 @@ variable "cluster_version" {
   default     = "1.22"
 }
 
+variable "manage_aws_auth_configmap" {
+  description = "Determines whether to manage the aws-auth configmap"
+  type        = bool
+  default     = false
+}
+
+variable "create_aws_auth_configmap" {
+  description = "Determines whether to create the aws-auth configmap. NOTE - this is only intended for scenarios where the configmap does not exist (i.e. - when using only self-managed node groups). Most users should use `manage_aws_auth_configmap`"
+  type        = bool
+  default     = false
+}
+
 #-------------------------------
 # EKS Cluster Security Groups
 #-------------------------------


### PR DESCRIPTION
### What does this PR do?

Adding aws_auth configmap parameters included in terraform-aws-eks module.


### Motivation

Feature needed for customer engagement.


### More

- [ ] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
