### PR TITLE
chore(addons/karpenter): Upgrade to 0.16.2

### DIFF
--- a/modules/kubernetes-addons/karpenter/locals.tf
+++ b/modules/kubernetes-addons/karpenter/locals.tf
@@ -17,7 +17,7 @@ locals {
     name        = local.name
     chart       = local.name
     repository  = "https://charts.karpenter.sh"
-    version     = "0.16.1"
+    version     = "0.16.2"
     namespace   = local.name
     timeout     = "300"
     values      = local.default_helm_values


### PR DESCRIPTION
### What does this PR do?

upgrades karpenter to [v0.16.2](https://github.com/aws/karpenter/releases/tag/v0.16.2)

<!-- A brief description of the change being made with this pull request. -->

### Motivation

consolidation enhancements

### More

- [X] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR

**Note**: Not all the PRs require a new example and/or doc page. In general:
- Use an existing example when possible to demonstrate a new addons usage
- A new docs page under `docs/add-ons/*` is required for new a new addon

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

Unable to test it by running karpenter example because of incompatibility of this repo with terraform v1.3.0 (https://github.com/aws-ia/terraform-aws-eks-blueprints/issues/635) . Will test it with older version on another machine. 

Update: 
tested karpenter example with terraform v1.2.9 using `sample_deployment_lt.yaml` and `sample_deployment.yaml`
and all 6 pods were successfully scheduled from both deployments.
Note that by default karpenter helm module is scheduling 2 pods of karpenter but only one of those pods is scheduling because of the unavailability of additional managed nodegroup node in that example (karpenter nodes don't tolerate karpenter pod by default). 

![image](https://user-images.githubusercontent.com/3725386/192222882-f3f7ef5c-299e-4e87-8917-294154026946.png)

```
2022-09-26T07:54:47.901Z	ERROR	controller.provisioning	Could not schedule pod, incompatible with provisioner "default", did not tolerate default=true:NoSchedule; incompatible with provisioner "default-lt", did not tolerate default-lt=true:NoSchedule	{"commit": "346b7d7-dirty", "pod": "karpenter/karpenter-558b445fc-c67dg"}

```

<!-- Anything else we should know when reviewing? -->
