### PR TITLE
fix: terratest - expected eks node to 3

### DIFF
--- a/test/src/eks_blueprints_e2e_test.go
+++ b/test/src/eks_blueprints_e2e_test.go
@@ -57,7 +57,7 @@ var (
 	}
 
 	/*EKS API Validation*/
-	expectedEKSWorkerNodes = 2
+	expectedEKSWorkerNodes = 3
 
 	/*Update the expected Deployments names and the namespace*/
 	expectedDeployments = [...]Deployment{


### PR DESCRIPTION
### What does this PR do?
- sets terratest expected node to 3 
🛑 Please open an issue first to discuss any significant work and flesh out details/direction - we would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/aws-ia/terraform-aws-eks-blueprints/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

<!-- A brief description of the change being made with this pull request. -->

### Motivation
- following https://github.com/aws-ia/terraform-aws-eks-blueprints/pull/973 the min-max-desired ASG set to 3, aligning Terratest to prevent terratest e2e failures.
<!-- What inspired you to submit this pull request? -->
- Resolves #<issue-number>

### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR

**Note**: Not all the PRs require a new example and/or doc page. In general:
- Use an existing example when possible to demonstrate a new addons usage
- A new docs page under `docs/add-ons/*` is required for new a new addon

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
