### PR TITLE
Fix for ArgoCD Workload Application URL

### DIFF
--- a/examples/eks-cluster-with-external-dns/main.tf
+++ b/examples/eks-cluster-with-external-dns/main.tf
@@ -78,7 +78,7 @@ module "eks_blueprints_kubernetes_addons" {
   argocd_applications = {
     workloads = {
       path     = "envs/dev"
-      repo_url = "https://github.com/aws-samples/eks_blueprints-workloads.git"
+      repo_url = "https://github.com/aws-samples/eks-blueprints-workloads.git"
       values = {
         spec = {
           ingress = {


### PR DESCRIPTION
### What does this PR do?

🛑 Please open an issue first to discuss any significant work and flesh out details/direction - we would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/aws-ia/terraform-aws-eks-blueprints/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

<!-- A brief description of the change being made with this pull request. -->

Fixed the URL for ArgoCD Workload application. It was referring to a wrong URL that was getting 404 error

### Motivation

<!-- What inspired you to submit this pull request? -->

https://github.com/aws-ia/terraform-aws-eks-blueprints/issues/861

### More

- [X] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [-] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [-] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [-] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [-] Yes, I ran `pre-commit run -a` with this PR

**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
