### PR TITLE
chore: Update PR template to ensure issue is linked and clarify when examples/docs should be added

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,6 +8,7 @@ Consult the [CONTRIBUTING](https://github.com/aws-ia/terraform-aws-eks-blueprint
 ### Motivation
 
 <!-- What inspired you to submit this pull request? -->
+- Resolves #<issue-number>
 
 ### More
 
@@ -17,7 +18,9 @@ Consult the [CONTRIBUTING](https://github.com/aws-ia/terraform-aws-eks-blueprint
 - [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
 - [ ] Yes, I ran `pre-commit run -a` with this PR
 
-**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.
+**Note**: Not all the PRs require a new example and/or doc page. In general:
+- Use an existing example when possible to demonstrate a new addons usage
+- A new docs page under `docs/add-ons/*` is required for new a new addon
 
 ### For Moderators
 


### PR DESCRIPTION
### What does this PR do?
- Add a templated line for `Resolves #<xxx>` to help guide users to autolink issues to PRs 
- Add clarifying note on using existing examples to demonstrate addon usage and add a docs page when adding an addon

### Motivation

- Updating project general practices

### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR

**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
