### PR TITLE
chore: kubernetes_service_account_v1 secret always show diff

### DIFF
--- a/modules/irsa/main.tf
+++ b/modules/irsa/main.tf
@@ -18,6 +18,17 @@ resource "kubernetes_service_account_v1" "irsa" {
   }
 
   automount_service_account_token = true
+
+  secret {
+    name = ""
+  }
+
+  lifecycle {
+    ignore_changes = [
+      image_pull_secret,
+      secret
+    ]
+  }
 }
 
 # NOTE: Don't change the condition from StringLike to StringEquals. We are using wild characters for service account hence StringLike is required.


### PR DESCRIPTION
issue: https://github.com/hashicorp/terraform-provider-kubernetes/issues/1043#issuecomment-1134245891

### What does this PR do?

🛑 Please open an issue first to discuss any significant work and flesh out details/direction - we would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/aws-ia/terraform-aws-eks-blueprints/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

<!-- A brief description of the change being made with this pull request. -->

### Motivation

<!-- What inspired you to submit this pull request? -->

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR

**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
