### PR TITLE
Bugfix `argocd_manage_add_ons` not passed to `external_secrets` module

### DIFF
--- a/modules/kubernetes-addons/main.tf
+++ b/modules/kubernetes-addons/main.tf
@@ -509,6 +509,7 @@ module "external_secrets" {
   count                                 = var.enable_external_secrets ? 1 : 0
   source                                = "./external-secrets"
   helm_config                           = var.external_secrets_helm_config
+  manage_via_gitops                     = var.argocd_manage_add_ons
   addon_context                         = local.addon_context
   irsa_policies                         = var.external_secrets_irsa_policies
   external_secrets_ssm_parameter_arns   = var.external_secrets_ssm_parameter_arns


### PR DESCRIPTION
### What does this PR do?

When enabling external_secrets addon, it will deploy the helm chart regardless of what you configured through `argocd_manage_add_ons`. It should instead create only AWS IAM stuff and the namespace with the service account.

### Motivation

<!-- What inspired you to submit this pull request? -->
- Resolves #956

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR

**Note**: Not all the PRs require a new example and/or doc page. In general:
- Use an existing example when possible to demonstrate a new addons usage
- A new docs page under `docs/add-ons/*` is required for new a new addon

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
