### PR TITLE
cert manager default behavior is to keep certificate after ingress/c…

### DIFF
--- a/modules/kubernetes-addons/README.md
+++ b/modules/kubernetes-addons/README.md
@@ -111,6 +111,7 @@
 | <a name="input_aws_privateca_acmca_arn"></a> [aws\_privateca\_acmca\_arn](#input\_aws\_privateca\_acmca\_arn) | ARN of AWS ACM PCA | `string` | `""` | no |
 | <a name="input_aws_privateca_issuer_helm_config"></a> [aws\_privateca\_issuer\_helm\_config](#input\_aws\_privateca\_issuer\_helm\_config) | PCA Issuer Helm Chart config | `any` | `{}` | no |
 | <a name="input_aws_privateca_issuer_irsa_policies"></a> [aws\_privateca\_issuer\_irsa\_policies](#input\_aws\_privateca\_issuer\_irsa\_policies) | IAM policy ARNs for AWS ACM PCA IRSA | `list(string)` | `[]` | no |
+| <a name="input_cert_manager_allow_reuse_cert_after_delete"></a> [cert\_manager\_allow\_reuse\_cert\_after\_delete](#input\_cert\_manager\_allow\_reuse\_cert\_after\_delete) | To avoid recreation of certificate when service is being delete and recreate.(can assist with letsencrypt rate limit) | `bool` | `true` | no |
 | <a name="input_cert_manager_domain_names"></a> [cert\_manager\_domain\_names](#input\_cert\_manager\_domain\_names) | Domain names of the Route53 hosted zone to use with cert-manager | `list(string)` | `[]` | no |
 | <a name="input_cert_manager_helm_config"></a> [cert\_manager\_helm\_config](#input\_cert\_manager\_helm\_config) | Cert Manager Helm Chart config | `any` | `{}` | no |
 | <a name="input_cert_manager_install_letsencrypt_issuers"></a> [cert\_manager\_install\_letsencrypt\_issuers](#input\_cert\_manager\_install\_letsencrypt\_issuers) | Install Let's Encrypt Cluster Issuers | `bool` | `true` | no |

--- a/modules/kubernetes-addons/cert-manager/README.md
+++ b/modules/kubernetes-addons/cert-manager/README.md
@@ -53,6 +53,7 @@ cert-manager docker image is available at this repo:
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_addon_context"></a> [addon\_context](#input\_addon\_context) | Input configuration for the addon | <pre>object({<br>    aws_caller_identity_account_id = string<br>    aws_caller_identity_arn        = string<br>    aws_eks_cluster_endpoint       = string<br>    aws_partition_id               = string<br>    aws_region_name                = string<br>    eks_cluster_id                 = string<br>    eks_oidc_issuer_url            = string<br>    eks_oidc_provider_arn          = string<br>    tags                           = map(string)<br>    irsa_iam_role_path             = string<br>  })</pre> | n/a | yes |
+| <a name="input_allow_reuse_cert_after_delete"></a> [allow\_reuse\_cert\_after\_delete](#input\_allow\_reuse\_cert\_after\_delete) | To avoid recreation of certificate when service is being delete and recreate.(can assist with letsencrypt rate limit) | `bool` | `true` | no |
 | <a name="input_domain_names"></a> [domain\_names](#input\_domain\_names) | Domain names of the Route53 hosted zone to use with cert-manager. | `list(string)` | `[]` | no |
 | <a name="input_helm_config"></a> [helm\_config](#input\_helm\_config) | cert-manager Helm chart configuration | `any` | `{}` | no |
 | <a name="input_install_letsencrypt_issuers"></a> [install\_letsencrypt\_issuers](#input\_install\_letsencrypt\_issuers) | Install Let's Encrypt Cluster Issuers. | `bool` | `true` | no |

--- a/modules/kubernetes-addons/cert-manager/locals.tf
+++ b/modules/kubernetes-addons/cert-manager/locals.tf
@@ -12,7 +12,7 @@ locals {
     values      = local.default_helm_values
   }
 
-  default_helm_values = [templatefile("${path.module}/values.yaml", {})]
+  default_helm_values = [templatefile("${path.module}/values.yaml", { delete_permanently = !var.allow_reuse_cert_after_delete })]
 
   helm_config = merge(
     local.default_helm_config,

--- a/modules/kubernetes-addons/cert-manager/values.yaml
+++ b/modules/kubernetes-addons/cert-manager/values.yaml
@@ -1,5 +1,5 @@
 extraArgs:
-  - --enable-certificate-owner-ref=true
+  - --enable-certificate-owner-ref=${delete_permanently}
 
 installCRDs: true
 

--- a/modules/kubernetes-addons/cert-manager/variables.tf
+++ b/modules/kubernetes-addons/cert-manager/variables.tf
@@ -34,6 +34,12 @@ variable "letsencrypt_email" {
   default     = ""
 }
 
+variable "allow_reuse_cert_after_delete" {
+  description = "To avoid recreation of certificate when service is being delete and recreate.(can assist with letsencrypt rate limit)"
+  type        = bool
+  default     = true
+}
+
 variable "addon_context" {
   description = "Input configuration for the addon"
   type = object({

--- a/modules/kubernetes-addons/main.tf
+++ b/modules/kubernetes-addons/main.tf
@@ -137,15 +137,16 @@ module "aws_node_termination_handler" {
 }
 
 module "cert_manager" {
-  count                       = var.enable_cert_manager ? 1 : 0
-  source                      = "./cert-manager"
-  helm_config                 = var.cert_manager_helm_config
-  manage_via_gitops           = var.argocd_manage_add_ons
-  irsa_policies               = var.cert_manager_irsa_policies
-  addon_context               = local.addon_context
-  domain_names                = var.cert_manager_domain_names
-  install_letsencrypt_issuers = var.cert_manager_install_letsencrypt_issuers
-  letsencrypt_email           = var.cert_manager_letsencrypt_email
+  count                         = var.enable_cert_manager ? 1 : 0
+  source                        = "./cert-manager"
+  helm_config                   = var.cert_manager_helm_config
+  manage_via_gitops             = var.argocd_manage_add_ons
+  irsa_policies                 = var.cert_manager_irsa_policies
+  addon_context                 = local.addon_context
+  domain_names                  = var.cert_manager_domain_names
+  install_letsencrypt_issuers   = var.cert_manager_install_letsencrypt_issuers
+  letsencrypt_email             = var.cert_manager_letsencrypt_email
+  allow_reuse_cert_after_delete = var.cert_manager_allow_reuse_cert_after_delete
 }
 
 module "cluster_autoscaler" {

--- a/modules/kubernetes-addons/variables.tf
+++ b/modules/kubernetes-addons/variables.tf
@@ -643,6 +643,12 @@ variable "cert_manager_letsencrypt_email" {
   default     = ""
 }
 
+variable "cert_manager_allow_reuse_cert_after_delete" {
+  description = "To avoid recreation of certificate when service is being delete and recreate.(can assist with letsencrypt rate limit)"
+  type        = bool
+  default     = true
+}
+
 #-----------Argo Rollouts ADDON-------------
 variable "enable_argo_rollouts" {
   description = "Enable Argo Rollouts add-on"


### PR DESCRIPTION
### What does this PR do?

I add this pr since we faced rate limit during developing in letsencrypt cert manager, u can read more about it [here](https://letsencrypt.org/docs/rate-limits/) 
It took me time to find out the reason and how to solve it, and I was not the only one [looking for a solution](https://github.com/cert-manager/cert-manager/issues/3298#issue-704410330).
So to make it simpler to other **I added a designated parameter to make it clear**, as well I changed the blueprint default behavior to be as cert-manager default behavior. 
cert manager default behavior is to keep certificate after ingress/certificate deletion. currently this behavior is override and u might hit letsencrypt rate limit (weekly) so it is long wait time. 
see discussion https://github.com/cert-manager/cert-manager/issues/3298#issuecomment-1030815199

### More

- [x] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [x] Yes, I ran `pre-commit run -a` with this PR
- [x] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature

**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
