### PR TITLE
Fix/set argocd helm value types explicitly

### DIFF
--- a/modules/kubernetes-addons/argocd/main.tf
+++ b/modules/kubernetes-addons/argocd/main.tf
@@ -64,14 +64,14 @@ resource "helm_release" "argocd_application" {
   }
 
   set {
-    name  = "source.helm.values"
+    name = "source.helm.values"
     value = yamlencode(merge(
       { repo_url = each.value.repo_url },
       each.value.values,
       local.global_application_values,
       each.value.add_on_application ? var.addon_config : {}
     ))
-    type  = "auto"
+    type = "auto"
   }
 
   # Destination Config.

--- a/modules/kubernetes-addons/argocd/main.tf
+++ b/modules/kubernetes-addons/argocd/main.tf
@@ -29,48 +29,56 @@ resource "helm_release" "argocd_application" {
   set {
     name  = "name"
     value = each.key
+    type  = "string"
   }
 
   set {
     name  = "project"
     value = each.value.project
+    type  = "string"
   }
 
   # Source Config.
   set {
     name  = "source.repoUrl"
     value = each.value.repo_url
+    type  = "string"
   }
 
   set {
     name  = "source.targetRevision"
     value = each.value.target_revision
+    type  = "string"
   }
 
   set {
     name  = "source.path"
     value = each.value.path
+    type  = "string"
   }
 
   set {
     name  = "source.helm.releaseName"
     value = each.key
+    type  = "string"
   }
 
   set {
-    name = "source.helm.values"
+    name  = "source.helm.values"
     value = yamlencode(merge(
       { repo_url = each.value.repo_url },
       each.value.values,
       local.global_application_values,
       each.value.add_on_application ? var.addon_config : {}
     ))
+    type  = "auto"
   }
 
   # Destination Config.
   set {
     name  = "destination.server"
     value = each.value.destination
+    type  = "string"
   }
 
   depends_on = [module.helm_addon]


### PR DESCRIPTION
### What does this PR do?
Explicitly setting the type for values used in the Helm release for ArgoCD.
This should remove errors reported for inconsistent final plans by Terraform.

### Motivation

* Closes https://github.com/aws-ia/terraform-aws-eks-blueprints/issues/633

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR

**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
