### PR TITLE
updating to make namespace creation optional

### DIFF
--- a/modules/kubernetes-addons/kube-prometheus-stack/locals.tf
+++ b/modules/kubernetes-addons/kube-prometheus-stack/locals.tf
@@ -1,5 +1,7 @@
 locals {
-  name = "kube-prometheus-stack"
+  name             = "kube-prometheus-stack"
+  namespace_name   = try(var.helm_config.namespace, "prometheus")
+  create_namespace = try(var.helm_config.create_namespace, true) && local.namespace_name != "kube-system"
   default_helm_config = {
     name        = local.name
     chart       = local.name

--- a/modules/kubernetes-addons/kube-prometheus-stack/main.tf
+++ b/modules/kubernetes-addons/kube-prometheus-stack/main.tf
@@ -2,12 +2,12 @@ module "helm_addon" {
   source        = "../helm-addon"
   helm_config   = local.helm_config
   addon_context = var.addon_context
-  depends_on    = [kubernetes_namespace_v1.prometheus]
 }
 
 resource "kubernetes_namespace_v1" "prometheus" {
+  count = local.create_namespace ? 1 : 0
   metadata {
-    name = local.helm_config["namespace"]
+    name = local.namespace_name
     labels = {
       "app.kubernetes.io/managed-by" = "terraform-aws-eks-blueprints"
     }


### PR DESCRIPTION
### What does this PR do?

Changes behavior of `kube-prometheus-stack` to conditionally create a namespace based on parameter set in helm_config. This will allow the chart to be deployed to a pre-existing namespace.

### Motivation

- Resolves #1056 

### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR

**Note**: Not all the PRs require a new example and/or doc page. In general:
- Use an existing example when possible to demonstrate a new addons usage
- A new docs page under `docs/add-ons/*` is required for new a new addon

### For Moderators

- [ ] E2E Test successfully complete before merge?
