### PR TITLE
chore: Replace EFS standalone resources with EFS module

### DIFF
--- a/examples/stateful/main.tf
+++ b/examples/stateful/main.tf
@@ -170,38 +170,31 @@ module "velero_backup_s3_bucket" {
   tags = local.tags
 }
 
-resource "aws_efs_file_system" "efs" {
-  creation_token = "efs"
-  encrypted      = true
+module "efs" {
+  source  = "terraform-aws-modules/efs/aws"
+  version = "~> 1.0"
 
-  tags = local.tags
-}
+  creation_token = local.name
+  name           = local.name
 
-resource "aws_efs_mount_target" "efs_mt" {
-  count = length(module.vpc.private_subnets)
-
-  file_system_id  = aws_efs_file_system.efs.id
-  subnet_id       = module.vpc.private_subnets[count.index]
-  security_groups = [aws_security_group.efs.id]
-}
-
-resource "aws_security_group" "efs" {
-  name        = "${local.name}-efs"
-  description = "Allow inbound NFS traffic from private subnets of the VPC"
-  vpc_id      = module.vpc.vpc_id
-
-  ingress {
-    description = "Allow NFS 2049/tcp"
-    cidr_blocks = module.vpc.private_subnets_cidr_blocks
-    from_port   = 2049
-    to_port     = 2049
-    protocol    = "tcp"
+  # Mount targets / security group
+  mount_targets = { for k, v in toset(range(length(local.azs))) :
+    element(local.azs, k) => { subnet_id = element(module.vpc.private_subnets, k) }
+  }
+  security_group_description = "${local.name} EFS security group"
+  security_group_vpc_id      = module.vpc.vpc_id
+  security_group_rules = {
+    vpc = {
+      # relying on the defaults provdied for EFS/NFS (2049/TCP + ingress)
+      description = "NFS ingress from VPC private subnets"
+      cidr_blocks = module.vpc.private_subnets_cidr_blocks
+    }
   }
 
   tags = local.tags
 }
 
-resource "kubernetes_storage_class" "storage_class" {
+resource "kubernetes_storage_class_v1" "gp3" {
   metadata {
     name = "gp3"
   }
@@ -214,5 +207,18 @@ resource "kubernetes_storage_class" "storage_class" {
     encrypted = true
     fsType    = "ext4"
     type      = "gp3"
+  }
+}
+
+resource "kubernetes_storage_class_v1" "efs" {
+  metadata {
+    name = "efs"
+  }
+
+  storage_provisioner = "efs.csi.aws.com"
+  parameters = {
+    provisioningMode = "efs-ap" # Dynamic provisioning
+    fileSystemId     = module.efs.id
+    directoryPerms   = "700"
   }
 }


### PR DESCRIPTION
### What does this PR do?

- Replace EFS standalone resources with EFS module

### Motivation

- Resolves #1080

### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR

**Note**: Not all the PRs require a new example and/or doc page. In general:
- Use an existing example when possible to demonstrate a new addons usage
- A new docs page under `docs/add-ons/*` is required for new a new addon

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
