### PR TITLE
chore: Fixed namespace doc for Crossplane Example

### DIFF
--- a/examples/crossplane/README.md
+++ b/examples/crossplane/README.md
@@ -101,10 +101,10 @@ aws eks --region <enter-your-region> update-kubeconfig --name <cluster-name>
 kubectl get nodes
 ```
 
-#### Step 7: List all the pods running in `crossplane` namespace
+#### Step 7: List all the pods running in `crossplane-system` namespace
 
 ```sh
-kubectl get pods -n crossplane
+kubectl get pods -n crossplane-system
 ```
 
 ### AWS Provider for Crossplane


### PR DESCRIPTION
Instruction to list pods in `crossplane` namespace does not work, as the namespace created through blueprint is `crossplane-system`. 

### What does this PR do?

This [minor] PR updates the Readme.md file to fix the specified namespace name to `crossplane-system`.

```shell
$ kubectl get pods -n crossplane
No resources found in crossplane namespace.

$ kubectl get pods -n crossplane-system
NAME                                             READY   STATUS    RESTARTS   AGE
aws-provider-f78664a342f1-b56dc7c4b-m2q49        1/1     Running   0          3m20s
crossplane-5696d784b8-26xps                      1/1     Running   0          5m57s
crossplane-rbac-manager-8466dfb7fc-4l8tr         1/1     Running   0          5m57s
jet-aws-provider-b42c59584ad8-6b4c7685dc-8bdj7   1/1     Running   0          3m41s
```

### Motivation

<!-- What inspired you to submit this pull request? -->
- This fix should help future uses of the example be successful

### More

- [X] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR

**Note**: Not all the PRs require a new example and/or doc page. In general:
- Use an existing example when possible to demonstrate a new addons usage
- A new docs page under `docs/add-ons/*` is required for new a new addon

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

I stan EKS Blueprints ❤️ 