### PR TITLE
fix: IRSA module namespace and service account dependency

### DIFF
--- a/modules/irsa/main.tf
+++ b/modules/irsa/main.tf
@@ -17,7 +17,7 @@ resource "kubernetes_service_account_v1" "irsa" {
   count = var.create_kubernetes_service_account ? 1 : 0
   metadata {
     name        = var.kubernetes_service_account
-    namespace   = var.kubernetes_namespace
+    namespace   = try(kubernetes_namespace_v1.irsa[count.index].id, var.kubernetes_namespace)
     annotations = var.irsa_iam_policies != null ? { "eks.amazonaws.com/role-arn" : aws_iam_role.irsa[0].arn } : null
   }
 

--- a/modules/irsa/main.tf
+++ b/modules/irsa/main.tf
@@ -17,7 +17,7 @@ resource "kubernetes_service_account_v1" "irsa" {
   count = var.create_kubernetes_service_account ? 1 : 0
   metadata {
     name        = var.kubernetes_service_account
-    namespace   = try(kubernetes_namespace_v1.irsa[count.index].id, var.kubernetes_namespace)
+    namespace   = try(kubernetes_namespace_v1.irsa[count.index].metadata[0].name, var.kubernetes_namespace)
     annotations = var.irsa_iam_policies != null ? { "eks.amazonaws.com/role-arn" : aws_iam_role.irsa[0].arn } : null
   }
 

--- a/modules/irsa/main.tf
+++ b/modules/irsa/main.tf
@@ -17,7 +17,7 @@ resource "kubernetes_service_account_v1" "irsa" {
   count = var.create_kubernetes_service_account ? 1 : 0
   metadata {
     name        = var.kubernetes_service_account
-    namespace   = try(kubernetes_namespace_v1.irsa[count.index].metadata[0].name, var.kubernetes_namespace)
+    namespace   = try(kubernetes_namespace_v1.irsa[0].metadata[0].name, var.kubernetes_namespace)
     annotations = var.irsa_iam_policies != null ? { "eks.amazonaws.com/role-arn" : aws_iam_role.irsa[0].arn } : null
   }
 


### PR DESCRIPTION
### What does this PR do?

To prevent namespace deletion before service account during the terrafrom destroy.

### Motivation

<!-- What inspired you to submit this pull request? -->
- Resolves #1012

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR

**Note**: Not all the PRs require a new example and/or doc page. In general:
- Use an existing example when possible to demonstrate a new addons usage
- A new docs page under `docs/add-ons/*` is required for new a new addon

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
