### PR TITLE
docs: Remove node groups from nav

### DIFF
--- a/docs/.pages
+++ b/docs/.pages
@@ -2,7 +2,6 @@ nav:
     - Overview: index.md
     - Getting Started: getting-started.md
     - Core Concepts: core-concepts.md
-    - Node Groups: node-groups.md
     - IAM: iam
     - Teams: teams.md
     - Modules: modules


### PR DESCRIPTION
### What does this PR do?
- removes node groups from github pages nav following https://github.com/aws-ia/terraform-aws-eks-blueprints/pull/1104
🛑 Please open an issue first to discuss any significant work and flesh out details/direction - we would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/aws-ia/terraform-aws-eks-blueprints/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

<!-- A brief description of the change being made with this pull request. -->

### Motivation

<!-- What inspired you to submit this pull request? -->
- Resolves https://github.com/aws-ia/terraform-aws-eks-blueprints/issues/1139

### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR

**Note**: Not all the PRs require a new example and/or doc page. In general:
- Use an existing example when possible to demonstrate a new addons usage
- A new docs page under `docs/add-ons/*` is required for new a new addon

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
