### PR TITLE
fix: Correct kubecost repo URL

### DIFF
--- a/docs/add-ons/kubecost.md
+++ b/docs/add-ons/kubecost.md
@@ -22,7 +22,7 @@ Deploy Kubecost with custom `values.yaml`
   # Optional Map value; pass kubecost-values.yaml from consumer module
     kubecost_helm_config = {
     name       = "kubecost"                                             # (Required) Release name.
-    repository = "oci://public.ecr.aws/kubecost/cost-analyzer"          # (Optional) Repository URL where to locate the requested chart.
+    repository = "oci://public.ecr.aws/kubecost"                        # (Optional) Repository URL where to locate the requested chart.
     chart      = "cost-analyzer"                                        # (Required) Chart name to be installed.
     version    = "1.96.0"                                               # (Optional) Specify the exact chart version to install. If this is not specified, it defaults to the version set within default_helm_config: https://github.com/aws-ia/terraform-aws-eks-blueprints/blob/main/modules/kubernetes-addons/kubecost/locals.tf
     namespace  = "kubecost"                                             # (Optional) The namespace to install the release into.

--- a/modules/kubernetes-addons/kubecost/locals.tf
+++ b/modules/kubernetes-addons/kubecost/locals.tf
@@ -4,7 +4,7 @@ locals {
   default_helm_config = {
     name             = local.name
     chart            = "cost-analyzer"
-    repository       = "oci://public.ecr.aws/kubecost/cost-analyzer"
+    repository       = "oci://public.ecr.aws/kubecost"
     version          = "1.96.0"
     namespace        = local.name
     values           = local.default_helm_values


### PR DESCRIPTION
### What does this PR do?

This PR fix the repo url for kubecost helm add-on
Closes #913

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [x] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR

**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
