### PR TITLE
fix annoying rancher annotations

### DIFF
--- a/modules/irsa/main.tf
+++ b/modules/irsa/main.tf
@@ -7,7 +7,12 @@ resource "kubernetes_namespace_v1" "irsa" {
   metadata {
     name = var.kubernetes_namespace
   }
-
+  lifecycle {
+    ignore_changes = [
+      metadata[0].annotations["cattle.io/status"],
+      metadata[0].annotations["lifecycle.cattle.io/create.namespace-auth"]
+    ]
+  }
   timeouts {
     delete = "15m"
   }


### PR DESCRIPTION
### What does this PR do?

adds a lifecycle block to `"irsa"` namespace resource to avoid clutter generated by Rancher annotations during terraform plan/apply commands

### Motivation

I encountered this while using the module and I already know the solution because I had issues while generating >50 namespaces and getting this clutter every-time, so I wanted to give something back.
- Resolves #1152 

### More

- [x ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ x] Yes, I ran `pre-commit run -a` with this PR

**Note**: Not all the PRs require a new example and/or doc page. In general:
- Use an existing example when possible to demonstrate a new addons usage
- A new docs page under `docs/add-ons/*` is required for new a new addon

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes


