### PR TITLE
feat: Allow users to specify multiple Route53 zones as well as cross account zones with `external-dns`

### DIFF
--- a/docs/add-ons/external-dns.md
+++ b/docs/add-ons/external-dns.md
@@ -18,6 +18,14 @@ External DNS can optionally leverage the `eks_cluster_domain` global property of
 eks_cluster_domain = <cluster_domain>
 ```
 
+Alternatively, you can supply a list of Route53 zone ARNs which external-dns will have access to create/manage records:
+
+```hcl
+  external_dns_route53_zone_arns = [
+    "arn:aws:route53::123456789012:hostedzone/Z1234567890"
+  ]
+```
+
 You can optionally customize the Helm chart that deploys `external-dns` via the following configuration.
 
 ```hcl

--- a/modules/kubernetes-addons/README.md
+++ b/modules/kubernetes-addons/README.md
@@ -181,6 +181,7 @@
 | <a name="input_external_dns_helm_config"></a> [external\_dns\_helm\_config](#input\_external\_dns\_helm\_config) | External DNS Helm Chart config | `any` | `{}` | no |
 | <a name="input_external_dns_irsa_policies"></a> [external\_dns\_irsa\_policies](#input\_external\_dns\_irsa\_policies) | Additional IAM policies for a IAM role for service accounts | `list(string)` | `[]` | no |
 | <a name="input_external_dns_private_zone"></a> [external\_dns\_private\_zone](#input\_external\_dns\_private\_zone) | Determines if referenced Route53 zone is private. | `bool` | `false` | no |
+| <a name="input_external_dns_route53_zone_arns"></a> [external\_dns\_route53\_zone\_arns](#input\_external\_dns\_route53\_zone\_arns) | List of Route53 zones ARNs which external-dns will have access to create/manage records | `list(string)` | `[]` | no |
 | <a name="input_external_secrets_helm_config"></a> [external\_secrets\_helm\_config](#input\_external\_secrets\_helm\_config) | External Secrets operator Helm Chart config | `any` | `{}` | no |
 | <a name="input_fargate_fluentbit_addon_config"></a> [fargate\_fluentbit\_addon\_config](#input\_fargate\_fluentbit\_addon\_config) | Fargate fluentbit add-on config | `any` | `{}` | no |
 | <a name="input_grafana_helm_config"></a> [grafana\_helm\_config](#input\_grafana\_helm\_config) | Kubernetes Grafana Helm Chart config | `any` | `null` | no |

--- a/modules/kubernetes-addons/external-dns/README.md
+++ b/modules/kubernetes-addons/external-dns/README.md
@@ -39,16 +39,16 @@ For complete project documentation, please visit the [ExternalDNS Github reposit
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_addon_context"></a> [addon\_context](#input\_addon\_context) | Input configuration for the addon | <pre>object({<br>    aws_caller_identity_account_id = string<br>    aws_caller_identity_arn        = string<br>    aws_eks_cluster_endpoint       = string<br>    aws_partition_id               = string<br>    aws_region_name                = string<br>    eks_cluster_id                 = string<br>    eks_oidc_issuer_url            = string<br>    eks_oidc_provider_arn          = string<br>    tags                           = map(string)<br>    irsa_iam_role_path             = string<br>    irsa_iam_permissions_boundary  = string<br>  })</pre> | n/a | yes |
-| <a name="input_domain_name"></a> [domain\_name](#input\_domain\_name) | Domain name of the Route53 hosted zone to use with External DNS. | `string` | n/a | yes |
+| <a name="input_domain_name"></a> [domain\_name](#input\_domain\_name) | [Deprecated - use `route53_zone_arns`] Domain name of the Route53 hosted zone to use with External DNS. | `string` | n/a | yes |
 | <a name="input_helm_config"></a> [helm\_config](#input\_helm\_config) | External DNS Helm Configuration | `any` | `{}` | no |
 | <a name="input_irsa_policies"></a> [irsa\_policies](#input\_irsa\_policies) | Additional IAM policies used for the add-on service account. | `list(string)` | n/a | yes |
 | <a name="input_manage_via_gitops"></a> [manage\_via\_gitops](#input\_manage\_via\_gitops) | Determines if the add-on should be managed via GitOps. | `bool` | `false` | no |
-| <a name="input_private_zone"></a> [private\_zone](#input\_private\_zone) | Determines if referenced Route53 hosted zone is private. | `bool` | `false` | no |
+| <a name="input_private_zone"></a> [private\_zone](#input\_private\_zone) | [Deprecated - use `route53_zone_arns`] Determines if referenced Route53 hosted zone is private. | `bool` | `false` | no |
+| <a name="input_route53_zone_arns"></a> [route53\_zone\_arns](#input\_route53\_zone\_arns) | List of Route53 zones ARNs which external-dns will have access to create/manage records | `list(string)` | `[]` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
 | <a name="output_argocd_gitops_config"></a> [argocd\_gitops\_config](#output\_argocd\_gitops\_config) | Configuration used for managing the add-on with GitOps |
-| <a name="output_zone_filter_ids"></a> [zone\_filter\_ids](#output\_zone\_filter\_ids) | Zone Filter Ids for the add-on |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/kubernetes-addons/external-dns/data.tf
+++ b/modules/kubernetes-addons/external-dns/data.tf
@@ -1,3 +1,4 @@
+# TODO - remove at next breaking change
 data "aws_route53_zone" "selected" {
   name         = var.domain_name
   private_zone = var.private_zone
@@ -5,11 +6,12 @@ data "aws_route53_zone" "selected" {
 
 data "aws_iam_policy_document" "external_dns_iam_policy_document" {
   statement {
-    effect    = "Allow"
-    resources = [data.aws_route53_zone.selected.arn]
-    actions = [
-      "route53:ChangeResourceRecordSets",
-    ]
+    effect = "Allow"
+    resources = distinct(concat(
+      [data.aws_route53_zone.selected.arn],
+      var.route53_zone_arns
+    ))
+    actions = ["route53:ChangeResourceRecordSets"]
   }
 
   statement {

--- a/modules/kubernetes-addons/external-dns/locals.tf
+++ b/modules/kubernetes-addons/external-dns/locals.tf
@@ -1,21 +1,19 @@
 locals {
   name                 = "external-dns"
   service_account_name = "${local.name}-sa"
-  zone_filter_ids      = jsonencode([data.aws_route53_zone.selected.zone_id])
 
   default_helm_config = {
     description = "ExternalDNS Helm Chart"
     name        = local.name
     chart       = local.name
     repository  = "https://charts.bitnami.com/bitnami"
-    version     = "6.5.6"
+    version     = "6.7.5"
     namespace   = local.name
     values      = local.default_helm_values
   }
 
   default_helm_values = [templatefile("${path.module}/values.yaml", {
-    aws_region      = var.addon_context.aws_region_name
-    zone_filter_ids = local.zone_filter_ids
+    aws_region = var.addon_context.aws_region_name
   })]
 
   helm_config = merge(
@@ -23,16 +21,19 @@ locals {
     var.helm_config
   )
 
-  set_values = [
-    {
-      name  = "serviceAccount.name"
-      value = local.service_account_name
-    },
-    {
-      name  = "serviceAccount.create"
-      value = false
-    }
-  ]
+  set_values = concat(
+    [
+      {
+        name  = "serviceAccount.name"
+        value = local.service_account_name
+      },
+      {
+        name  = "serviceAccount.create"
+        value = false
+      }
+    ],
+    try(var.helm_config.set_values, [])
+  )
 
   irsa_config = {
     kubernetes_namespace              = local.helm_config["namespace"]
@@ -44,7 +45,6 @@ locals {
 
   argocd_gitops_config = {
     enable             = true
-    zoneIdFilter       = data.aws_route53_zone.selected.zone_id
     serviceAccountName = local.service_account_name
   }
 }

--- a/modules/kubernetes-addons/external-dns/outputs.tf
+++ b/modules/kubernetes-addons/external-dns/outputs.tf
@@ -1,8 +1,3 @@
-output "zone_filter_ids" {
-  description = "Zone Filter Ids for the add-on"
-  value       = local.zone_filter_ids
-}
-
 output "argocd_gitops_config" {
   description = "Configuration used for managing the add-on with GitOps"
   value       = var.manage_via_gitops ? local.argocd_gitops_config : null

--- a/modules/kubernetes-addons/external-dns/values.yaml
+++ b/modules/kubernetes-addons/external-dns/values.yaml
@@ -1,4 +1,3 @@
 provider: aws
-zoneIdFilters: ${zone_filter_ids}
 aws:
   region: ${aws_region}

--- a/modules/kubernetes-addons/external-dns/variables.tf
+++ b/modules/kubernetes-addons/external-dns/variables.tf
@@ -16,14 +16,20 @@ variable "irsa_policies" {
 }
 
 variable "domain_name" {
-  description = "Domain name of the Route53 hosted zone to use with External DNS."
+  description = "[Deprecated - use `route53_zone_arns`] Domain name of the Route53 hosted zone to use with External DNS."
   type        = string
 }
 
 variable "private_zone" {
+  description = "[Deprecated - use `route53_zone_arns`] Determines if referenced Route53 hosted zone is private."
   type        = bool
-  description = "Determines if referenced Route53 hosted zone is private."
   default     = false
+}
+
+variable "route53_zone_arns" {
+  description = "List of Route53 zones ARNs which external-dns will have access to create/manage records"
+  type        = list(string)
+  default     = []
 }
 
 variable "addon_context" {

--- a/modules/kubernetes-addons/main.tf
+++ b/modules/kubernetes-addons/main.tf
@@ -179,14 +179,18 @@ module "crossplane" {
 }
 
 module "external_dns" {
-  count             = var.enable_external_dns ? 1 : 0
-  source            = "./external-dns"
+  source = "./external-dns"
+
+  count = var.enable_external_dns ? 1 : 0
+
   helm_config       = var.external_dns_helm_config
   manage_via_gitops = var.argocd_manage_add_ons
   irsa_policies     = var.external_dns_irsa_policies
   addon_context     = local.addon_context
+
   domain_name       = var.eks_cluster_domain
   private_zone      = var.external_dns_private_zone
+  route53_zone_arns = var.external_dns_route53_zone_arns
 }
 
 module "fargate_fluentbit" {

--- a/modules/kubernetes-addons/variables.tf
+++ b/modules/kubernetes-addons/variables.tf
@@ -285,6 +285,12 @@ variable "external_dns_private_zone" {
   default     = false
 }
 
+variable "external_dns_route53_zone_arns" {
+  description = "List of Route53 zones ARNs which external-dns will have access to create/manage records"
+  type        = list(string)
+  default     = []
+}
+
 #-----------Amazon Managed Service for Prometheus-------------
 variable "enable_amazon_prometheus" {
   description = "Enable AWS Managed Prometheus service"


### PR DESCRIPTION
### What does this PR do?
- Allow users to specify multiple Route53 zones as well as cross account zones with `external-dns`
- Allow setting `set_values` through `helm_config` variable
- Update default `external-dns` helm chart version to latest

### Motivation
- This allows users to use `external-dns` addon with one or more Route53 zones in the current account, external account(s), or both while not requiring them to re-provide the values set in the default `values.yaml` file provided in the addon
- Closes #512 
- Closes #516
- Closes #541
- Closes #638 

### More

- [ ] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [x] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
