### PR TITLE
[addon/external-dns] update irsa policy

### DIFF
--- a/modules/kubernetes-addons/external-dns/data.tf
+++ b/modules/kubernetes-addons/external-dns/data.tf
@@ -9,7 +9,6 @@ data "aws_iam_policy_document" "external_dns_iam_policy_document" {
     resources = [data.aws_route53_zone.selected.arn]
     actions = [
       "route53:ChangeResourceRecordSets",
-      "route53:ListResourceRecordSets",
     ]
   }
 
@@ -18,6 +17,7 @@ data "aws_iam_policy_document" "external_dns_iam_policy_document" {
     resources = ["*"]
     actions = [
       "route53:ListHostedZones",
+      "route53:ListResourceRecordSets",
     ]
   }
 }


### PR DESCRIPTION
### What does this PR do?

current policy occurs error in external-dns when user has hosted zone more than 2.
and refer to official document (https://kubernetes-sigs.github.io/external-dns/v0.12.1/tutorials/aws/#iam-policy) , follow the policy guide.


### Motivation

before fix
```
time="2022-07-26T07:44:34Z" level=error msg="failed to list resource records sets for zone /hostedzone/Z0098938DV62NKCC892B: AccessDenied: User: arn:aws:sts::88425xxxxxxx:assumed-role/eks-external-dns-sa-irsa/1658820563382445612 is not authorized to perform: route53:ListResourceRecordSets on resource: arn:aws:route53:::hostedzone/Z0098938DV62xxxxxxxx because no identity-based policy allows the route53:ListResourceRecordSets action\n\tstatus code: 403, request id: cdb13f18-51ba-490b-a0fe-8c21"
```

after apply fix
```
time="2022-07-26T07:46:36Z" level=info msg="Applying provider record filter for domains: [xxxx.com. .xxxx.com. xxxxx.io. .xxxxx.io. a.com. .a.com. b.com. .b.com.]"
time="2022-07-26T07:46:37Z" level=info msg="Desired change: CREATE cname-n.a.com TXT [Id: /hostedzone/Z0004878N3Yxxxx]"
```

### More

- [x] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [x] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [x] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [x] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
