### PR TITLE
Support forcing type on Helm chart `set` attribute

### DIFF
--- a/examples/eks-cluster-with-new-vpc/main.tf
+++ b/examples/eks-cluster-with-new-vpc/main.tf
@@ -79,10 +79,20 @@ module "eks_blueprints_kubernetes_addons" {
   # Add-ons
   enable_aws_load_balancer_controller = true
   enable_metrics_server               = true
-  enable_cluster_autoscaler           = true
   enable_aws_cloudwatch_metrics       = true
   enable_kubecost                     = true
   enable_gatekeeper                   = true
+
+  enable_cluster_autoscaler = true
+  cluster_autoscaler_helm_config = {
+    set = [
+      {
+        name  = "podLabels.prometheus\\.io/scrape",
+        value = "true",
+        type  = "string",
+      }
+    ]
+  }
 
   enable_cert_manager = true
   cert_manager_helm_config = {

--- a/modules/kubernetes-addons/helm-addon/main.tf
+++ b/modules/kubernetes-addons/helm-addon/main.tf
@@ -43,6 +43,7 @@ resource "helm_release" "addon" {
     content {
       name  = each_item.value.name
       value = each_item.value.value
+      type  = try(each_item.value.type, null)
     }
   }
 
@@ -53,6 +54,7 @@ resource "helm_release" "addon" {
     content {
       name  = each_item.value.name
       value = each_item.value.value
+      type  = try(each_item.value.type, null)
     }
   }
   depends_on = [module.irsa]


### PR DESCRIPTION
### What does this PR do?

🛑 Please open an issue first to discuss any significant work and flesh out details/direction - we would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/aws-ia/terraform-aws-eks-blueprints/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

Allow the user to set the `type` attribute within the `set` block of the `helm_release` resource if needed.

### Motivation

<!-- What inspired you to submit this pull request? -->
- Resolves #942 

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR

**Note**: Not all the PRs require a new example and/or doc page. In general:
- Use an existing example when possible to demonstrate a new addons usage
- A new docs page under `docs/add-ons/*` is required for new a new addon

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

I've updated the `eks-cluster-with-new-vpc` to prove it works, but noticed that `cert_manager_helm_config` is using `set_values` to configure Helm attributes - I don't think `set_values` works?
