### PR TITLE
chore: Only run CI checks when necessary (affected files changed)

### DIFF
--- a/.github/workflows/e2e-terratest.yml
+++ b/.github/workflows/e2e-terratest.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches:
       - main
+    paths:
+      - '**.tf'
+      - '**.yml'
+      - '**.yaml'
+      - 'test/*'
   workflow_dispatch:
 
 concurrency: e2e-terratest

--- a/.github/workflows/plan-examples.yml
+++ b/.github/workflows/plan-examples.yml
@@ -11,6 +11,10 @@ on:
       - '**.yaml'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   getExampleDirectories:
     name: Get example directories

--- a/.github/workflows/plan-examples.yml
+++ b/.github/workflows/plan-examples.yml
@@ -5,6 +5,10 @@ on:
   pull_request_target:
     branches:
       - main
+    paths:
+      - '**.tf'
+      - '**.yml'
+      - '**.yaml'
   workflow_dispatch:
 
 jobs:
@@ -42,7 +46,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tf_working_dir: ${{ fromJson(needs.getExampleDirectories.outputs.directories) }}
+        directory: ${{ fromJson(needs.getExampleDirectories.outputs.directories) }}
 
     steps:
       - name: checkout-merge
@@ -55,8 +59,16 @@ jobs:
         if: "!contains(github.event_name, 'pull_request')"
         uses: actions/checkout@v3
 
+      - uses: dorny/paths-filter@v2
+        id: changes
+        with:
+          filters: |
+            dir:
+              - '${{ matrix.directory }}/**'
+
       - name: Configure AWS credentials from Test account
         uses: aws-actions/configure-aws-credentials@v1
+        if: steps.changes.outputs.dir == 'true'
         with:
           role-to-assume: ${{ secrets.ROLE_TO_ASSUME }}
           aws-region: us-west-2
@@ -65,15 +77,16 @@ jobs:
 
       - name: Terraform Job
         uses: hashicorp/setup-terraform@v2
+        if: steps.changes.outputs.dir == 'true'
         with:
           terraform_version: 1.0.0
 
       - name: Terraform Init
-        id: init
+        if: steps.changes.outputs.dir == 'true'
         run: terraform init -reconfigure
-        working-directory: ${{ matrix.tf_working_dir }}
+        working-directory: ${{ matrix.directory }}
 
       - name: Terraform Plan
-        id: plan
-        working-directory: ${{ matrix.tf_working_dir }}
+        if: steps.changes.outputs.dir == 'true'
+        working-directory: ${{ matrix.directory }}
         run: terraform plan -no-color

--- a/.github/workflows/plan-examples.yml
+++ b/.github/workflows/plan-examples.yml
@@ -66,13 +66,18 @@ jobs:
       - uses: dorny/paths-filter@v2
         id: changes
         with:
+          # Need to check not only the example directory
+          # but also the supporting module(s) code
+          # for plans (not for pre-commit)
           filters: |
-            dir:
-              - '${{ matrix.directory }}/**'
+            src:
+              - '${{ matrix.directory }}/**/*.(tf|yml|yaml)'
+              - 'modules/**/*.(tf|yml|yaml)'
+              - '*.tf'
 
       - name: Configure AWS credentials from Test account
         uses: aws-actions/configure-aws-credentials@v1
-        if: steps.changes.outputs.dir == 'true'
+        if: steps.changes.outputs.src== 'true'
         with:
           role-to-assume: ${{ secrets.ROLE_TO_ASSUME }}
           aws-region: us-west-2
@@ -81,16 +86,16 @@ jobs:
 
       - name: Terraform Job
         uses: hashicorp/setup-terraform@v2
-        if: steps.changes.outputs.dir == 'true'
+        if: steps.changes.outputs.src== 'true'
         with:
           terraform_version: 1.0.0
 
       - name: Terraform Init
-        if: steps.changes.outputs.dir == 'true'
+        if: steps.changes.outputs.src== 'true'
         run: terraform init -reconfigure
         working-directory: ${{ matrix.directory }}
 
       - name: Terraform Plan
-        if: steps.changes.outputs.dir == 'true'
+        if: steps.changes.outputs.src== 'true'
         working-directory: ${{ matrix.directory }}
         run: terraform plan -no-color

--- a/.github/workflows/plan-examples.yml
+++ b/.github/workflows/plan-examples.yml
@@ -53,14 +53,7 @@ jobs:
         directory: ${{ fromJson(needs.getExampleDirectories.outputs.directories) }}
 
     steps:
-      # - name: checkout-merge
-      #   if: "contains(github.event_name, 'pull_request')"
-      #   uses: actions/checkout@v3
-      #   with:
-      #     ref: refs/pull/${{github.event.pull_request.number}}/merge
-
       - name: checkout
-        # if: "!contains(github.event_name, 'pull_request')"
         uses: actions/checkout@v3
 
       - uses: dorny/paths-filter@v2

--- a/.github/workflows/plan-examples.yml
+++ b/.github/workflows/plan-examples.yml
@@ -5,10 +5,6 @@ on:
   pull_request_target:
     branches:
       - main
-    paths:
-      - '**.tf'
-      - '**.yml'
-      - '**.yaml'
   workflow_dispatch:
 
 concurrency:
@@ -53,7 +49,14 @@ jobs:
         directory: ${{ fromJson(needs.getExampleDirectories.outputs.directories) }}
 
     steps:
+      - name: checkout-merge
+        if: "contains(github.event_name, 'pull_request')"
+        uses: actions/checkout@v3
+        with:
+          ref: refs/pull/${{github.event.pull_request.number}}/merge
+
       - name: checkout
+        if: "!contains(github.event_name, 'pull_request')"
         uses: actions/checkout@v3
 
       - uses: dorny/paths-filter@v2

--- a/.github/workflows/plan-examples.yml
+++ b/.github/workflows/plan-examples.yml
@@ -49,14 +49,14 @@ jobs:
         directory: ${{ fromJson(needs.getExampleDirectories.outputs.directories) }}
 
     steps:
-      - name: checkout-merge
-        if: "contains(github.event_name, 'pull_request')"
-        uses: actions/checkout@v3
-        with:
-          ref: refs/pull/${{github.event.pull_request.number}}/merge
+      # - name: checkout-merge
+      #   if: "contains(github.event_name, 'pull_request')"
+      #   uses: actions/checkout@v3
+      #   with:
+      #     ref: refs/pull/${{github.event.pull_request.number}}/merge
 
       - name: checkout
-        if: "!contains(github.event_name, 'pull_request')"
+        # if: "!contains(github.event_name, 'pull_request')"
         uses: actions/checkout@v3
 
       - uses: dorny/paths-filter@v2

--- a/.github/workflows/plan-examples.yml
+++ b/.github/workflows/plan-examples.yml
@@ -12,7 +12,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.head_ref || github.run_id }}
+  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -48,17 +48,20 @@ jobs:
       - uses: dorny/paths-filter@v2
         id: changes
         with:
+          # We only need to check Terraform files for the current directory
+          # because the `preCommitMaxVersion` job will run the full,
+          # exhaustive checks (always)
           filters: |
-            dir:
-              - '${{ matrix.directory }}/**'
+            src:
+              - '${{ matrix.directory }}/*.tf'
 
       - name: Config Terraform plugin cache
-        if: steps.changes.outputs.dir == 'true'
+        if: steps.changes.outputs.src== 'true'
         run: mkdir --parents ${{ env.TERRAFORM_DOCS_VERSION }}
 
       - name: Cache Terraform
         uses: actions/cache@v3
-        if: steps.changes.outputs.dir == 'true'
+        if: steps.changes.outputs.src== 'true'
         with:
           path: ${{ env.TERRAFORM_DOCS_VERSION }}
           key: ${{ runner.os }}-terraform-${{ hashFiles('**/.terraform.lock.hcl') }}
@@ -66,7 +69,7 @@ jobs:
 
       - name: Terraform min/max versions
         uses: clowdhaus/terraform-min-max@v1.0.7
-        if: steps.changes.outputs.dir == 'true'
+        if: steps.changes.outputs.src== 'true'
         id: minMax
         with:
           directory: ${{ matrix.directory }}
@@ -74,7 +77,7 @@ jobs:
       - name: Pre-commit Terraform ${{ steps.minMax.outputs.minVersion }}
         uses: clowdhaus/terraform-composite-actions/pre-commit@v1.6.0
         # Run only validate pre-commit check on min version supported
-        if: ${{ matrix.directory !=  '.' && steps.changes.outputs.dir == 'true' }}
+        if: ${{ matrix.directory !=  '.' && steps.changes.outputs.src== 'true' }}
         with:
           terraform-version: ${{ steps.minMax.outputs.minVersion }}
           args: 'terraform_validate --color=always --show-diff-on-failure --files ${{ matrix.directory }}/*'
@@ -82,7 +85,7 @@ jobs:
       - name: Pre-commit Terraform ${{ steps.minMax.outputs.minVersion }}
         uses: clowdhaus/terraform-composite-actions/pre-commit@v1.6.0
         # Run only validate pre-commit check on min version supported
-        if: ${{ matrix.directory ==  '.' && steps.changes.outputs.dir == 'true' }}
+        if: ${{ matrix.directory ==  '.' && steps.changes.outputs.src== 'true' }}
         with:
           terraform-version: ${{ steps.minMax.outputs.minVersion }}
           args: 'terraform_validate --color=always --show-diff-on-failure --files $(ls *.tf)'

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -26,7 +26,6 @@ jobs:
     outputs:
       directories: ${{ steps.dirs.outputs.directories }}
     steps:
-      - run: aws --version
       - name: Checkout
         uses: actions/checkout@v3
 
@@ -97,29 +96,38 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+
+      - uses: dorny/paths-filter@v2
+        id: changes
         with:
-          ref: ${{ github.event.pull_request.head.ref }}
-          repository: ${{github.event.pull_request.head.repo.full_name}}
+          filters: |
+            src:
+              - '**/*.tf'
 
       - name: Config Terraform plugin cache
+        if: steps.changes.outputs.src== 'true'
         run: mkdir --parents ${{ env.TERRAFORM_DOCS_VERSION }}
 
       - name: Cache Terraform
         uses: actions/cache@v3
+        if: steps.changes.outputs.src== 'true'
         with:
           path: ${{ env.TF_PLUGIN_CACHE_DIR }}
           key: ${{ runner.os }}-terraform-${{ hashFiles('**/.terraform.lock.hcl') }}
           restore-keys: ${{ runner.os }}-terraform-
 
       - name: Install tfsec
+        if: steps.changes.outputs.src== 'true'
         run: curl -sSLo ./tfsec https://github.com/aquasecurity/tfsec/releases/download/${{ env.TFSEC_VERSION }}/tfsec-$(uname)-amd64 && chmod +x tfsec && sudo mv tfsec /usr/bin/
 
       - name: Terraform min/max versions
         id: minMax
         uses: clowdhaus/terraform-min-max@v1.0.7
+        if: steps.changes.outputs.src== 'true'
 
       - name: Pre-commit Terraform ${{ steps.minMax.outputs.maxVersion }}
         uses: clowdhaus/terraform-composite-actions/pre-commit@v1.6.0
+        if: steps.changes.outputs.src== 'true'
         with:
           terraform-version: ${{ steps.minMax.outputs.maxVersion }}
           terraform-docs-version: ${{ env.TERRAFORM_DOCS_VERSION }}

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -70,7 +70,7 @@ jobs:
       - name: Pre-commit Terraform ${{ steps.minMax.outputs.minVersion }}
         uses: clowdhaus/terraform-composite-actions/pre-commit@v1.6.0
         # Run only validate pre-commit check on min version supported
-        if: ${{ matrix.directory !=  '.' }} && steps.changes.outputs.dir == 'true'
+        if: ${{ matrix.directory !=  '.' && steps.changes.outputs.dir == 'true' }}
         with:
           terraform-version: ${{ steps.minMax.outputs.minVersion }}
           args: 'terraform_validate --color=always --show-diff-on-failure --files ${{ matrix.directory }}/*'
@@ -78,7 +78,7 @@ jobs:
       - name: Pre-commit Terraform ${{ steps.minMax.outputs.minVersion }}
         uses: clowdhaus/terraform-composite-actions/pre-commit@v1.6.0
         # Run only validate pre-commit check on min version supported
-        if: ${{ matrix.directory ==  '.' }} && steps.changes.outputs.dir == 'true'
+        if: ${{ matrix.directory ==  '.' && steps.changes.outputs.dir == 'true' }}
         with:
           terraform-version: ${{ steps.minMax.outputs.minVersion }}
           args: 'terraform_validate --color=always --show-diff-on-failure --files $(ls *.tf)'

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -16,7 +16,7 @@ env:
   TFLINT_VERSION: v0.38.1
 
 concurrency:
-  group: ${{ github.head_ref || github.run_id }}
+  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -15,6 +15,10 @@ env:
   TF_PLUGIN_CACHE_DIR: ${{ github.workspace }}/.terraform.d/plugin-cache
   TFLINT_VERSION: v0.38.1
 
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   collectInputs:
     name: Collect workflow inputs

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches:
       - main
+    paths:
+      - '**.tf'
+      - '**.yml'
+      - '**.yaml'
 
 env:
   TERRAFORM_DOCS_VERSION: v0.16.0
@@ -37,34 +41,44 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - uses: dorny/paths-filter@v2
+        id: changes
+        with:
+          filters: |
+            dir:
+              - '${{ matrix.directory }}/**'
+
       - name: Config Terraform plugin cache
+        if: steps.changes.outputs.dir == 'true'
         run: mkdir --parents ${{ env.TERRAFORM_DOCS_VERSION }}
 
       - name: Cache Terraform
         uses: actions/cache@v3
+        if: steps.changes.outputs.dir == 'true'
         with:
           path: ${{ env.TERRAFORM_DOCS_VERSION }}
           key: ${{ runner.os }}-terraform-${{ hashFiles('**/.terraform.lock.hcl') }}
           restore-keys: ${{ runner.os }}-terraform-
 
       - name: Terraform min/max versions
-        id: minMax
         uses: clowdhaus/terraform-min-max@v1.0.7
+        if: steps.changes.outputs.dir == 'true'
+        id: minMax
         with:
           directory: ${{ matrix.directory }}
 
       - name: Pre-commit Terraform ${{ steps.minMax.outputs.minVersion }}
-        # Run only validate pre-commit check on min version supported
-        if: ${{ matrix.directory !=  '.' }}
         uses: clowdhaus/terraform-composite-actions/pre-commit@v1.6.0
+        # Run only validate pre-commit check on min version supported
+        if: ${{ matrix.directory !=  '.' }} && steps.changes.outputs.dir == 'true'
         with:
           terraform-version: ${{ steps.minMax.outputs.minVersion }}
           args: 'terraform_validate --color=always --show-diff-on-failure --files ${{ matrix.directory }}/*'
 
       - name: Pre-commit Terraform ${{ steps.minMax.outputs.minVersion }}
-        # Run only validate pre-commit check on min version supported
-        if: ${{ matrix.directory ==  '.' }}
         uses: clowdhaus/terraform-composite-actions/pre-commit@v1.6.0
+        # Run only validate pre-commit check on min version supported
+        if: ${{ matrix.directory ==  '.' }} && steps.changes.outputs.dir == 'true'
         with:
           terraform-version: ${{ steps.minMax.outputs.minVersion }}
           args: 'terraform_validate --color=always --show-diff-on-failure --files $(ls *.tf)'


### PR DESCRIPTION
### What does this PR do?
- Only run CI checks when necessary (affected files changed)

### Motivation
- Reduce the amount of checks that get executed that are not necessary for the given changeset

### More

- [ ] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
