### PR TITLE
Update main.tf

### DIFF
--- a/examples/karpenter/main.tf
+++ b/examples/karpenter/main.tf
@@ -197,7 +197,7 @@ data "kubectl_path_documents" "karpenter_provisioners" {
 }
 
 resource "kubectl_manifest" "karpenter_provisioner" {
-  for_each  = toset(data.kubectl_path_documents.karpenter_provisioners.documents)
+  for_each  = data.kubectl_path_documents.karpenter_provisioners.manifests
   yaml_body = each.value
 
   depends_on = [module.eks_blueprints_kubernetes_addons]


### PR DESCRIPTION
### What does this PR do?

Updating example to provide better code for the real-world usage


### Motivation

The problem I met by following this example on my project


### More

- [x] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [x] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

If we are using 
`for_each  = toset(data.kubectl_path_documents.karpenter_provisioners.documents)`
it will remove provisioner each time we are making changes to it (as a result all resources created by our provisioner will be removed by karpenter)
Having proposed variant we will have better kubectl_manifest document name which will not be updated each when we changing provisioner itself.
