### PR TITLE
fix: Windows - Changing docker files to be stored on secondary drive

### DIFF
--- a/modules/launch-templates/templates/userdata-windows.tpl
+++ b/modules/launch-templates/templates/userdata-windows.tpl
@@ -17,6 +17,23 @@ if ($disks_to_adjust -ne $null) {
   }
 }
 
+# Redirect Docker files to new the disk
+Stop-Service -Name "docker" -Force -NoWait
+
+$dockerdataredirect = @'
+{
+    "data-root": "D:\\ProgramData\\Docker"
+}
+'@
+
+$daemon_file = "C:\ProgramData\docker\config\daemon.json"
+$directory = "D:\ProgramData\docker"
+New-Item $directory -ItemType Directory
+New-Item $daemon_file -ItemType File 
+Add-Content $daemon_file $dockerdataredirect
+
+Start-Service -Name "docker" 
+
 # Bootstrap and join the cluster
 [string]$EKSBinDir = "$env:ProgramFiles\Amazon\EKS"
 [string]$EKSBootstrapScriptName = 'Start-EKSBootstrap.ps1'


### PR DESCRIPTION
### What does this PR do?

🛑 Please open an issue first to discuss any significant work and flesh out details/direction - we would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/aws-ia/terraform-aws-eks-blueprints/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

The Windows self-managed node is being deployed with a secondary encrypted 50GB Amazon EBS disk as /dev/xvda, where the actual Userdata described in this script initializes the disk and formats but doesn't give any real usage. So, to enhance docker performance during node startup by avoiding concurrency disk I/O with the Operational system and image pulling, I'm proposing these additional lines in the scripts that set docker data to be stored on the secondary disk.

### Motivation

<!-- What inspired you to submit this pull request? -->

To help customers fully utilize their AWS resources, I'm giving the existing secondary disk actual usage, which will help reduce NodeDiskPressure due to concurrence IO by having OS and Docker compete on the node initialization.

### More

- [ X ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR

**Note**: Not all the PRs require a new example and/or doc page. In general:
- Use an existing example when possible to demonstrate a new addons usage
- A new docs page under `docs/add-ons/*` is required for new a new addon

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->

In the image below, you can confirm that docker is now consuming the drive D as it is pulling images.

![image (1)](https://user-images.githubusercontent.com/26945091/197661894-3678eeb2-0cd6-4a04-af3c-d5f011c950cb.png)
![image (2)](https://user-images.githubusercontent.com/26945091/197661911-ac6ecd41-223a-42bc-9544-adaab2e89003.png)
