### PR TITLE
fix: Use bcrypt for argo password, don't create cw log group

### DIFF
--- a/examples/gitops/argocd/main.tf
+++ b/examples/gitops/argocd/main.tf
@@ -2,6 +2,9 @@ provider "aws" {
   region = local.region
 }
 
+provider "bcrypt" {
+}
+
 provider "kubernetes" {
   host                   = module.eks_blueprints.eks_cluster_endpoint
   cluster_ca_certificate = base64decode(module.eks_blueprints.eks_cluster_certificate_authority_data)
@@ -77,7 +80,7 @@ module "eks_blueprints_kubernetes_addons" {
     set_sensitive = [
       {
         name  = "configs.secret.argocdServerAdminPassword"
-        value = random_password.argocd.result
+        value = bcrypt_hash.argo.id
       }
     ]
   }
@@ -108,16 +111,18 @@ module "eks_blueprints_kubernetes_addons" {
   # Add-ons
   enable_amazon_eks_aws_ebs_csi_driver = true
   enable_aws_for_fluentbit             = true
-  enable_cert_manager                  = true
-  enable_cluster_autoscaler            = true
-  enable_karpenter                     = true
-  enable_keda                          = true
-  enable_metrics_server                = true
-  enable_prometheus                    = true
-  enable_traefik                       = true
-  enable_vpa                           = true
-  enable_yunikorn                      = true
-  enable_argo_rollouts                 = true
+  # Let fluentbit create the cw log group 
+  aws_for_fluentbit_create_cw_log_group = false
+  enable_cert_manager                   = true
+  enable_cluster_autoscaler             = true
+  enable_karpenter                      = true
+  enable_keda                           = true
+  enable_metrics_server                 = true
+  enable_prometheus                     = true
+  enable_traefik                        = true
+  enable_vpa                            = true
+  enable_yunikorn                       = true
+  enable_argo_rollouts                  = true
 
   tags = local.tags
 }
@@ -130,6 +135,12 @@ resource "random_password" "argocd" {
   length           = 16
   special          = true
   override_special = "!#$%&*()-_=+[]{}<>:?"
+}
+
+# Argo requires the password to be bcrypt, we use custom provider of bcrypt, 
+# as the default bcrypt function generates diff for each terraform plan  
+resource "bcrypt_hash" "argo" {
+  cleartext = random_password.argocd.result
 }
 
 #tfsec:ignore:aws-ssm-secret-use-customer-key

--- a/examples/gitops/argocd/main.tf
+++ b/examples/gitops/argocd/main.tf
@@ -111,7 +111,7 @@ module "eks_blueprints_kubernetes_addons" {
   # Add-ons
   enable_amazon_eks_aws_ebs_csi_driver = true
   enable_aws_for_fluentbit             = true
-  # Let fluentbit create the cw log group 
+  # Let fluentbit create the cw log group
   aws_for_fluentbit_create_cw_log_group = false
   enable_cert_manager                   = true
   enable_cluster_autoscaler             = true
@@ -137,8 +137,8 @@ resource "random_password" "argocd" {
   override_special = "!#$%&*()-_=+[]{}<>:?"
 }
 
-# Argo requires the password to be bcrypt, we use custom provider of bcrypt, 
-# as the default bcrypt function generates diff for each terraform plan  
+# Argo requires the password to be bcrypt, we use custom provider of bcrypt,
+# as the default bcrypt function generates diff for each terraform plan
 resource "bcrypt_hash" "argo" {
   cleartext = random_password.argocd.result
 }

--- a/examples/gitops/argocd/versions.tf
+++ b/examples/gitops/argocd/versions.tf
@@ -18,6 +18,10 @@ terraform {
       source  = "hashicorp/random"
       version = "3.3.2"
     }
+    bcrypt = {
+      source = "viktorradnai/bcrypt"
+      version = ">= 0.1.2"
+    }
   }
 
   # ##  Used for end-to-end testing on project; update to suit your needs

--- a/examples/gitops/argocd/versions.tf
+++ b/examples/gitops/argocd/versions.tf
@@ -19,7 +19,7 @@ terraform {
       version = "3.3.2"
     }
     bcrypt = {
-      source = "viktorradnai/bcrypt"
+      source  = "viktorradnai/bcrypt"
       version = ">= 0.1.2"
     }
   }


### PR DESCRIPTION
### What does this PR do?
- adds custom bcrypt provider for argo example
Using custom bcrypt provider instead of the Hashicorp default one because the default generates a diff for every TF plan, leading to issues like https://github.com/aws-ia/terraform-aws-eks-blueprints/issues/1113 where the resources appears as changed every time. as mentioned in the [docs](https://registry.terraform.io/providers/viktorradnai/bcrypt/latest/docs/resources/hash): 
```
Unlike the built-in bcrypt function, this resource will not generate a diff unless the cleartext value changes.
```
- disables fluentbit CW log group creation by Terraform for Argo example
🛑 Please open an issue first to discuss any significant work and flesh out details/direction - we would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/aws-ia/terraform-aws-eks-blueprints/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

<!-- A brief description of the change being made with this pull request. -->

### Motivation

<!-- What inspired you to submit this pull request? -->
- Related to https://github.com/aws-ia/terraform-aws-eks-blueprints/issues/1113
- bcrypt required by Argo as the password has to bcrypt
- fluentbit currently tries to create CW log group like Terraform, and this causes terraform to fail sometimes with "log group with the same name already exists", so for now, disabling TF from creating the log group and letting the addon itself to do it (confirmed IRSA permissions created log group in cloud trail).


### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR

**Note**: Not all the PRs require a new example and/or doc page. In general:
- Use an existing example when possible to demonstrate a new addons usage
- A new docs page under `docs/add-ons/*` is required for new a new addon

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
