### PR TITLE
fix: Failed to create NAT gateway for `eks-cluster-with-new-vpc` example if local zones are enabled

### DIFF
--- a/examples/eks-cluster-with-new-vpc/main.tf
+++ b/examples/eks-cluster-with-new-vpc/main.tf
@@ -20,7 +20,12 @@ data "aws_eks_cluster_auth" "this" {
   name = module.eks_blueprints.eks_cluster_id
 }
 
-data "aws_availability_zones" "available" {}
+data "aws_availability_zones" "available" {
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
 
 locals {
   name = basename(path.cwd)


### PR DESCRIPTION
### What does this PR do?

🛑 Please open an issue first to discuss any significant work and flesh out details/direction - we would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/aws-ia/terraform-aws-eks-blueprints/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

<!-- A brief description of the change being made with this pull request. -->

### Motivation

Followed the getting started documentation with the `eks-cluster-with-new-vpc` example and the step
```
terraform apply -target="module.vpc"
```

failed with the error

```
│ Error: error creating EC2 NAT Gateway: NotAvailableInZone: Nat Gateway is not available in this availability zone
│ 	status code: 400, request id: 522ca79d-4c64-4b62-8be9-66b4d5b91014
│
│   with module.vpc.aws_nat_gateway.this[0],
│   on .terraform/modules/vpc/main.tf line 1025, in resource "aws_nat_gateway" "this":
│ 1025: resource "aws_nat_gateway" "this" {
│
```

Upon investigation, Terraform had selected the Phoenix Local zone to create one of the subnets and then tried to create the NAT gateway in the local zone.

### More

- [X] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR

**Note**: Not all the PRs require a new example and/or doc page. In general:
- Use an existing example when possible to demonstrate a new addons usage
- A new docs page under `docs/add-ons/*` is required for new a new addon

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

I followed the instructions in the Terraform docs to filter only availability zones.

https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones#by-filter

Only Availability Zones (no Local Zones):
```
data "aws_availability_zones" "example" {
  filter {
    name   = "opt-in-status"
    values = ["opt-in-not-required"]
  }
}
```
