### PR TITLE
fix: Correct IRSA module name used to not default to `null` through `coalesce()`

### DIFF
--- a/modules/irsa/main.tf
+++ b/modules/irsa/main.tf
@@ -20,7 +20,7 @@ resource "kubernetes_service_account_v1" "irsa" {
 resource "aws_iam_role" "irsa" {
   count = var.irsa_iam_policies != null ? 1 : 0
 
-  name        = try(var.addon_context.irsa_iam_role_name, format("%s-%s-%s", var.addon_context.eks_cluster_id, trim(var.kubernetes_service_account, "-*"), "irsa"))
+  name        = try(coalesce(var.addon_context.irsa_iam_role_name, format("%s-%s-%s", var.addon_context.eks_cluster_id, trim(var.kubernetes_service_account, "-*"), "irsa")), null)
   description = "AWS IAM Role for the Kubernetes service account ${var.kubernetes_service_account}."
   assume_role_policy = jsonencode({
     "Version" : "2012-10-17",


### PR DESCRIPTION
### What does this PR do?
- Correct IRSA module name used to not default to `null` through `coalesce()`
	- Because of the use of optional variable attributes, when a value is not provided it defaults to `null` which is a valid value inside a `try()` block and for IAM role names. When the value is `null`, Terraform will provide a value for it which is not the desired default behavior. Instead, we want to use a custom name if provided, otherwise fall back to the format provided by the module

### Motivation
- Closes #788 


### More

- [x] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
