### PR TITLE
Add instance refresh to self managed node groups

### DIFF
--- a/modules/aws-eks-self-managed-node-groups/main.tf
+++ b/modules/aws-eks-self-managed-node-groups/main.tf
@@ -7,6 +7,9 @@ resource "aws_autoscaling_group" "self_managed_ng" {
 
   capacity_rebalance = local.self_managed_node_group["capacity_rebalance"]
   target_group_arns  = try(local.self_managed_node_group["target_group_arns"], null)
+  instance_refresh {
+    strategy = "Rolling"
+  }
 
   dynamic "launch_template" {
     for_each = !local.needs_mixed_instances_policy ? [1] : []


### PR DESCRIPTION
### What does this PR do?
Add instance_refresh to self managed node groups
Issue https://github.com/aws-ia/terraform-aws-eks-blueprints/issues/874

### Motivation
Changes to launch template (and other things) currently require a manual instance refresh in AWS
This change will make it so that these changes are reflected in running instances.

### More

- [X] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR

**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

