### PR TITLE
fix: fluentbit use correct cw retention variable

### DIFF
--- a/docs/add-ons/aws-for-fluent-bit.md
+++ b/docs/add-ons/aws-for-fluent-bit.md
@@ -22,6 +22,7 @@ You can optionally customize the Helm chart that deploys `aws_for_fluentbit` via
 ```hcl
   enable_aws_for_fluentbit = true
   aws_for_fluentbit_irsa_policies = ["IAM Policies"] # Add list of additional policies to IRSA to enable access to Kinesis, OpenSearch etc.
+  aws_for_fluentbit_cw_log_group_retention = 90
   aws_for_fluentbit_helm_config = {
     name                                      = "aws-for-fluent-bit"
     chart                                     = "aws-for-fluent-bit"
@@ -29,7 +30,6 @@ You can optionally customize the Helm chart that deploys `aws_for_fluentbit` via
     version                                   = "0.1.0"
     namespace                                 = "logging"
     aws_for_fluent_bit_cw_log_group           = "/${local.cluster_id}/worker-fluentbit-logs" # Optional
-    aws_for_fluentbit_cwlog_retention_in_days = 90
     create_namespace                          = true
     values = [templatefile("${path.module}/values.yaml", {
       region                          = data.aws_region.current.name,

--- a/examples/complete-kubernetes-addons/main.tf
+++ b/examples/complete-kubernetes-addons/main.tf
@@ -179,16 +179,16 @@ module "eks_blueprints_kubernetes_addons" {
   enable_amazon_prometheus             = true
   amazon_prometheus_workspace_endpoint = module.managed_prometheus.workspace_prometheus_endpoint
 
-  enable_aws_for_fluentbit = true
+  enable_aws_for_fluentbit                 = true
+  aws_for_fluentbit_cw_log_group_retention = 30
   aws_for_fluentbit_helm_config = {
-    name                                      = "aws-for-fluent-bit"
-    chart                                     = "aws-for-fluent-bit"
-    repository                                = "https://aws.github.io/eks-charts"
-    version                                   = "0.1.16"
-    namespace                                 = "logging"
-    aws_for_fluent_bit_cw_log_group           = "/${module.eks_blueprints.eks_cluster_id}/worker-fluentbit-logs" # Optional
-    aws_for_fluentbit_cwlog_retention_in_days = 90
-    create_namespace                          = true
+    name                            = "aws-for-fluent-bit"
+    chart                           = "aws-for-fluent-bit"
+    repository                      = "https://aws.github.io/eks-charts"
+    version                         = "0.1.16"
+    namespace                       = "logging"
+    aws_for_fluent_bit_cw_log_group = "/${module.eks_blueprints.eks_cluster_id}/worker-fluentbit-logs" # Optional
+    create_namespace                = true
     values = [templatefile("${path.module}/helm_values/aws-for-fluentbit-values.yaml", {
       region                          = local.region
       aws_for_fluent_bit_cw_log_group = "/${module.eks_blueprints.eks_cluster_id}/worker-fluentbit-logs"


### PR DESCRIPTION
### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
- Using correct variable to set the fluentbit cw log group retention in docs and example. 

### Motivation
- Closes https://github.com/aws-ia/terraform-aws-eks-blueprints/issues/786
<!-- What inspired you to submit this pull request? -->


### More

- [ ] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
