### PR TITLE
fix: Changed non portable usage of base64 --decode flag to -d

### DIFF
--- a/examples/ipv4-prefix-delegation/main.tf
+++ b/examples/ipv4-prefix-delegation/main.tf
@@ -160,8 +160,8 @@ resource "null_resource" "kubectl_set_env" {
 
     # Reference docs https://docs.aws.amazon.com/eks/latest/userguide/cni-increase-ip-addresses.html
     command = <<-EOT
-      kubectl set env daemonset aws-node -n kube-system ENABLE_PREFIX_DELEGATION=true --kubeconfig <(echo $KUBECONFIG | base64 --decode)
-      kubectl set env daemonset aws-node -n kube-system WARM_PREFIX_TARGET=1 --kubeconfig <(echo $KUBECONFIG | base64 --decode)
+      kubectl set env daemonset aws-node -n kube-system ENABLE_PREFIX_DELEGATION=true --kubeconfig <(echo $KUBECONFIG | base64 -d)
+      kubectl set env daemonset aws-node -n kube-system WARM_PREFIX_TARGET=1 --kubeconfig <(echo $KUBECONFIG | base64 -d)
     EOT
   }
 }

--- a/examples/vpc-cni-custom-networking/main.tf
+++ b/examples/vpc-cni-custom-networking/main.tf
@@ -178,13 +178,13 @@ resource "null_resource" "kubectl_set_env" {
     # Reference https://docs.aws.amazon.com/eks/latest/userguide/cni-increase-ip-addresses.html
     command = <<-EOT
       # Custom networking
-      kubectl set env daemonset aws-node -n kube-system AWS_VPC_K8S_CNI_CUSTOM_NETWORK_CFG=true --kubeconfig <(echo $KUBECONFIG | base64 --decode)
-      kubectl set env daemonset aws-node -n kube-system ENI_CONFIG_LABEL_DEF=failure-domain.beta.kubernetes.io/zone --kubeconfig <(echo $KUBECONFIG | base64 --decode)
+      kubectl set env daemonset aws-node -n kube-system AWS_VPC_K8S_CNI_CUSTOM_NETWORK_CFG=true --kubeconfig <(echo $KUBECONFIG | base64 -d)
+      kubectl set env daemonset aws-node -n kube-system ENI_CONFIG_LABEL_DEF=failure-domain.beta.kubernetes.io/zone --kubeconfig <(echo $KUBECONFIG | base64 -d)
 
 
       # Prefix delegation
-      kubectl set env daemonset aws-node -n kube-system ENABLE_PREFIX_DELEGATION=true --kubeconfig <(echo $KUBECONFIG | base64 --decode)
-      kubectl set env daemonset aws-node -n kube-system WARM_PREFIX_TARGET=1 --kubeconfig <(echo $KUBECONFIG | base64 --decode)
+      kubectl set env daemonset aws-node -n kube-system ENABLE_PREFIX_DELEGATION=true --kubeconfig <(echo $KUBECONFIG | base64 -d)
+      kubectl set env daemonset aws-node -n kube-system WARM_PREFIX_TARGET=1 --kubeconfig <(echo $KUBECONFIG | base64 -d)
     EOT
   }
 }

--- a/modules/kubernetes-addons/aws-coredns/main.tf
+++ b/modules/kubernetes-addons/aws-coredns/main.tf
@@ -132,7 +132,7 @@ resource "null_resource" "remove_default_coredns_deployment" {
     # We are removing the deployment provided by the EKS service and replacing it through the self-managed CoreDNS Helm addon
     # However, we are maintaing the existing kube-dns service and annotating it for Helm to assume control
     command = <<-EOT
-      kubectl --namespace kube-system delete deployment coredns --kubeconfig <(echo $KUBECONFIG | base64 --decode)
+      kubectl --namespace kube-system delete deployment coredns --kubeconfig <(echo $KUBECONFIG | base64 -d)
     EOT
   }
 }
@@ -151,9 +151,9 @@ resource "null_resource" "modify_kube_dns" {
 
     # We are maintaing the existing kube-dns service and annotating it for Helm to assume control
     command = <<-EOT
-      kubectl --namespace kube-system annotate --overwrite service kube-dns meta.helm.sh/release-name=coredns --kubeconfig <(echo $KUBECONFIG | base64 --decode)
-      kubectl --namespace kube-system annotate --overwrite service kube-dns meta.helm.sh/release-namespace=kube-system --kubeconfig <(echo $KUBECONFIG | base64 --decode)
-      kubectl --namespace kube-system label --overwrite service kube-dns app.kubernetes.io/managed-by=Helm --kubeconfig <(echo $KUBECONFIG | base64 --decode)
+      kubectl --namespace kube-system annotate --overwrite service kube-dns meta.helm.sh/release-name=coredns --kubeconfig <(echo $KUBECONFIG | base64 -d)
+      kubectl --namespace kube-system annotate --overwrite service kube-dns meta.helm.sh/release-namespace=kube-system --kubeconfig <(echo $KUBECONFIG | base64 -d)
+      kubectl --namespace kube-system label --overwrite service kube-dns app.kubernetes.io/managed-by=Helm --kubeconfig <(echo $KUBECONFIG | base64 -d)
     EOT
   }
 }


### PR DESCRIPTION
### What does this PR do?

- Changed coredns local exec calls to base64 with flag `--decode` to `-d` which is supported universally on darwin & other linux distributions. 

### Motivation

<!-- What inspired you to submit this pull request? -->
- Resolves #1115 

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [n/a] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [n/a] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [n/a] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR

**Note**: Not all the PRs require a new example and/or doc page. In general:
- Use an existing example when possible to demonstrate a new addons usage
- A new docs page under `docs/add-ons/*` is required for new a new addon

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes
This TF code is being run on alpine based system, not MacOS. Demonstrates changes fixed the initial issue. 

```module.eks_blueprints.module.aws_coredns[0].null_resource.remove_default_coredns_deployment[0]: Destroying... [id=5577006791947779410]
module.eks_blueprints.module.aws_coredns[0].null_resource.remove_default_coredns_deployment[0]: Destruction complete after 0s
module.eks_blueprints.module.aws_coredns[0].null_resource.remove_default_coredns_deployment[0]: Creating...
module.eks_blueprints.module.aws_coredns[0].null_resource.remove_default_coredns_deployment[0]: Provisioning with 'local-exec'...
module.eks_blueprints.module.aws_coredns[0].null_resource.remove_default_coredns_deployment[0] (local-exec): (output suppressed due to sensitive value in config)
module.eks_blueprints.module.aws_coredns[0].null_resource.remove_default_coredns_deployment[0] (local-exec): (output suppressed due to sensitive value in config)
module.eks_blueprints.module.aws_coredns[0].null_resource.remove_default_coredns_deployment[0]: Creation complete after 1s [id=5577006791947779410]
module.eks_blueprints.module.aws_coredns[0].null_resource.modify_kube_dns[0]: Creating...
module.eks_blueprints.module.aws_coredns[0].null_resource.modify_kube_dns[0]: Provisioning with 'local-exec'...
module.eks_blueprints.module.aws_coredns[0].null_resource.modify_kube_dns[0] (local-exec): (output suppressed due to sensitive value in config)
module.eks_blueprints.module.aws_coredns[0].module.helm_addon[0].helm_release.addon[0]: Creating...
module.eks_blueprints.module.aws_coredns[0].null_resource.modify_kube_dns[0] (local-exec): (output suppressed due to sensitive value in config)
module.eks_blueprints.module.aws_coredns[0].null_resource.modify_kube_dns[0] (local-exec): (output suppressed due to sensitive value in config)
module.eks_blueprints.module.aws_coredns[0].null_resource.modify_kube_dns[0] (local-exec): (output suppressed due to sensitive value in config)
module.eks_blueprints.module.aws_coredns[0].null_resource.modify_kube_dns[0]: Creation complete after 0s [id=8674665223082153551]
module.eks_blueprints.module.aws_coredns[0].module.helm_addon[0].helm_release.addon[0]: Still creating... [10s elapsed]
module.eks_blueprints.module.aws_coredns[0].module.helm_addon[0].helm_release.addon[0]: Still creating... [20s elapsed]
module.eks_blueprints.module.aws_coredns[0].module.helm_addon[0].helm_release.addon[0]: Still creating... [30s elapsed]
module.eks_blueprints.module.aws_coredns[0].module.helm_addon[0].helm_release.addon[0]: Still creating... [40s elapsed]
module.eks_blueprints.module.aws_coredns[0].module.helm_addon[0].helm_release.addon[0]: Creation complete after 43s [id=coredns]

Apply complete! Resources: 3 added, 0 changed, 1 destroyed.```
