### PR TITLE
fix: Additional IAM policy support for the aws-ebs-csi-driver addon role

### DIFF
--- a/modules/kubernetes-addons/aws-ebs-csi-driver/main.tf
+++ b/modules/kubernetes-addons/aws-ebs-csi-driver/main.tf
@@ -64,7 +64,7 @@ module "helm_addon" {
     kubernetes_namespace              = local.namespace
     create_kubernetes_service_account = true
     kubernetes_service_account        = "ebs-csi-controller-sa"
-    irsa_iam_policies                 = concat([aws_iam_policy.aws_ebs_csi_driver[0].arn], try(var.helm_config.additional_iam_policies, []))
+    irsa_iam_policies                 = concat([aws_iam_policy.aws_ebs_csi_driver[0].arn], lookup(var.helm_config, "additional_iam_policies", []))
   }
 
   # Blueprints
@@ -80,7 +80,7 @@ module "irsa_addon" {
   create_kubernetes_service_account = false
   kubernetes_namespace              = local.namespace
   kubernetes_service_account        = "ebs-csi-controller-sa"
-  irsa_iam_policies                 = concat([aws_iam_policy.aws_ebs_csi_driver[0].arn], try(var.addon_config.additional_iam_policies, []))
+  irsa_iam_policies                 = concat([aws_iam_policy.aws_ebs_csi_driver[0].arn], lookup(var.addon_config, "additional_iam_policies", []))
   irsa_iam_role_path                = var.addon_context.irsa_iam_role_path
   irsa_iam_permissions_boundary     = var.addon_context.irsa_iam_permissions_boundary
   eks_cluster_id                    = var.addon_context.eks_cluster_id


### PR DESCRIPTION
The irsa_iam_policies field has an impact on the role creation, via a count field. The try in this cause it to be unpredictable without a precursory apply. A lookup doesn't suffer from the same problem.

Fixes #1144

### What does this PR do?

Makes the additional IAM policies a predictable input to the IRSA role `count` creation conditional check.

### Motivation

<!-- What inspired you to submit this pull request? -->
- Resolves #1144 

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR

**Note**: Not all the PRs require a new example and/or doc page. In general:
- Use an existing example when possible to demonstrate a new addons usage
- A new docs page under `docs/add-ons/*` is required for new a new addon

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
