### PR TITLE
fix: Enable `external-secrets` support via GitOps and ArgoCD

### DIFF
--- a/modules/kubernetes-addons/locals.tf
+++ b/modules/kubernetes-addons/locals.tf
@@ -32,6 +32,7 @@ locals {
     kubernetesDashboard       = var.enable_kubernetes_dashboard ? module.kubernetes_dashboard[0].argocd_gitops_config : null
     awsCloudWatchMetrics      = var.enable_aws_cloudwatch_metrics ? module.aws_cloudwatch_metrics[0].argocd_gitops_config : null
     externalDns               = var.enable_external_dns ? module.external_dns[0].argocd_gitops_config : null
+    externalSecrets           = var.enable_external_secrets ? module.external_secrets[0].argocd_gitops_config : null
     velero                    = var.enable_velero ? module.velero[0].argocd_gitops_config : null
     promtail                  = var.enable_promtail ? module.promtail[0].argocd_gitops_config : null
     calico                    = var.enable_calico ? module.calico[0].argocd_gitops_config : null


### PR DESCRIPTION
### What does this PR do?

external secrets are now available in git ops.

### Motivation

without it, git ops will not install external secrets.

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [x] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR

**Note**: Not all the PRs require a new example and/or doc page. In general:
- Use an existing example when possible to demonstrate a new addons usage
- A new docs page under `docs/add-ons/*` is required for new a new addon

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
