### PR TITLE
fix: Helm-addon irsa_config default value for create_namespace condition

### DIFF
--- a/modules/kubernetes-addons/helm-addon/main.tf
+++ b/modules/kubernetes-addons/helm-addon/main.tf
@@ -6,7 +6,7 @@ resource "helm_release" "addon" {
   version                    = try(var.helm_config["version"], null)
   timeout                    = try(var.helm_config["timeout"], 1200)
   values                     = try(var.helm_config["values"], null)
-  create_namespace           = var.irsa_config != null ? false : try(var.helm_config["create_namespace"], false)
+  create_namespace           = var.irsa_config != {} ? false : try(var.helm_config["create_namespace"], false)
   namespace                  = var.helm_config["namespace"]
   lint                       = try(var.helm_config["lint"], false)
   description                = try(var.helm_config["description"], "")

--- a/modules/kubernetes-addons/helm-addon/main.tf
+++ b/modules/kubernetes-addons/helm-addon/main.tf
@@ -6,7 +6,7 @@ resource "helm_release" "addon" {
   version                    = try(var.helm_config["version"], null)
   timeout                    = try(var.helm_config["timeout"], 1200)
   values                     = try(var.helm_config["values"], null)
-  create_namespace           = var.irsa_config != {} ? false : try(var.helm_config["create_namespace"], false)
+  create_namespace           = length(var.irsa_config) > 0 ? false : try(var.helm_config["create_namespace"], false)
   namespace                  = var.helm_config["namespace"]
   lint                       = try(var.helm_config["lint"], false)
   description                = try(var.helm_config["description"], "")


### PR DESCRIPTION
### What does this PR do?

With 4.12 the default value of the `irsa_config` variable was changed from `null` to `{}` while the value of the `create_namespace` property within the `resource "helm_release" "addon"` was not updated and remained as:
```
var.irsa_config != null ? false : try(var.helm_config["create_namespace"], false)
```

The correct value should be:
```
var.irsa_config != {} ? false : try(var.helm_config["create_namespace"], false)
```

Versions comparison: https://github.com/aws-ia/terraform-aws-eks-blueprints/compare/v4.11.0...v4.12.0#diff-08ec4987c7b396bd22851dba98a35f66754059cbc09e6f88a0801533f8d03946R33

### Motivation

I was using v4.11.0, updated to v4.12.0, and spotted that the `create_namespace` value I wasn't overriding was suddenly changed from the default `true` to `false`.

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR

**Note**: Not all the PRs require a new example and/or doc page. In general:
- Use an existing example when possible to demonstrate a new addons usage
- A new docs page under `docs/add-ons/*` is required for new a new addon

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

Got:
```
No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.
```

Instead of:
```
Terraform will perform the following actions:

  # module.eks_addons.module.argocd[0].module.helm_addon.helm_release.addon[0] will be updated in-place
  ~ resource "helm_release" "addon" {
      ~ create_namespace           = true -> false
        id                         = "argo-cd"
        name                       = "argo-cd"
        # (28 unchanged attributes hidden)

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```
