### PR TITLE
Stakater reloader kubernetes addon

### DIFF
--- a/examples/crossplane/main.tf
+++ b/examples/crossplane/main.tf
@@ -97,6 +97,9 @@ module "eks_blueprints_kubernetes_addons" {
     additional_irsa_policies = ["arn:aws:iam::aws:policy/AmazonS3FullAccess"]
   }
 
+  # Enable configmap reloader
+  enable_reloader = true
+
   tags = local.tags
 }
 

--- a/modules/kubernetes-addons/README.md
+++ b/modules/kubernetes-addons/README.md
@@ -59,6 +59,7 @@
 | <a name="module_opentelemetry_operator"></a> [opentelemetry\_operator](#module\_opentelemetry\_operator) | ./opentelemetry-operator | n/a |
 | <a name="module_prometheus"></a> [prometheus](#module\_prometheus) | ./prometheus | n/a |
 | <a name="module_promtail"></a> [promtail](#module\_promtail) | ./promtail | n/a |
+| <a name="module_reloader"></a> [reloader](#module\_reloader) | ./reloader | n/a |
 | <a name="module_secrets_store_csi_driver"></a> [secrets\_store\_csi\_driver](#module\_secrets\_store\_csi\_driver) | ./secrets-store-csi-driver | n/a |
 | <a name="module_spark_history_server"></a> [spark\_history\_server](#module\_spark\_history\_server) | ./spark-history-server | n/a |
 | <a name="module_spark_k8s_operator"></a> [spark\_k8s\_operator](#module\_spark\_k8s\_operator) | ./spark-k8s-operator | n/a |
@@ -179,6 +180,7 @@
 | <a name="input_enable_opentelemetry_operator"></a> [enable\_opentelemetry\_operator](#input\_enable\_opentelemetry\_operator) | Enable opentelemetry operator add-on | `bool` | `false` | no |
 | <a name="input_enable_prometheus"></a> [enable\_prometheus](#input\_enable\_prometheus) | Enable Community Prometheus add-on | `bool` | `false` | no |
 | <a name="input_enable_promtail"></a> [enable\_promtail](#input\_enable\_promtail) | Enable Promtail add-on | `bool` | `false` | no |
+| <a name="input_enable_reloader"></a> [enable\_reloader](#input\_enable\_reloader) | Enable Reloader add-on | `bool` | `false` | no |
 | <a name="input_enable_secrets_store_csi_driver"></a> [enable\_secrets\_store\_csi\_driver](#input\_enable\_secrets\_store\_csi\_driver) | Enable CSI Secrets Store Provider | `bool` | `false` | no |
 | <a name="input_enable_secrets_store_csi_driver_provider_aws"></a> [enable\_secrets\_store\_csi\_driver\_provider\_aws](#input\_enable\_secrets\_store\_csi\_driver\_provider\_aws) | Enable AWS CSI Secrets Store Provider | `bool` | `false` | no |
 | <a name="input_enable_self_managed_aws_ebs_csi_driver"></a> [enable\_self\_managed\_aws\_ebs\_csi\_driver](#input\_enable\_self\_managed\_aws\_ebs\_csi\_driver) | Enable self-managed aws-ebs-csi-driver add-on; enable\_self\_managed\_aws\_ebs\_csi\_driver and enable\_amazon\_eks\_aws\_ebs\_csi\_driver are mutually exclusive | `bool` | `false` | no |
@@ -227,6 +229,7 @@
 | <a name="input_opentelemetry_operator_helm_config"></a> [opentelemetry\_operator\_helm\_config](#input\_opentelemetry\_operator\_helm\_config) | Opentelemetry Operator Helm Chart config | `any` | `{}` | no |
 | <a name="input_prometheus_helm_config"></a> [prometheus\_helm\_config](#input\_prometheus\_helm\_config) | Community Prometheus Helm Chart config | `any` | `{}` | no |
 | <a name="input_promtail_helm_config"></a> [promtail\_helm\_config](#input\_promtail\_helm\_config) | Promtail Helm Chart config | `any` | `{}` | no |
+| <a name="input_reloader_helm_config"></a> [reloader\_helm\_config](#input\_reloader\_helm\_config) | Reloader Helm Chart config | `any` | `{}` | no |
 | <a name="input_secrets_store_csi_driver_helm_config"></a> [secrets\_store\_csi\_driver\_helm\_config](#input\_secrets\_store\_csi\_driver\_helm\_config) | CSI Secrets Store Provider Helm Configurations | `any` | `null` | no |
 | <a name="input_self_managed_aws_ebs_csi_driver_helm_config"></a> [self\_managed\_aws\_ebs\_csi\_driver\_helm\_config](#input\_self\_managed\_aws\_ebs\_csi\_driver\_helm\_config) | Self-managed aws-ebs-csi-driver Helm chart config | `any` | `{}` | no |
 | <a name="input_self_managed_coredns_helm_config"></a> [self\_managed\_coredns\_helm\_config](#input\_self\_managed\_coredns\_helm\_config) | Self-managed CoreDNS Helm chart config | `any` | `{}` | no |

--- a/modules/kubernetes-addons/main.tf
+++ b/modules/kubernetes-addons/main.tf
@@ -302,6 +302,14 @@ module "prometheus" {
   addon_context                        = local.addon_context
 }
 
+module "reloader" {
+  count             = var.enable_reloader ? 1 : 0
+  source            = "./reloader"
+  helm_config       = var.reloader_helm_config
+  manage_via_gitops = var.argocd_manage_add_ons
+  addon_context     = local.addon_context
+}
+
 module "spark_history_server" {
   count             = var.enable_spark_history_server ? 1 : 0
   source            = "./spark-history-server"

--- a/modules/kubernetes-addons/reloader/README.md
+++ b/modules/kubernetes-addons/reloader/README.md
@@ -1,0 +1,40 @@
+# Reloader Helm Chart
+
+This add-on configures the [Reloader Helm Chart](https://github.com/stakater/Reloader)
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
+| <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.4.1 |
+
+## Providers
+
+No providers.
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_helm_addon"></a> [helm\_addon](#module\_helm\_addon) | ../helm-addon | n/a |
+
+## Resources
+
+No resources.
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_addon_context"></a> [addon\_context](#input\_addon\_context) | Input configuration for the addon | <pre>object({<br>    aws_caller_identity_account_id = string<br>    aws_caller_identity_arn        = string<br>    aws_eks_cluster_endpoint       = string<br>    aws_partition_id               = string<br>    aws_region_name                = string<br>    eks_cluster_id                 = string<br>    eks_oidc_issuer_url            = string<br>    eks_oidc_provider_arn          = string<br>    tags                           = map(string)<br>    irsa_iam_role_path             = string<br>    irsa_iam_permissions_boundary  = string<br>  })</pre> | n/a | yes |
+| <a name="input_helm_config"></a> [helm\_config](#input\_helm\_config) | Helm provider config for Reloader. | `any` | `{}` | no |
+| <a name="input_manage_via_gitops"></a> [manage\_via\_gitops](#input\_manage\_via\_gitops) | Determines if the add-on should be managed via GitOps. | `bool` | `false` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_argocd_gitops_config"></a> [argocd\_gitops\_config](#output\_argocd\_gitops\_config) | Configuration used for managing the add-on with ArgoCD |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/kubernetes-addons/reloader/locals.tf
+++ b/modules/kubernetes-addons/reloader/locals.tf
@@ -1,0 +1,24 @@
+locals {
+  name = "reloader"
+
+  default_helm_config = {
+    name        = local.name
+    chart       = local.name
+    repository  = "https://stakater.github.io/stakater-charts"
+    version     = "v0.0.118"
+    namespace   = local.name
+    values      = []
+    description = "Reloader Helm Chart deployment configuration"
+  }
+
+  helm_config = merge(
+    local.default_helm_config,
+    var.helm_config
+  )
+
+
+  argocd_gitops_config = {
+    enable             = true
+    serviceAccountName = local.name
+  }
+}

--- a/modules/kubernetes-addons/reloader/locals.tf
+++ b/modules/kubernetes-addons/reloader/locals.tf
@@ -2,13 +2,14 @@ locals {
   name = "reloader"
 
   default_helm_config = {
-    name        = local.name
-    chart       = local.name
-    repository  = "https://stakater.github.io/stakater-charts"
-    version     = "v0.0.118"
-    namespace   = local.name
-    values      = []
-    description = "Reloader Helm Chart deployment configuration"
+    name             = local.name
+    chart            = local.name
+    repository       = "https://stakater.github.io/stakater-charts"
+    version          = "v0.0.118"
+    namespace        = local.name
+    create_namespace = true
+    values           = []
+    description      = "Reloader Helm Chart deployment configuration"
   }
 
   helm_config = merge(

--- a/modules/kubernetes-addons/reloader/main.tf
+++ b/modules/kubernetes-addons/reloader/main.tf
@@ -1,0 +1,7 @@
+module "helm_addon" {
+  source            = "../helm-addon"
+  manage_via_gitops = var.manage_via_gitops
+  helm_config       = local.helm_config
+  irsa_config       = null
+  addon_context     = var.addon_context
+}

--- a/modules/kubernetes-addons/reloader/outputs.tf
+++ b/modules/kubernetes-addons/reloader/outputs.tf
@@ -1,0 +1,4 @@
+output "argocd_gitops_config" {
+  description = "Configuration used for managing the add-on with ArgoCD"
+  value       = var.manage_via_gitops ? local.argocd_gitops_config : null
+}

--- a/modules/kubernetes-addons/reloader/variables.tf
+++ b/modules/kubernetes-addons/reloader/variables.tf
@@ -1,0 +1,28 @@
+variable "helm_config" {
+  description = "Helm provider config for Reloader."
+  type        = any
+  default     = {}
+}
+
+variable "manage_via_gitops" {
+  description = "Determines if the add-on should be managed via GitOps."
+  type        = bool
+  default     = false
+}
+
+variable "addon_context" {
+  description = "Input configuration for the addon"
+  type = object({
+    aws_caller_identity_account_id = string
+    aws_caller_identity_arn        = string
+    aws_eks_cluster_endpoint       = string
+    aws_partition_id               = string
+    aws_region_name                = string
+    eks_cluster_id                 = string
+    eks_oidc_issuer_url            = string
+    eks_oidc_provider_arn          = string
+    tags                           = map(string)
+    irsa_iam_role_path             = string
+    irsa_iam_permissions_boundary  = string
+  })
+}

--- a/modules/kubernetes-addons/reloader/versions.tf
+++ b/modules/kubernetes-addons/reloader/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.0.0"
+
+  required_providers {
+    helm = {
+      source  = "hashicorp/helm"
+      version = ">= 2.4.1"
+    }
+  }
+}

--- a/modules/kubernetes-addons/variables.tf
+++ b/modules/kubernetes-addons/variables.tf
@@ -1026,6 +1026,19 @@ variable "kuberay_operator_helm_config" {
   default     = {}
 }
 
+#----------- Reloader Addon-------------
+variable "enable_reloader" {
+  description = "Enable Reloader add-on"
+  type        = bool
+  default     = false
+}
+
+variable "reloader_helm_config" {
+  description = "Reloader Helm Chart config"
+  type        = any
+  default     = {}
+}
+
 #-----------Apache Airflow ADDON-------------
 variable "enable_airflow" {
   description = "Enable Airflow add-on"


### PR DESCRIPTION
### What does this PR do?

Adds [Reloader](https://github.com/stakater/Reloader) to the Kubernetes addons deployable. 

### Motivation

My company intends to use this addon in our deployment. Adding it to the blueprints makes this easier.

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [x] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR (Extended the Crossplane example)
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR

**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
