### PR TITLE
fix: Remove `examples/portworx` from planning checks due to unknown computed value caused by IAM policy

### DIFF
--- a/.github/workflows/plan-examples.py
+++ b/.github/workflows/plan-examples.py
@@ -11,10 +11,11 @@ def get_examples():
     exclude = {
         'examples/eks-cluster-with-external-dns',  # excluded until Rout53 is setup
         'examples/ci-cd/gitlab-ci-cd',  # excluded since GitLab auth, backend, etc. required
-        'examples/fully-private-eks-cluster/vpc', # skipping until issue #711 is addressed
+        'examples/fully-private-eks-cluster/vpc',  # skipping until issue #711 is addressed
         'examples/fully-private-eks-cluster/eks',
         'examples/fully-private-eks-cluster/add-ons',
-        'examples/ai-ml/ray' # excluded until #887 is fixed
+        'examples/ai-ml/ray',  # excluded until #887 is fixed
+        'examples/portworx',  # excluded due to policy not known at plan/apply time
     }
 
     projects = {


### PR DESCRIPTION
### What does this PR do?

- Remove `examples/portworx` from planning checks due to unknown computed value caused by IAM policy

### Motivation

- CI checks are currently failing due to unknown computed value https://github.com/aws-ia/terraform-aws-eks-blueprints/actions/runs/3240810888/jobs/5316774404

```
Run terraform plan -no-color
/home/runner/work/_temp/ff75930b-2eb0-4df2-bd09-4a516df11020/terraform-bin plan -no-color

Error: Invalid for_each argument

  on .terraform/modules/eks_blueprints.aws_eks/main.tf line 290, in resource "aws_iam_role_policy_attachment" "this":
 290:   for_each = local.create_iam_role ? toset(compact(distinct(concat([
 291:     "${local.policy_arn_prefix}/AmazonEKSClusterPolicy",
 292:     "${local.policy_arn_prefix}/AmazonEKSVPCResourceController",
 293:   ], var.iam_role_additional_policies)))) : toset([])
    ├────────────────
    │ local.create_iam_role is true
    │ local.policy_arn_prefix is a string, known only after apply
    │ var.iam_role_additional_policies is empty list of string

The "for_each" value depends on resource attributes that cannot be determined
until apply, so Terraform cannot predict how many instances will be created.
To work around this, use the -target argument to first apply only the
resources that the for_each depends on.

Warning: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Warning: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Warning: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
Error: Terraform exited with code 1.
Error: Process completed with exit code 1.
```

### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR

**Note**: Not all the PRs require a new example and/or doc page. In general:
- Use an existing example when possible to demonstrate a new addons usage
- A new docs page under `docs/add-ons/*` is required for new a new addon

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
