### PR TITLE
fix: Pin Terraform version to `< 1.3.0` due to use of optional attribute experiment that was removed in `v1.3.0`

### DIFF
--- a/modules/kubernetes-addons/README.md
+++ b/modules/kubernetes-addons/README.md
@@ -5,7 +5,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0, < 1.3.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.72 |
 
 ## Providers

--- a/modules/kubernetes-addons/main.tf
+++ b/modules/kubernetes-addons/main.tf
@@ -588,3 +588,5 @@ module "local_volume_provisioner" {
   helm_config   = var.local_volume_provisioner_helm_config
   addon_context = local.addon_context
 }
+
+# whitespace noise

--- a/modules/kubernetes-addons/versions.tf
+++ b/modules/kubernetes-addons/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0.0"
+  required_version = ">= 1.0.0, < 1.3.0"
 
   required_providers {
     aws = {

--- a/modules/launch-templates/README.md
+++ b/modules/launch-templates/README.md
@@ -97,7 +97,7 @@ module "launch_templates" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0, < 1.3.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.72 |
 
 ## Providers

--- a/modules/launch-templates/versions.tf
+++ b/modules/launch-templates/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0.0"
+  required_version = ">= 1.0.0, < 1.3.0"
 
   required_providers {
     aws = {


### PR DESCRIPTION
### What does this PR do?

- Pin Terraform version to `< 1.3.0` due to use of optional attribute experiment that was removed in `v1.3.0`

### Motivation

- Ref https://github.com/aws-ia/terraform-aws-eks-blueprints/actions/runs/3115601935/jobs/5052669371
- Closes #982

### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR

**Note**: Not all the PRs require a new example and/or doc page. In general:
- Use an existing example when possible to demonstrate a new addons usage
- A new docs page under `docs/add-ons/*` is required for new a new addon

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
