### PR TITLE
ci: Update runners to remove default Terraform version and use what we specify

### DIFF
--- a/.github/workflows/plan-examples.yml
+++ b/.github/workflows/plan-examples.yml
@@ -49,6 +49,13 @@ jobs:
         directory: ${{ fromJson(needs.getExampleDirectories.outputs.directories) }}
 
     steps:
+      - name: Remove default Terraform
+        run: rm -rf $(which terraform)
+
+      - name: Should fail
+        continue-on-error: true
+        run: terraform version
+
       - name: checkout-merge
         if: "contains(github.event_name, 'pull_request')"
         uses: actions/checkout@v3
@@ -85,6 +92,8 @@ jobs:
         if: steps.changes.outputs.src== 'true'
         with:
           terraform_version: 1.0.0
+
+      - run: terraform version
 
       - name: Terraform Init
         if: steps.changes.outputs.src== 'true'

--- a/.github/workflows/plan-examples.yml
+++ b/.github/workflows/plan-examples.yml
@@ -93,7 +93,8 @@ jobs:
         with:
           terraform_version: 1.0.0
 
-      - run: terraform version
+      - if: steps.changes.outputs.src== 'true'
+        run: terraform version
 
       - name: Terraform Init
         if: steps.changes.outputs.src== 'true'

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -96,7 +96,8 @@ jobs:
           terraform-version: ${{ steps.minMax.outputs.minVersion }}
           args: 'terraform_validate --color=always --show-diff-on-failure --files $(ls *.tf)'
 
-      - run: terraform version
+      - if: steps.changes.outputs.src== 'true'
+        run: terraform version
 
   preCommitMaxVersion:
     name: Max TF pre-commit
@@ -150,4 +151,5 @@ jobs:
           terraform-docs-version: ${{ env.TERRAFORM_DOCS_VERSION }}
           tflint-version: ${{ env.TFLINT_VERSION }}
 
-      - run: terraform version
+      - if: steps.changes.outputs.src== 'true'
+        run: terraform version

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -41,6 +41,13 @@ jobs:
       matrix:
         directory: ${{ fromJson(needs.collectInputs.outputs.directories) }}
     steps:
+      - name: Remove default Terraform
+        run: rm -rf $(which terraform)
+
+      - name: Should fail
+        continue-on-error: true
+        run: terraform version
+
       - name: Checkout
         uses: actions/checkout@v3
 
@@ -89,11 +96,20 @@ jobs:
           terraform-version: ${{ steps.minMax.outputs.minVersion }}
           args: 'terraform_validate --color=always --show-diff-on-failure --files $(ls *.tf)'
 
+      - run: terraform version
+
   preCommitMaxVersion:
     name: Max TF pre-commit
     runs-on: ubuntu-latest
     needs: collectInputs
     steps:
+      - name: Remove default Terraform
+        run: rm -rf $(which terraform)
+
+      - name: Should fail
+        continue-on-error: true
+        run: terraform version
+
       - name: Checkout
         uses: actions/checkout@v3
 
@@ -133,3 +149,5 @@ jobs:
           terraform-version: 1.2.9 # ${{ steps.minMax.outputs.maxVersion }}
           terraform-docs-version: ${{ env.TERRAFORM_DOCS_VERSION }}
           tflint-version: ${{ env.TFLINT_VERSION }}
+
+      - run: terraform version

--- a/versions.tf
+++ b/versions.tf
@@ -32,3 +32,5 @@ terraform {
     }
   }
 }
+
+# modify something for CI to run


### PR DESCRIPTION
### What does this PR do?

- Update runners to remove default Terraform version and use what we specify

### Motivation

- GitHub runners come with installed software by default, one of which is Terraform and this can cause conflicts on which version is used: the one the runner provides or the one we install via CI

### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR

**Note**: Not all the PRs require a new example and/or doc page. In general:
- Use an existing example when possible to demonstrate a new addons usage
- A new docs page under `docs/add-ons/*` is required for new a new addon

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
