### PR TITLE
feat: Add `flb_log_cw` parameter to Fargate FluentBit addon to enable sending logs to CloudWatch

### DIFF
--- a/examples/complete-kubernetes-addons/main.tf
+++ b/examples/complete-kubernetes-addons/main.tf
@@ -210,7 +210,7 @@ module "eks_blueprints_kubernetes_addons" {
       Time_Keep On
       Decode_Field_As json message
     EOF
-    flb_log_cw = true
+    flb_log_cw   = true
   }
 
   enable_kyverno                 = true

--- a/examples/complete-kubernetes-addons/main.tf
+++ b/examples/complete-kubernetes-addons/main.tf
@@ -210,6 +210,7 @@ module "eks_blueprints_kubernetes_addons" {
       Time_Keep On
       Decode_Field_As json message
     EOF
+    flb_log_cw = true
   }
 
   enable_kyverno                 = true

--- a/modules/kubernetes-addons/fargate-fluentbit/README.md
+++ b/modules/kubernetes-addons/fargate-fluentbit/README.md
@@ -56,6 +56,7 @@ Please find the updated configuration from [AWS Docs](https://docs.aws.amazon.co
   Time_Keep On
   Decode_Field_As json message
     EOF
+  flb_log_cw: true
   }
 ```
 

--- a/modules/kubernetes-addons/fargate-fluentbit/locals.tf
+++ b/modules/kubernetes-addons/fargate-fluentbit/locals.tf
@@ -32,6 +32,7 @@ locals {
       Time_Keep On
       Decode_Field_As json message
     EOF
+    flb_log_cw = false
   }
 
   config = merge(

--- a/modules/kubernetes-addons/fargate-fluentbit/locals.tf
+++ b/modules/kubernetes-addons/fargate-fluentbit/locals.tf
@@ -32,7 +32,7 @@ locals {
       Time_Keep On
       Decode_Field_As json message
     EOF
-    flb_log_cw = false
+    flb_log_cw   = false
   }
 
   config = merge(

--- a/modules/kubernetes-addons/fargate-fluentbit/main.tf
+++ b/modules/kubernetes-addons/fargate-fluentbit/main.tf
@@ -22,6 +22,6 @@ resource "kubernetes_config_map" "aws_logging" {
     "parsers.conf" = local.config["parsers_conf"]
     "filters.conf" = local.config["filters_conf"]
     "output.conf"  = local.config["output_conf"]
-    "flb_log_cw" =  local.config["flb_log_cw"]
+    "flb_log_cw"   = local.config["flb_log_cw"]
   }
 }

--- a/modules/kubernetes-addons/fargate-fluentbit/main.tf
+++ b/modules/kubernetes-addons/fargate-fluentbit/main.tf
@@ -22,5 +22,6 @@ resource "kubernetes_config_map" "aws_logging" {
     "parsers.conf" = local.config["parsers_conf"]
     "filters.conf" = local.config["filters_conf"]
     "output.conf"  = local.config["output_conf"]
+    "flb_log_cw" =  local.config["flb_log_cw"]
   }
 }


### PR DESCRIPTION
### What does this PR do?

Allows you to send fluent-bit process logs to CloudWatch.

### Motivation

This feature allows you to view the fluent bit process log in CloudWatch. The biggest benefit is being able to view the errors raised by the plugin. This new parameter is mentioned in the aws [documentation](https://docs.aws.amazon.com/pt_br/eks/latest/userguide/fargate-logging.html).

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR

**Note**: Not all the PRs require a new example and/or doc page. In general:
- Use an existing example when possible to demonstrate a new addons usage
- A new docs page under `docs/add-ons/*` is required for new a new addon

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes


