### PR TITLE
fix: Add `fsx:UpdateFileSystem` permission to `aws-fsx-csi-driver` addon

### DIFF
--- a/modules/kubernetes-addons/aws-fsx-csi-driver/data.tf
+++ b/modules/kubernetes-addons/aws-fsx-csi-driver/data.tf
@@ -34,6 +34,7 @@ data "aws_iam_policy_document" "aws_fsx_csi_driver" {
       "fsx:CreateFileSystem",
       "fsx:DeleteFileSystem",
       "fsx:DescribeFileSystems",
+      "fsx:UpdateFileSystem",
       "fsx:TagResource",
     ]
   }


### PR DESCRIPTION
### What does this PR do?

Adding "fsx:UpdateFileSystem" action in the policy, in order to allow dynamic resize of the File System. Without this updated policy, a resize request in PVC results in an error. With this policy, insted, volume resizing works.

Closes #911

Adding "fsx:UpdateFileSystem" action in the policy, in order to allow dynamic resize of the File System. Without this updated policy, a resize request in PVC results in an error. With this policy, insted, volume resizing works.

### Motivation

Volume resizing is required for me, but it can be required for many other users

### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR

**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
