### PR TITLE
fix: Add support for Terraform v1.3+ using local version of partner modules temporarily

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
       - id: detect-aws-credentials
         args: ['--allow-missing-credentials']
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.75.0
+    rev: v1.76.0
     hooks:
       - id: terraform_fmt
       - id: terraform_docs

--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ The below demonstrates how you can leverage EKS Blueprints to deploy an EKS clus
 
 ```hcl
 module "eks_blueprints" {
-  source = "github.com/aws-ia/terraform-aws-eks-blueprints?ref=v4.0.2"
+  source = "github.com/aws-ia/terraform-aws-eks-blueprints?ref=v4.12.0"
 
   # EKS CLUSTER
-  cluster_version           = "1.21"
+  cluster_version           = "1.23"
   vpc_id                    = "<vpcid>"                                      # Enter VPC ID
   private_subnet_ids        = ["<subnet-a>", "<subnet-b>", "<subnet-c>"]     # Enter Private Subnet IDs
 
@@ -46,7 +46,7 @@ module "eks_blueprints" {
 }
 
 module "eks_blueprints_kubernetes_addons" {
-  source = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons?ref=v4.0.2"
+  source = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons?ref=v4.12.0"
 
   eks_cluster_id = module.eks_blueprints.eks_cluster_id
 
@@ -102,11 +102,6 @@ To post feedback, submit feature ideas, or report bugs, please use the [Issues s
 For architectural details, step-by-step instructions, and customization options, see our [documentation site](https://aws-ia.github.io/terraform-aws-eks-blueprints/).
 
 If you are interested in contributing to EKS Blueprints, see the [Contribution guide](https://github.com/aws-ia/terraform-aws-eks-blueprints/blob/main/CONTRIBUTING.md).
-
----
-
-> **_NOTE:_** Use terraform versions after version 1.0.0 and before version 1.3.0.  
-Support for 1.3.x and above [here](https://github.com/aws-ia/terraform-aws-eks-blueprints/issues/988)
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements

--- a/docs/add-ons/vault.md
+++ b/docs/add-ons/vault.md
@@ -31,4 +31,4 @@ Alternatively, you can override the Helm Values by setting the `vault_helm_confi
   }
 ```
 
-This snippet does not contain _all_ available options that can be set as part of `vault_helm_config`. For the complete listing, see the [`hashicorp-vault-eks-blueprints-addon` repository](https://github.com/hashicorp/terraform-aws-hashicorp-vault-eks-addon/blob/main/locals.tf).
+This snippet does not contain _all_ available options that can be set as part of `vault_helm_config`. For the complete listing, see the [`hashicorp-vault-eks-blueprints-addon` repository](https://github.com/hashicorp/terraform-aws-hashicorp-vault-eks-addon/).

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -9,8 +9,6 @@ First, ensure that you have installed the following tools locally.
 1. [aws cli](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html)
 2. [kubectl](https://Kubernetes.io/docs/tasks/tools/)
 3. [terraform](https://learn.hashicorp.com/tutorials/terraform/install-cli)
-> **_NOTE:_** Use terraform versions after version 1.0.0 and before version 1.3.0.  
-Support for 1.3.x and above [here](https://github.com/aws-ia/terraform-aws-eks-blueprints/issues/988)
 
 ## Deployment Steps
 
@@ -25,7 +23,7 @@ The following steps will walk you through the deployment of an [example blueprin
 
 ### Clone the repo
 
-```
+```sh
 git clone https://github.com/aws-ia/terraform-aws-eks-blueprints.git
 ```
 
@@ -33,13 +31,13 @@ git clone https://github.com/aws-ia/terraform-aws-eks-blueprints.git
 
 CD into the example directory:
 
-```
+```sh
 cd examples/eks-cluster-with-new-vpc/
 ```
 
 Initialize the working directory with the following:
 
-```
+```sh
 terraform init
 ```
 
@@ -47,7 +45,7 @@ terraform init
 
 Verify the resources that will be created by this execution:
 
-```
+```sh
 terraform plan
 ```
 
@@ -57,33 +55,33 @@ We will leverage Terraform's [target](https://learn.hashicorp.com/tutorials/terr
 
 **Deploy the VPC**. This step will take roughly 3 minutes to complete.
 
-```
+```sh
 terraform apply -target="module.vpc"
 ```
 
 **Deploy the EKS cluster**. This step will take roughly 14 minutes to complete.
 
-```
+```sh
 terraform apply -target="module.eks_blueprints"
 ```
 
 **Deploy the add-ons**. This step will take rough 5 minutes to complete.
 
-```
-terraform apply -target="module.eks_blueprints_kubernetes_addons"
+```sh
+terraform apply
 ```
 
 ## Configure kubectl
 
 Terraform output will display a command in your console that you can use to bootstrap your local `kubeconfig`.
 
-```
+```sh
 configure_kubectl = "aws eks --region <region> update-kubeconfig --name <cluster-name>"
 ```
 
 Run the command in your terminal.
 
-```
+```sh
 aws eks --region <region> update-kubeconfig --name <cluster-name>
 ```
 
@@ -91,7 +89,7 @@ aws eks --region <region> update-kubeconfig --name <cluster-name>
 
 ### List worker nodes
 
-```
+```sh
 kubectl get nodes
 ```
 
@@ -106,7 +104,7 @@ ip-10-0-12-48.us-west-2.compute.internal    Ready    <none>   4h18m   v1.21.5-ek
 
 ### List pods
 
-```
+```sh
 kubectl get pods -n kube-system
 ```
 
@@ -132,20 +130,8 @@ metrics-server-694d47d564-hzd8h                             1/1     Running   1 
 
 To clean up your environment, destroy the Terraform modules in reverse order.
 
-Destroy the add-ons.
-
-```
-terraform destroy -target="module.eks_blueprints_kubernetes_addons"
-```
-
-Destroy the EKS cluster.
-
-```
-terraform destroy -target="module.eks_blueprints"
-```
-
-Destroy the VPC.
-
-```
-terraform destroy -target="module.vpc"
+```sh
+terraform destroy -target="module.eks_blueprints_kubernetes_addons" -auto-approve
+terraform destroy -target="module.eks_blueprints" -auto-approve
+terraform destroy -auto-approve
 ```

--- a/modules/kubernetes-addons/README.md
+++ b/modules/kubernetes-addons/README.md
@@ -62,7 +62,7 @@
 | <a name="module_local_volume_provisioner"></a> [local\_volume\_provisioner](#module\_local\_volume\_provisioner) | ./local-volume-provisioner | n/a |
 | <a name="module_metrics_server"></a> [metrics\_server](#module\_metrics\_server) | ./metrics-server | n/a |
 | <a name="module_nvidia_device_plugin"></a> [nvidia\_device\_plugin](#module\_nvidia\_device\_plugin) | ./nvidia-device-plugin | n/a |
-| <a name="module_ondat"></a> [ondat](#module\_ondat) | ondat/ondat-addon/eksblueprints | 0.1.1 |
+| <a name="module_ondat"></a> [ondat](#module\_ondat) | ./ondat | n/a |
 | <a name="module_opentelemetry_operator"></a> [opentelemetry\_operator](#module\_opentelemetry\_operator) | ./opentelemetry-operator | n/a |
 | <a name="module_prometheus"></a> [prometheus](#module\_prometheus) | ./prometheus | n/a |
 | <a name="module_promtail"></a> [promtail](#module\_promtail) | ./promtail | n/a |
@@ -71,9 +71,9 @@
 | <a name="module_smb_csi_driver"></a> [smb\_csi\_driver](#module\_smb\_csi\_driver) | ./smb-csi-driver | n/a |
 | <a name="module_spark_history_server"></a> [spark\_history\_server](#module\_spark\_history\_server) | ./spark-history-server | n/a |
 | <a name="module_spark_k8s_operator"></a> [spark\_k8s\_operator](#module\_spark\_k8s\_operator) | ./spark-k8s-operator | n/a |
-| <a name="module_tetrate_istio"></a> [tetrate\_istio](#module\_tetrate\_istio) | tetratelabs/tetrate-istio-addon/eksblueprints | 0.0.7 |
+| <a name="module_tetrate_istio"></a> [tetrate\_istio](#module\_tetrate\_istio) | ./tetrate-istio | n/a |
 | <a name="module_traefik"></a> [traefik](#module\_traefik) | ./traefik | n/a |
-| <a name="module_vault"></a> [vault](#module\_vault) | hashicorp/hashicorp-vault-eks-addon/aws | 0.9.0 |
+| <a name="module_vault"></a> [vault](#module\_vault) | hashicorp/hashicorp-vault-eks-addon/aws | 1.0.0-rc1 |
 | <a name="module_velero"></a> [velero](#module\_velero) | ./velero | n/a |
 | <a name="module_vpa"></a> [vpa](#module\_vpa) | ./vpa | n/a |
 | <a name="module_yunikorn"></a> [yunikorn](#module\_yunikorn) | ./yunikorn | n/a |

--- a/modules/kubernetes-addons/main.tf
+++ b/modules/kubernetes-addons/main.tf
@@ -278,9 +278,15 @@ module "metrics_server" {
 }
 
 module "ondat" {
-  count             = var.enable_ondat ? 1 : 0
-  source            = "ondat/ondat-addon/eksblueprints"
-  version           = "0.1.1"
+  # source  = "ondat/ondat-addon/eksblueprints"
+  # version = "0.1.1"
+
+  # TODO - remove local source and revert to remote once
+  # https://github.com/ondat/terraform-eksblueprints-ondat-addon/pull/12  is merged
+  source = "./ondat"
+
+  count = var.enable_ondat ? 1 : 0
+
   helm_config       = var.ondat_helm_config
   manage_via_gitops = var.argocd_manage_add_ons
   addon_context     = local.addon_context
@@ -339,9 +345,15 @@ module "spark_k8s_operator" {
 }
 
 module "tetrate_istio" {
-  count                = var.enable_tetrate_istio ? 1 : 0
-  source               = "tetratelabs/tetrate-istio-addon/eksblueprints"
-  version              = "0.0.7"
+  # source  = "tetratelabs/tetrate-istio-addon/eksblueprints"
+  # version = "0.0.7"
+
+  # TODO - remove local source and revert to remote once
+  # https://github.com/tetratelabs/terraform-eksblueprints-tetrate-istio-addon/pull/12  is merged
+  source = "./tetrate-istio"
+
+  count = var.enable_tetrate_istio ? 1 : 0
+
   distribution         = var.tetrate_istio_distribution
   distribution_version = var.tetrate_istio_version
   install_base         = var.tetrate_istio_install_base
@@ -369,11 +381,10 @@ module "vault" {
 
   # See https://registry.terraform.io/modules/hashicorp/hashicorp-vault-eks-addon/aws/
   source  = "hashicorp/hashicorp-vault-eks-addon/aws"
-  version = "0.9.0"
+  version = "1.0.0-rc1"
 
   helm_config       = var.vault_helm_config
   manage_via_gitops = var.argocd_manage_add_ons
-  addon_context     = local.addon_context
 }
 
 module "vpa" {

--- a/modules/kubernetes-addons/ondat/README.md
+++ b/modules/kubernetes-addons/ondat/README.md
@@ -1,0 +1,79 @@
+# Ondat add-on for EKS Blueprints
+
+## Introduction
+
+[Ondat](https://ondat.io) is a highly scalable Kubernetes data plane that
+provides stateful storage for applications. This blueprint installs Ondat
+on Amazon Elastic Kubernetes Service (AWS EKS).
+
+## Key features
+
+1. Hyperconverged (all nodes have storage) or centralised (some nodes 
+have storage), Kubernetes-native storage on any infrastructure - use the
+same code and storage features in-cloud and on-premises!
+1. Best-in-class performance, availability and security - individually
+encrypted volumes, performs better than competitors and synchronizes replicas
+quickly and efficiently.
+1. NFS (RWX) support allowing for performant sharing of volumes across multiple
+workloads.
+1. Free tier with 1TiB of storage under management plus unlimited replicas
+1. Larger storage capacity and business support available in paid product
+
+Find out more in our [documentation](https://docs.ondat.io/docs/concepts/)!
+
+## Examples
+
+See [blueprints](blueprints/).
+
+<!--- BEGIN_TF_DOCS --->
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.15.1 |
+| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 2.11.0 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_helm_addon"></a> [helm\_addon](#module\_helm\_addon) | github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon | v4.1.0 |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [kubernetes_namespace.ondat](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace) | resource |
+| [kubernetes_namespace.storageos](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace) | resource |
+| [kubernetes_secret.etcd](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
+| [kubernetes_storage_class.etcd](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/storage_class) | resource |
+| [aws_eks_cluster.eks](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_cluster) | data source |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_addon_context"></a> [addon\_context](#input\_addon\_context) | Input configuration for the addon | <pre>object({<br>    aws_caller_identity_account_id = string<br>    aws_caller_identity_arn        = string<br>    aws_eks_cluster_endpoint       = string<br>    aws_partition_id               = string<br>    aws_region_name                = string<br>    eks_cluster_id                 = string<br>    eks_oidc_issuer_url            = string<br>    eks_oidc_provider_arn          = string<br>    tags                           = map(string)<br>    irsa_iam_role_path             = optional(string)<br>    irsa_iam_permissions_boundary  = optional(string)<br>  })</pre> | n/a | yes |
+| <a name="input_admin_password"></a> [admin\_password](#input\_admin\_password) | Password for the Ondat admin user | `string` | `"storageos"` | no |
+| <a name="input_admin_username"></a> [admin\_username](#input\_admin\_username) | Username for the Ondat admin user | `string` | `"storageos"` | no |
+| <a name="input_create_cluster"></a> [create\_cluster](#input\_create\_cluster) | Determines if the StorageOSCluster and secrets should be created | `bool` | `true` | no |
+| <a name="input_etcd_ca"></a> [etcd\_ca](#input\_etcd\_ca) | The PEM encoded CA for Ondat's etcd | `string` | `null` | no |
+| <a name="input_etcd_cert"></a> [etcd\_cert](#input\_etcd\_cert) | The PEM encoded client certificate for Ondat's etcd | `string` | `null` | no |
+| <a name="input_etcd_endpoints"></a> [etcd\_endpoints](#input\_etcd\_endpoints) | A list of etcd endpoints for Ondat | `list(string)` | `[]` | no |
+| <a name="input_etcd_key"></a> [etcd\_key](#input\_etcd\_key) | The PEM encoded client key for Ondat's etcd | `string` | `null` | no |
+| <a name="input_helm_config"></a> [helm\_config](#input\_helm\_config) | Helm provider config for the ondat addon | `any` | `{}` | no |
+| <a name="input_irsa_permissions_boundary"></a> [irsa\_permissions\_boundary](#input\_irsa\_permissions\_boundary) | IAM Policy ARN for IRSA IAM role permissions boundary | `string` | `""` | no |
+| <a name="input_irsa_policies"></a> [irsa\_policies](#input\_irsa\_policies) | IAM policy ARNs for Ondat IRSA | `list(string)` | `[]` | no |
+| <a name="input_manage_via_gitops"></a> [manage\_via\_gitops](#input\_manage\_via\_gitops) | Determines if the add-on should be managed via GitOps. | `bool` | `false` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_argocd_gitops_config"></a> [argocd\_gitops\_config](#output\_argocd\_gitops\_config) | Configuration used for managing the add-on with ArgoCD |
+<!--- END_TF_DOCS --->

--- a/modules/kubernetes-addons/ondat/main.tf
+++ b/modules/kubernetes-addons/ondat/main.tf
@@ -1,0 +1,179 @@
+locals {
+  name                 = "ondat"
+  service_account_name = "storageos-operator"
+
+  ondat_etcd_endpoints = length(var.etcd_endpoints) == 0 ? "storageos-etcd.storageos-etcd:2379" : join(",", var.etcd_endpoints)
+
+  argocd_gitops_config = {
+    enable                             = true
+    etcdClusterCreate                  = length(var.etcd_endpoints) == 0
+    serviceAccountName                 = local.service_account_name
+    clusterSecretRefName               = "storageos-api"
+    clusterAdminUsername               = "storageos"
+    clusterAdminPassword               = "storageos"
+    clusterKvBackendAddress            = local.ondat_etcd_endpoints
+    clusterKvBackendTLSSecretName      = length(kubernetes_secret.etcd) > 0 ? kubernetes_secret.etcd[0].metadata[0].name : "storageos-etcd-secret"
+    clusterKvBackendTLSSecretNamespace = length(kubernetes_secret.etcd) > 0 ? kubernetes_secret.etcd[0].metadata[0].namespace : "storageos"
+    clusterNodeSelectorTermKey         = "storageos-node"
+    clusterNodeSelectorTermValue       = "1"
+    etcdNodeSelectorTermKey            = "storageos-etcd"
+    etcdNodeSelectorTermValue          = "1"
+  }
+
+  default_helm_values = [templatefile("${path.module}/values.yaml",
+    {
+      ondat_service_account_name   = local.service_account_name,
+      ondat_nodeselectorterm_key   = "storageos-node"
+      ondat_nodeselectorterm_value = "1"
+      etcd_nodeselectorterm_key    = "storageos-etcd"
+      etcd_nodeselectorterm_value  = "1"
+      ondat_admin_username         = "storageos",
+      ondat_admin_password         = "storageos",
+      ondat_credential_secret_name = "storageos-api",
+      etcd_address                 = local.ondat_etcd_endpoints,
+    },
+  )]
+}
+
+module "helm_addon" {
+  source = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon"
+
+  manage_via_gitops = var.manage_via_gitops
+
+  helm_config = merge(
+    {
+      name             = local.name
+      chart            = "ondat"
+      repository       = "https://ondat.github.io/charts"
+      version          = "0.2.5"
+      namespace        = kubernetes_namespace.ondat.metadata[0].name
+      timeout          = "1500"
+      create_namespace = false
+      values           = local.default_helm_values
+      description      = "Ondat Helm Chart for storage"
+    },
+    var.helm_config
+  )
+
+  set_values = [
+    {
+      name  = "ondat-operator.serviceAccount.name"
+      value = local.service_account_name
+    },
+    {
+      name  = "ondat-operator.cluster.create"
+      value = var.create_cluster
+    },
+    {
+      name  = "ondat-operator.cluster.secretRefName"
+      value = "storageos-api"
+    },
+    {
+      name  = "ondat-operator.cluster.kvBackend.address"
+      value = local.ondat_etcd_endpoints
+    },
+    {
+      name  = "ondat-operator.cluster.kvBackend.tlsSecretName"
+      value = length(kubernetes_secret.etcd) > 0 ? kubernetes_secret.etcd[0].metadata[0].name : "storageos-etcd-secret"
+    },
+    {
+      name  = "ondat-operator.cluster.kvBackend.tlsSecretNamespace"
+      value = length(kubernetes_secret.etcd) > 0 ? kubernetes_secret.etcd[0].metadata[0].namespace : "storageos"
+    },
+    {
+      name  = "etcd-cluster-operator.cluster.create"
+      value = length(var.etcd_endpoints) == 0
+    },
+  ]
+
+  set_sensitive_values = [
+    {
+      name  = "cluster.admin.username",
+      value = var.admin_username
+    },
+    {
+      name  = "cluster.admin.password",
+      value = var.admin_password
+    },
+  ]
+
+  irsa_config = {
+    create_kubernetes_namespace = false
+    kubernetes_namespace        = kubernetes_namespace.ondat.metadata[0].name
+
+    create_kubernetes_service_account = true
+    kubernetes_service_account        = local.service_account_name
+
+    iam_role_path                 = "/"
+    tags                          = var.addon_context.tags
+    eks_cluster_id                = var.addon_context.eks_cluster_id
+    irsa_iam_policies             = var.irsa_policies
+    irsa_iam_permissions_boundary = var.irsa_permissions_boundary
+  }
+
+  addon_context = var.addon_context
+}
+
+resource "kubernetes_namespace" "ondat" {
+  metadata {
+    name = "ondat"
+    labels = {
+      app = local.name
+    }
+  }
+}
+
+################################################################################
+# Secrets
+################################################################################
+
+resource "kubernetes_namespace" "storageos" {
+  count = length(var.etcd_endpoints) == 0 ? 0 : 1
+
+  metadata {
+    name = "storageos"
+    labels = {
+      app = local.name
+    }
+  }
+}
+
+resource "kubernetes_secret" "etcd" {
+  count = length(var.etcd_endpoints) == 0 ? 0 : 1
+
+  metadata {
+    name      = "storageos-etcd"
+    namespace = kubernetes_namespace.storageos[0].metadata[0].name
+    labels = {
+      app = local.name
+    }
+  }
+
+  data = {
+    "etcd-client-ca.crt" = var.etcd_ca
+    "etcd-client.crt"    = var.etcd_cert
+    "etcd-client.key"    = var.etcd_key
+  }
+
+  type = "kubernetes.io/storageos"
+}
+
+################################################################################
+# Storage Class
+################################################################################
+
+resource "kubernetes_storage_class" "etcd" {
+  count = length(var.etcd_endpoints) == 0 ? 1 : 0
+
+  metadata {
+    name = "etcd"
+  }
+
+  storage_provisioner = "ebs.csi.aws.com"
+  reclaim_policy      = "Retain"
+  volume_binding_mode = "WaitForFirstConsumer"
+
+  parameters = {
+    type = "gp3"
+  }
+}

--- a/modules/kubernetes-addons/ondat/outputs.tf
+++ b/modules/kubernetes-addons/ondat/outputs.tf
@@ -1,0 +1,4 @@
+output "argocd_gitops_config" {
+  description = "Configuration used for managing the add-on with ArgoCD"
+  value       = var.manage_via_gitops ? local.argocd_gitops_config : null
+}

--- a/modules/kubernetes-addons/ondat/values.yaml
+++ b/modules/kubernetes-addons/ondat/values.yaml
@@ -1,0 +1,25 @@
+ondat-operator:
+  serviceAccount:
+    create: false
+    name: ${ondat_service_account_name}
+  cluster:
+    create: true
+    secretRefName: ${ondat_credential_secret_name}
+    admin:
+      username: ${ondat_admin_username}
+      password: ${ondat_admin_password}
+    kvBackend:
+      address: ${etcd_address}
+    nodeSelectorTerm:
+      key: ${ondat_nodeselectorterm_key}
+      value: ${ondat_nodeselectorterm_value}
+etcd-cluster-operator:
+  cluster:
+    replicas: 5
+    storage: 15Gi
+    storageclass: etcd
+    nodeSelectorTerm:
+      key: ${etcd_nodeselectorterm_key}
+      value: ${etcd_nodeselectorterm_value}
+  ondat:
+    namespace: storageos

--- a/modules/kubernetes-addons/ondat/variables.tf
+++ b/modules/kubernetes-addons/ondat/variables.tf
@@ -1,0 +1,72 @@
+variable "helm_config" {
+  description = "Helm provider config for the ondat addon"
+  type        = any
+  default     = {}
+}
+
+variable "manage_via_gitops" {
+  description = "Determines if the add-on should be managed via GitOps"
+  type        = bool
+  default     = false
+}
+
+variable "addon_context" {
+  description = "Input configuration for the addon"
+  type        = any
+}
+
+variable "irsa_permissions_boundary" {
+  description = "IAM Policy ARN for IRSA IAM role permissions boundary"
+  type        = string
+  default     = ""
+}
+
+variable "irsa_policies" {
+  description = "IAM policy ARNs for Ondat IRSA"
+  type        = list(string)
+  default     = []
+}
+
+variable "create_cluster" {
+  description = "Determines if the StorageOSCluster and secrets should be created"
+  type        = bool
+  default     = true
+}
+
+variable "etcd_endpoints" {
+  description = "A list of etcd endpoints for Ondat"
+  type        = list(string)
+  default     = []
+}
+
+variable "etcd_ca" {
+  description = "The PEM encoded CA for Ondat's etcd"
+  type        = string
+  default     = null
+}
+
+variable "etcd_cert" {
+  description = "The PEM encoded client certificate for Ondat's etcd"
+  type        = string
+  default     = null
+}
+
+variable "etcd_key" {
+  description = "The PEM encoded client key for Ondat's etcd"
+  type        = string
+  default     = null
+  sensitive   = true
+}
+
+variable "admin_username" {
+  description = "Username for the Ondat admin user"
+  type        = string
+  default     = "storageos"
+}
+
+variable "admin_password" {
+  description = "Password for the Ondat admin user"
+  type        = string
+  default     = "storageos"
+  sensitive   = true
+}

--- a/modules/kubernetes-addons/ondat/versions.tf
+++ b/modules/kubernetes-addons/ondat/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.10"
+    }
+  }
+}

--- a/modules/kubernetes-addons/tetrate-istio/README.md
+++ b/modules/kubernetes-addons/tetrate-istio/README.md
@@ -1,0 +1,57 @@
+# Tetrate Istio add-on
+
+## What is Tetrate Istio Distro
+
+[Tetrate Istio Distro](https://istio.tetratelabs.io/) is simple, safe enterprise-grade Istio distro.
+
+## Examples
+
+See [blueprints](https://github.com/tetratelabs/terraform-eksblueprints-tetrate-istio-addon/tree/main/blueprints).
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
+
+## Providers
+
+No providers.
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_base"></a> [base](#module\_base) | github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon | n/a |
+| <a name="module_cni"></a> [cni](#module\_cni) | github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon | n/a |
+| <a name="module_gateway"></a> [gateway](#module\_gateway) | github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon | n/a |
+| <a name="module_istiod"></a> [istiod](#module\_istiod) | github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon | n/a |
+
+## Resources
+
+No resources.
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_addon_context"></a> [addon\_context](#input\_addon\_context) | Input configuration for the addon | `any` | n/a | yes |
+| <a name="input_base_helm_config"></a> [base\_helm\_config](#input\_base\_helm\_config) | Istio `base` Helm Chart Configuration | `any` | `{}` | no |
+| <a name="input_cni_helm_config"></a> [cni\_helm\_config](#input\_cni\_helm\_config) | Istio `cni` Helm Chart Configuration | `any` | `{}` | no |
+| <a name="input_distribution"></a> [distribution](#input\_distribution) | Istio distribution | `string` | `"TID"` | no |
+| <a name="input_distribution_version"></a> [distribution\_version](#input\_distribution\_version) | Istio version | `string` | `""` | no |
+| <a name="input_gateway_helm_config"></a> [gateway\_helm\_config](#input\_gateway\_helm\_config) | Istio `gateway` Helm Chart Configuration | `any` | `{}` | no |
+| <a name="input_install_base"></a> [install\_base](#input\_install\_base) | Install Istio `base` Helm Chart | `bool` | `true` | no |
+| <a name="input_install_cni"></a> [install\_cni](#input\_install\_cni) | Install Istio `cni` Helm Chart | `bool` | `true` | no |
+| <a name="input_install_gateway"></a> [install\_gateway](#input\_install\_gateway) | Install Istio `gateway` Helm Chart | `bool` | `true` | no |
+| <a name="input_install_istiod"></a> [install\_istiod](#input\_install\_istiod) | Install Istio `istiod` Helm Chart | `bool` | `true` | no |
+| <a name="input_istiod_helm_config"></a> [istiod\_helm\_config](#input\_istiod\_helm\_config) | Istio `istiod` Helm Chart Configuration | `any` | `{}` | no |
+| <a name="input_manage_via_gitops"></a> [manage\_via\_gitops](#input\_manage\_via\_gitops) | Determines if the add-on should be managed via GitOps | `bool` | `false` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_argocd_gitops_config"></a> [argocd\_gitops\_config](#output\_argocd\_gitops\_config) | Configuration used for managing the add-on with ArgoCD |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/kubernetes-addons/tetrate-istio/locals.tf
+++ b/modules/kubernetes-addons/tetrate-istio/locals.tf
@@ -1,0 +1,72 @@
+locals {
+  default_version = coalesce(var.distribution_version, "1.12.2")
+
+  default_helm_config = {
+    name             = "undefined"
+    chart            = "undefined"
+    repository       = "https://istio-release.storage.googleapis.com/charts"
+    version          = local.default_version
+    namespace        = "istio-system"
+    timeout          = "1200"
+    create_namespace = true
+    description      = "Istio service mesh"
+  }
+
+  per_distribution_helm_configs = {
+    "TID" = local.tetrate_istio_distribution_helm_config
+  }
+
+  per_distribution_helm_values = {
+    "TID" = local.tetrate_istio_distribution_helm_values
+  }
+
+  distribution_helm_config = lookup(local.per_distribution_helm_configs, var.distribution, {})
+  distribution_helm_values = lookup(local.per_distribution_helm_values, var.distribution, {})
+
+  cni_helm_values = [yamlencode({
+    "istio_cni" : {
+      "enabled" : var.install_cni
+    }
+  })]
+
+  default_base_helm_values    = lookup(local.distribution_helm_values, "base", [])
+  default_cni_helm_values     = lookup(local.distribution_helm_values, "cni", [])
+  default_istiod_helm_values  = concat(lookup(local.distribution_helm_values, "istiod", []), local.cni_helm_values)
+  default_gateway_helm_values = lookup(local.distribution_helm_values, "gateway", [])
+
+  base_helm_config = merge(
+    local.default_helm_config,
+    local.distribution_helm_config,
+    { name = "istio-base", chart = "base" },
+    var.base_helm_config,
+    { values = concat(local.default_base_helm_values, lookup(var.base_helm_config, "values", [])) }
+  )
+
+  cni_helm_config = merge(
+    local.default_helm_config,
+    local.distribution_helm_config,
+    { name = "istio-cni", chart = "cni" },
+    var.cni_helm_config,
+    { values = concat(local.default_cni_helm_values, lookup(var.cni_helm_config, "values", [])) }
+  )
+
+  istiod_helm_config = merge(
+    local.default_helm_config,
+    local.distribution_helm_config,
+    { name = "istio-istiod", chart = "istiod" },
+    var.istiod_helm_config,
+    { values = concat(local.default_istiod_helm_values, lookup(var.istiod_helm_config, "values", [])) }
+  )
+
+  gateway_helm_config = merge(
+    local.default_helm_config,
+    local.distribution_helm_config,
+    { name = "istio-ingressgateway", chart = "gateway" },
+    var.gateway_helm_config,
+    { values = concat(local.default_gateway_helm_values, lookup(var.gateway_helm_config, "values", [])) }
+  )
+
+  argocd_gitops_config = {
+    enable = true
+  }
+}

--- a/modules/kubernetes-addons/tetrate-istio/locals_tid.tf
+++ b/modules/kubernetes-addons/tetrate-istio/locals_tid.tf
@@ -1,0 +1,20 @@
+locals {
+  tetrate_istio_distribution_helm_config = {
+    description = "Tetrate Istio Distribution - Simple, safe enterprise-grade Istio distribution"
+  }
+
+  tetrate_istio_distribution_helm_values = {
+    cni = tolist([yamlencode({
+      "global" : {
+        "hub" : "containers.istio.tetratelabs.com",
+        "tag" : "${lookup(var.cni_helm_config, "version", local.default_helm_config.version)}-tetratefips-v0",
+      }
+    })])
+    istiod = tolist([yamlencode({
+      "global" : {
+        "hub" : "containers.istio.tetratelabs.com",
+        "tag" : "${lookup(var.istiod_helm_config, "version", local.default_helm_config.version)}-tetratefips-v0",
+      }
+    })])
+  }
+}

--- a/modules/kubernetes-addons/tetrate-istio/main.tf
+++ b/modules/kubernetes-addons/tetrate-istio/main.tf
@@ -1,0 +1,45 @@
+module "base" {
+  source = "../helm-addon"
+
+  count = var.install_base ? 1 : 0
+
+  manage_via_gitops = var.manage_via_gitops
+  helm_config       = local.base_helm_config
+  addon_context     = var.addon_context
+}
+
+module "cni" {
+  source = "../helm-addon"
+
+  count = var.install_cni ? 1 : 0
+
+  manage_via_gitops = var.manage_via_gitops
+  helm_config       = local.cni_helm_config
+  addon_context     = var.addon_context
+
+  depends_on = [module.base]
+}
+
+module "istiod" {
+  source = "../helm-addon"
+
+  count = var.install_istiod ? 1 : 0
+
+  manage_via_gitops = var.manage_via_gitops
+  helm_config       = local.istiod_helm_config
+  addon_context     = var.addon_context
+
+  depends_on = [module.cni]
+}
+
+module "gateway" {
+  source = "../helm-addon"
+
+  count = var.install_gateway ? 1 : 0
+
+  manage_via_gitops = var.manage_via_gitops
+  helm_config       = local.gateway_helm_config
+  addon_context     = var.addon_context
+
+  depends_on = [module.istiod]
+}

--- a/modules/kubernetes-addons/tetrate-istio/outputs.tf
+++ b/modules/kubernetes-addons/tetrate-istio/outputs.tf
@@ -1,0 +1,4 @@
+output "argocd_gitops_config" {
+  description = "Configuration used for managing the add-on with ArgoCD"
+  value       = var.manage_via_gitops ? local.argocd_gitops_config : null
+}

--- a/modules/kubernetes-addons/tetrate-istio/variables.tf
+++ b/modules/kubernetes-addons/tetrate-istio/variables.tf
@@ -1,0 +1,70 @@
+variable "distribution" {
+  description = "Istio distribution"
+  type        = string
+  default     = "TID"
+}
+
+variable "distribution_version" {
+  description = "Istio version"
+  type        = string
+  default     = ""
+}
+
+variable "install_base" {
+  description = "Install Istio `base` Helm Chart"
+  type        = bool
+  default     = true
+}
+
+variable "install_cni" {
+  description = "Install Istio `cni` Helm Chart"
+  type        = bool
+  default     = true
+}
+
+variable "install_istiod" {
+  description = "Install Istio `istiod` Helm Chart"
+  type        = bool
+  default     = true
+}
+
+variable "install_gateway" {
+  description = "Install Istio `gateway` Helm Chart"
+  type        = bool
+  default     = true
+}
+
+variable "base_helm_config" {
+  description = "Istio `base` Helm Chart Configuration"
+  type        = any
+  default     = {}
+}
+
+variable "cni_helm_config" {
+  description = "Istio `cni` Helm Chart Configuration"
+  type        = any
+  default     = {}
+}
+
+variable "istiod_helm_config" {
+  description = "Istio `istiod` Helm Chart Configuration"
+  type        = any
+  default     = {}
+}
+
+variable "gateway_helm_config" {
+  description = "Istio `gateway` Helm Chart Configuration"
+  type        = any
+  default     = {}
+}
+
+variable "manage_via_gitops" {
+  description = "Determines if the add-on should be managed via GitOps"
+  type        = bool
+  default     = false
+}
+
+variable "addon_context" {
+  description = "Input configuration for the addon"
+  type        = any
+}

--- a/modules/kubernetes-addons/tetrate-istio/versions.tf
+++ b/modules/kubernetes-addons/tetrate-istio/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 1.0.0"
+}

--- a/versions.tf
+++ b/versions.tf
@@ -32,5 +32,3 @@ terraform {
     }
   }
 }
-
-# modify something for CI to run


### PR DESCRIPTION
### What does this PR do?

- Add support for Terraform v1.3+ using local version of partner modules temporarily. Once the associated pull requests have been remediated on the external addon projects, we can remove the local versions added in this PR in favor of the external addons. An issue has been created to track this follow up update to use the external addons once remediated - but for now this unblocks users of EKS Blueprints

### Motivation

- Resolves #659
- Resolves #754
- Resolves #988

### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR

**Note**: Not all the PRs require a new example and/or doc page. In general:
- Use an existing example when possible to demonstrate a new addons usage
- A new docs page under `docs/add-ons/*` is required for new a new addon

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
