### PR TITLE
fix: Add k8s provider & wait for addons

### DIFF
--- a/examples/tls-with-aws-pca-issuer/main.tf
+++ b/examples/tls-with-aws-pca-issuer/main.tf
@@ -10,6 +10,12 @@ provider "kubectl" {
   token                  = data.aws_eks_cluster_auth.this.token
 }
 
+provider "kubernetes" {
+  host                   = module.eks_blueprints.eks_cluster_endpoint
+  cluster_ca_certificate = base64decode(module.eks_blueprints.eks_cluster_certificate_authority_data)
+  token                  = data.aws_eks_cluster_auth.this.token
+}
+
 provider "helm" {
   kubernetes {
     host                   = module.eks_blueprints.eks_cluster_endpoint
@@ -145,6 +151,10 @@ resource "kubectl_manifest" "cluster_pca_issuer" {
       region : local.region
     }
   })
+
+  depends_on = [
+    module.eks_blueprints_kubernetes_addons
+  ]
 }
 
 #-------------------------------
@@ -185,7 +195,6 @@ resource "kubectl_manifest" "example_pca_certificate" {
   })
 
   depends_on = [
-    module.eks_blueprints_kubernetes_addons,
     kubectl_manifest.cluster_pca_issuer,
   ]
 }


### PR DESCRIPTION
### What does this PR do?
- Adds missing k8s provider to the TLS example
- Adds depends on to wait for addons module

### Motivation
- k8s provider required otherwise will face the same localhost issues mentioned in the related issue.
- wait for addons to be deployed  first (let CRDs be created) before we try to create manifests that depends on CRDs
- Resolves https://github.com/aws-ia/terraform-aws-eks-blueprints/issues/1124

### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR

**Note**: Not all the PRs require a new example and/or doc page. In general:
- Use an existing example when possible to demonstrate a new addons usage
- A new docs page under `docs/add-ons/*` is required for new a new addon

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
