### PR TITLE
fix: Let ingress_nginx depend on aws_load_balancer_controller (fixes #1030)

### DIFF
--- a/examples/ingress-controllers/nginx/README.md
+++ b/examples/ingress-controllers/nginx/README.md
@@ -88,8 +88,6 @@ The following command destroys the resources created by `terraform apply`
 
 ```shell script
 cd examples/ingress-controllers/nginx
-terraform destroy -target="module.eks_blueprints_kubernetes_addons.module.ingress_nginx[0]" -auto-approve
-terraform destroy -target="module.eks_blueprints_kubernetes_addons.module.aws_load_balancer_controller[0]" -auto-approve
 terraform destroy -target="module.eks-blueprints-kubernetes-addons" -auto-approve
 terraform destroy -target="module.eks-blueprints" -auto-approve
 terraform destroy -auto-approve

--- a/modules/kubernetes-addons/main.tf
+++ b/modules/kubernetes-addons/main.tf
@@ -181,6 +181,7 @@ module "ingress_nginx" {
   helm_config       = var.ingress_nginx_helm_config
   manage_via_gitops = var.argocd_manage_add_ons
   addon_context     = local.addon_context
+  depends_on        = [module.aws_load_balancer_controller]
 }
 
 module "karpenter" {


### PR DESCRIPTION
### What does this PR do?

This change makes sure that if you enable the aws_load_balancer_controller and the nginx_ingress the ingress is deleted before the loadbalancer so the finalizers can be fulfilled.

### Motivation

- Resolves #1030 

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [x] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [x] Yes, I ran `pre-commit run -a` with this PR


### For Moderators

- [ ] E2E Test successfully complete before merge?
