### PR TITLE
Add the cert-manager CSI driver

### DIFF
--- a/docs/add-ons/cert-manager-csi-driver.md
+++ b/docs/add-ons/cert-manager-csi-driver.md
@@ -1,0 +1,24 @@
+# cert-manager-csi-driver
+
+Cert Manager csi-driver is a Container Storage Interface (CSI) driver plugin for Kubernetes to work along cert-manager. The goal for this plugin is to seamlessly request and mount certificate key pairs to pods. This is useful for facilitating mTLS, or otherwise securing connections of pods with guaranteed present certificates whilst having all of the features that cert-manager provides.
+
+For complete project documentation, please visit the [cert-manager-csi-driver documentation site](https://cert-manager.io/docs/projects/csi-driver).
+
+## Usage
+
+cert-manger can be deployed by enabling the add-on via the following.
+
+```hcl
+enable_cert_manager_csi_driver = true
+```
+
+### GitOps Configuration
+
+The following properties are made available for use when managing the add-on via GitOps.
+
+```
+
+certManagerCsiDriver = {
+  enable = true
+}
+```

--- a/examples/eks-cluster-with-new-vpc/main.tf
+++ b/examples/eks-cluster-with-new-vpc/main.tf
@@ -103,6 +103,7 @@ module "eks_blueprints_kubernetes_addons" {
       },
     ]
   }
+  enable_cert_manager_csi_driver = true
 
   tags = local.tags
 }

--- a/examples/tls-with-aws-pca-issuer/README.md
+++ b/examples/tls-with-aws-pca-issuer/README.md
@@ -6,6 +6,7 @@ This example deploys the following
 - Creates a new sample VPC, 3 Private Subnets and 3 Public Subnets
 - Creates Internet gateway for Public Subnets and NAT Gateway for Private Subnets
 - Enables cert-manager module
+- Enables cert-manager CSI driver module
 - Enables aws-privateca-issuer module
 - Creates AWS Certificate Manager Private Certificate Authority, enables and activates it
 - Creates the CRDs to fetch `tls.crt`, `tls.key` and `ca.crt` , which will be available as Kubernetes Secret. Now you may mount the secret in the application for end to end TLS.

--- a/examples/tls-with-aws-pca-issuer/main.tf
+++ b/examples/tls-with-aws-pca-issuer/main.tf
@@ -77,9 +77,10 @@ module "eks_blueprints_kubernetes_addons" {
   enable_amazon_eks_kube_proxy = true
 
   # Add-ons
-  enable_cert_manager         = true
-  enable_aws_privateca_issuer = true
-  aws_privateca_acmca_arn     = aws_acmpca_certificate_authority.example.arn
+  enable_cert_manager            = true
+  enable_cert_manager_csi_driver = true
+  enable_aws_privateca_issuer    = true
+  aws_privateca_acmca_arn        = aws_acmpca_certificate_authority.example.arn
 
   tags = local.tags
 }

--- a/modules/kubernetes-addons/README.md
+++ b/modules/kubernetes-addons/README.md
@@ -39,6 +39,7 @@
 | <a name="module_aws_vpc_cni"></a> [aws\_vpc\_cni](#module\_aws\_vpc\_cni) | ./aws-vpc-cni | n/a |
 | <a name="module_calico"></a> [calico](#module\_calico) | ./calico | n/a |
 | <a name="module_cert_manager"></a> [cert\_manager](#module\_cert\_manager) | ./cert-manager | n/a |
+| <a name="module_cert_manager_csi_driver"></a> [cert\_manager\_csi\_driver](#module\_cert\_manager\_csi\_driver) | ./cert-manager-csi-driver | n/a |
 | <a name="module_chaos_mesh"></a> [chaos\_mesh](#module\_chaos\_mesh) | ./chaos-mesh | n/a |
 | <a name="module_cilium"></a> [cilium](#module\_cilium) | ./cilium | n/a |
 | <a name="module_cluster_autoscaler"></a> [cluster\_autoscaler](#module\_cluster\_autoscaler) | ./cluster-autoscaler | n/a |
@@ -123,6 +124,7 @@
 | <a name="input_aws_privateca_issuer_helm_config"></a> [aws\_privateca\_issuer\_helm\_config](#input\_aws\_privateca\_issuer\_helm\_config) | PCA Issuer Helm Chart config | `any` | `{}` | no |
 | <a name="input_aws_privateca_issuer_irsa_policies"></a> [aws\_privateca\_issuer\_irsa\_policies](#input\_aws\_privateca\_issuer\_irsa\_policies) | IAM policy ARNs for AWS ACM PCA IRSA | `list(string)` | `[]` | no |
 | <a name="input_calico_helm_config"></a> [calico\_helm\_config](#input\_calico\_helm\_config) | Calico add-on config | `any` | `{}` | no |
+| <a name="input_cert_manager_csi_driver_helm_config"></a> [cert\_manager\_csi\_driver\_helm\_config](#input\_cert\_manager\_csi\_driver\_helm\_config) | Cert Manager CSI Driver Helm Chart config | `any` | `{}` | no |
 | <a name="input_cert_manager_domain_names"></a> [cert\_manager\_domain\_names](#input\_cert\_manager\_domain\_names) | Domain names of the Route53 hosted zone to use with cert-manager | `list(string)` | `[]` | no |
 | <a name="input_cert_manager_helm_config"></a> [cert\_manager\_helm\_config](#input\_cert\_manager\_helm\_config) | Cert Manager Helm Chart config | `any` | `{}` | no |
 | <a name="input_cert_manager_install_letsencrypt_issuers"></a> [cert\_manager\_install\_letsencrypt\_issuers](#input\_cert\_manager\_install\_letsencrypt\_issuers) | Install Let's Encrypt Cluster Issuers | `bool` | `true` | no |
@@ -166,6 +168,7 @@
 | <a name="input_enable_aws_privateca_issuer"></a> [enable\_aws\_privateca\_issuer](#input\_enable\_aws\_privateca\_issuer) | Enable PCA Issuer | `bool` | `false` | no |
 | <a name="input_enable_calico"></a> [enable\_calico](#input\_enable\_calico) | Enable Calico add-on | `bool` | `false` | no |
 | <a name="input_enable_cert_manager"></a> [enable\_cert\_manager](#input\_enable\_cert\_manager) | Enable Cert Manager add-on | `bool` | `false` | no |
+| <a name="input_enable_cert_manager_csi_driver"></a> [enable\_cert\_manager\_csi\_driver](#input\_enable\_cert\_manager\_csi\_driver) | Enable Cert Manager CSI Driver add-on | `bool` | `false` | no |
 | <a name="input_enable_chaos_mesh"></a> [enable\_chaos\_mesh](#input\_enable\_chaos\_mesh) | Enable Chaos Mesh add-on | `bool` | `false` | no |
 | <a name="input_enable_cilium"></a> [enable\_cilium](#input\_enable\_cilium) | Enable Cilium add-on | `bool` | `false` | no |
 | <a name="input_enable_cluster_autoscaler"></a> [enable\_cluster\_autoscaler](#input\_enable\_cluster\_autoscaler) | Enable Cluster autoscaler add-on | `bool` | `false` | no |

--- a/modules/kubernetes-addons/cert-manager-csi-driver/README.md
+++ b/modules/kubernetes-addons/cert-manager-csi-driver/README.md
@@ -1,0 +1,36 @@
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
+| <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.4.1 |
+
+## Providers
+
+No providers.
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_helm_addon"></a> [helm\_addon](#module\_helm\_addon) | ../helm-addon | n/a |
+
+## Resources
+
+No resources.
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_addon_context"></a> [addon\_context](#input\_addon\_context) | Input configuration for the addon | <pre>object({<br>    aws_caller_identity_account_id = string<br>    aws_caller_identity_arn        = string<br>    aws_eks_cluster_endpoint       = string<br>    aws_partition_id               = string<br>    aws_region_name                = string<br>    eks_cluster_id                 = string<br>    eks_oidc_issuer_url            = string<br>    eks_oidc_provider_arn          = string<br>    tags                           = map(string)<br>    irsa_iam_role_path             = string<br>    irsa_iam_permissions_boundary  = string<br>  })</pre> | n/a | yes |
+| <a name="input_helm_config"></a> [helm\_config](#input\_helm\_config) | Helm provider config for Cert-Manager CSI Driver. | `any` | `{}` | no |
+| <a name="input_manage_via_gitops"></a> [manage\_via\_gitops](#input\_manage\_via\_gitops) | Determines if the add-on should be managed via GitOps. | `bool` | `false` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_argocd_gitops_config"></a> [argocd\_gitops\_config](#output\_argocd\_gitops\_config) | Configuration used for managing the add-on with ArgoCD |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/kubernetes-addons/cert-manager-csi-driver/locals.tf
+++ b/modules/kubernetes-addons/cert-manager-csi-driver/locals.tf
@@ -1,0 +1,23 @@
+locals {
+  name      = "cert-manager-csi-driver"
+  namespace = "cert-manager"
+
+  default_helm_config = {
+    name        = local.name
+    chart       = local.name
+    repository  = "https://charts.jetstack.io"
+    version     = "v0.4.2"
+    namespace   = local.namespace
+    description = "Cert Manager CSI Driver Add-on"
+    values      = []
+  }
+
+  helm_config = merge(
+    local.default_helm_config,
+    var.helm_config
+  )
+
+  argocd_gitops_config = {
+    enable = true
+  }
+}

--- a/modules/kubernetes-addons/cert-manager-csi-driver/main.tf
+++ b/modules/kubernetes-addons/cert-manager-csi-driver/main.tf
@@ -1,0 +1,7 @@
+module "helm_addon" {
+  source            = "../helm-addon"
+  manage_via_gitops = var.manage_via_gitops
+  helm_config       = local.helm_config
+  irsa_config       = null
+  addon_context     = var.addon_context
+}

--- a/modules/kubernetes-addons/cert-manager-csi-driver/outputs.tf
+++ b/modules/kubernetes-addons/cert-manager-csi-driver/outputs.tf
@@ -1,0 +1,4 @@
+output "argocd_gitops_config" {
+  description = "Configuration used for managing the add-on with ArgoCD"
+  value       = var.manage_via_gitops ? local.argocd_gitops_config : null
+}

--- a/modules/kubernetes-addons/cert-manager-csi-driver/variables.tf
+++ b/modules/kubernetes-addons/cert-manager-csi-driver/variables.tf
@@ -1,0 +1,28 @@
+variable "helm_config" {
+  description = "Helm provider config for Cert-Manager CSI Driver."
+  type        = any
+  default     = {}
+}
+
+variable "manage_via_gitops" {
+  description = "Determines if the add-on should be managed via GitOps."
+  type        = bool
+  default     = false
+}
+
+variable "addon_context" {
+  description = "Input configuration for the addon"
+  type = object({
+    aws_caller_identity_account_id = string
+    aws_caller_identity_arn        = string
+    aws_eks_cluster_endpoint       = string
+    aws_partition_id               = string
+    aws_region_name                = string
+    eks_cluster_id                 = string
+    eks_oidc_issuer_url            = string
+    eks_oidc_provider_arn          = string
+    tags                           = map(string)
+    irsa_iam_role_path             = string
+    irsa_iam_permissions_boundary  = string
+  })
+}

--- a/modules/kubernetes-addons/cert-manager-csi-driver/versions.tf
+++ b/modules/kubernetes-addons/cert-manager-csi-driver/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.0.0"
+
+  required_providers {
+    helm = {
+      source  = "hashicorp/helm"
+      version = ">= 2.4.1"
+    }
+  }
+}

--- a/modules/kubernetes-addons/main.tf
+++ b/modules/kubernetes-addons/main.tf
@@ -163,6 +163,14 @@ module "cert_manager" {
   letsencrypt_email           = var.cert_manager_letsencrypt_email
 }
 
+module "cert_manager_csi_driver" {
+  count             = var.enable_cert_manager_csi_driver ? 1 : 0
+  source            = "./cert-manager-csi-driver"
+  helm_config       = var.cert_manager_csi_driver_helm_config
+  manage_via_gitops = var.argocd_manage_add_ons
+  addon_context     = local.addon_context
+}
+
 module "cluster_autoscaler" {
   source = "./cluster-autoscaler"
 

--- a/modules/kubernetes-addons/variables.tf
+++ b/modules/kubernetes-addons/variables.tf
@@ -661,6 +661,18 @@ variable "cert_manager_letsencrypt_email" {
   default     = ""
 }
 
+variable "enable_cert_manager_csi_driver" {
+  description = "Enable Cert Manager CSI Driver add-on"
+  type        = bool
+  default     = false
+}
+
+variable "cert_manager_csi_driver_helm_config" {
+  description = "Cert Manager CSI Driver Helm Chart config"
+  type        = any
+  default     = {}
+}
+
 #-----------Argo Rollouts ADDON-------------
 variable "enable_argo_rollouts" {
   description = "Enable Argo Rollouts add-on"


### PR DESCRIPTION
The cert-manager CSI driver can be used to generate and attach certificates and private keys directly to pods.

### What does this PR do?

Add the Cert Manager CSI driver. Closes #950 

### Motivation

I would like to use this, with Cert Manager as it makes generating and mounting certificates for mTLS very easy.

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [x] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [x] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [x] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR

**Note**: Not all the PRs require a new example and/or doc page. In general:
- Use an existing example when possible to demonstrate a new addons usage
- A new docs page under `docs/add-ons/*` is required for new a new addon

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
