### PR TITLE
Pass target_group_arns to self managed nodes autoscaling group

### DIFF
--- a/modules/aws-eks-self-managed-node-groups/locals.tf
+++ b/modules/aws-eks-self-managed-node-groups/locals.tf
@@ -40,6 +40,7 @@ locals {
     subnet_ids              = []
     additional_tags         = {}
     additional_iam_policies = []
+    target_group_arns       = []
   }
 
   needs_mixed_instances_policy = length(local.self_managed_node_group["instance_types"]) > 1 ? true : false

--- a/modules/aws-eks-self-managed-node-groups/locals.tf
+++ b/modules/aws-eks-self-managed-node-groups/locals.tf
@@ -40,7 +40,6 @@ locals {
     subnet_ids              = []
     additional_tags         = {}
     additional_iam_policies = []
-    target_group_arns       = []
   }
 
   needs_mixed_instances_policy = length(local.self_managed_node_group["instance_types"]) > 1 ? true : false

--- a/modules/aws-eks-self-managed-node-groups/main.tf
+++ b/modules/aws-eks-self-managed-node-groups/main.tf
@@ -6,6 +6,7 @@ resource "aws_autoscaling_group" "self_managed_ng" {
   vpc_zone_identifier = length(local.self_managed_node_group["subnet_ids"]) == 0 ? (local.self_managed_node_group["subnet_type"] == "public" ? var.context.public_subnet_ids : var.context.private_subnet_ids) : local.self_managed_node_group["subnet_ids"]
 
   capacity_rebalance = local.self_managed_node_group["capacity_rebalance"]
+  target_group_arns  = local.self_managed_node_group["target_group_arns"]
 
   dynamic "launch_template" {
     for_each = !local.needs_mixed_instances_policy ? [1] : []

--- a/modules/aws-eks-self-managed-node-groups/main.tf
+++ b/modules/aws-eks-self-managed-node-groups/main.tf
@@ -6,7 +6,7 @@ resource "aws_autoscaling_group" "self_managed_ng" {
   vpc_zone_identifier = length(local.self_managed_node_group["subnet_ids"]) == 0 ? (local.self_managed_node_group["subnet_type"] == "public" ? var.context.public_subnet_ids : var.context.private_subnet_ids) : local.self_managed_node_group["subnet_ids"]
 
   capacity_rebalance = local.self_managed_node_group["capacity_rebalance"]
-  target_group_arns  = local.self_managed_node_group["target_group_arns"]
+  target_group_arns  = try(local.self_managed_node_group["target_group_arns"], null)
 
   dynamic "launch_template" {
     for_each = !local.needs_mixed_instances_policy ? [1] : []


### PR DESCRIPTION
### What does this PR do?
Pass target_group_arns to self managed nodes autoscaling group
See issue: https://github.com/aws-ia/terraform-aws-eks-blueprints/issues/854

### Motivation
When adding an alb for our nodes there was no way of passing down the target_group_arn to the nodes
This can be circumvented by using an autoscaling attachment but in every other apply the eks_blueprint notices an attachment that isn't defined in the blueprint so it removes it.
See issue: https://github.com/aws-ia/terraform-aws-eks-blueprints/issues/854

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR

**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
