### PR TITLE
doc: remove argocd_admin_password_secret_name

### DIFF
--- a/docs/add-ons/argocd.md
+++ b/docs/add-ons/argocd.md
@@ -16,12 +16,6 @@ enable_argocd = true
 
 ArgoCD has a built-in `admin` user that has full access to the ArgoCD instance. By default, Argo will create a password for the admin user.
 
-You can optionally provide a custom password for the admin user by specifying the name of an AWS Secrets Manager secret. The value for the secret should be a [bcrypt hash](https://github.com/argoproj/argo-helm/blob/master/charts/argo-cd/values.yaml#L1785) of your admin password. The hashed value will be stored as a Kubernetes Secret and will be used to configure the admin password for Argo.
-
-```
-argocd_admin_password_secret_name = <secret_name>
-```
-
 See the [ArgoCD documentation](https://argo-cd.readthedocs.io/en/stable/operator-manual/user-management/) for additional details on managing users.
 
 ### Customizing the Helm Chart
@@ -112,7 +106,6 @@ The following demonstrates a complete example for configuring ArgoCD.
 ```hcl
 enable_argocd                       = true
 argocd_manage_add_ons               = true
-argocd_admin_password_secret_name   = <secret_name>
 
 argocd_helm_config = {
   name             = "argo-cd"


### PR DESCRIPTION
### What does this PR do?

🛑 Please open an issue first to discuss any significant work and flesh out details/direction - we would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/aws-ia/terraform-aws-eks-blueprints/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

<!-- A brief description of the change being made with this pull request. -->
- removes `argocd_admin_password_secret_name` from the docs

### Motivation

<!-- What inspired you to submit this pull request? -->
- `argocd_admin_password_secret_name` has been removed in https://github.com/aws-ia/terraform-aws-eks-blueprints/pull/748 but wasn't removed in the docs.


### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR

**Note**: Not all the PRs require a new example and/or doc page. In general:
- Use an existing example when possible to demonstrate a new addons usage
- A new docs page under `docs/add-ons/*` is required for new a new addon

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
