### PR TITLE
fix: E2E cleanup log group one time & wait for cluster readiness before creating teams k8s resources

### DIFF
--- a/.github/workflows/e2e-parallel-full.yml
+++ b/.github/workflows/e2e-parallel-full.yml
@@ -15,9 +15,34 @@ env:
   BUCKET_NAME: terraform-eks-blueprints-iam-policies-examples
 
 jobs:
+  prereq-cleanup:
+    name: Prerequisite Cleanup
+    runs-on: ubuntu-latest
+    # These permissions are needed to interact with GitHub's OIDC Token endpoint.
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Auth AWS
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.ROLE_TO_ASSUME }}
+          aws-region: us-west-2
+          role-duration-seconds: 3600
+          role-session-name: GithubActions-Session
+
+      - name: Ensure log groups are removed
+        run: |
+          pip3 install boto3
+          python3 .github/scripts/delete-log-groups.py
+
   deploy:
     name: Run e2e test
     runs-on: ubuntu-latest
+    needs: prereq-cleanup
 
     # These permissions are needed to interact with GitHub's OIDC Token endpoint.
     permissions:
@@ -56,11 +81,6 @@ jobs:
           aws-region: us-west-2
           role-duration-seconds: 3600
           role-session-name: GithubActions-Session
-
-      - name: Ensure log groups are removed
-        run: |
-          pip3 install boto3
-          python3 .github/scripts/delete-log-groups.py
 
       - name: Iamlive Setup & Run
         run: |

--- a/main.tf
+++ b/main.tf
@@ -125,4 +125,8 @@ module "aws_eks_teams" {
   iam_role_permissions_boundary = var.iam_role_permissions_boundary
   eks_cluster_id                = module.aws_eks.cluster_id
   tags                          = var.tags
+
+  depends_on = [
+    data.http.eks_cluster_readiness[0]
+  ]
 }


### PR DESCRIPTION
### What does this PR do?
- Changes cleanup log group script to run 1 time as pre-requisite job in the workflow
- adds depends_on cluster readiness to the teams module

🛑 Please open an issue first to discuss any significant work and flesh out details/direction - we would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/aws-ia/terraform-aws-eks-blueprints/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

<!-- A brief description of the change being made with this pull request. -->

### Motivation
After reviewing last [e2e results](https://github.com/aws-ia/terraform-aws-eks-blueprints/actions/runs/3463906047/jobs/5784775725) noticed:
1) in multi tenancy example, terraform tries to create k8s resources before the cluster is healthy and ready (`healthz` endpoint returns 200), added depends_on to readiness data source.
2) in the spark-k8s example, the "ensure log groups are removed" failed with:
```
botocore.errorfactory.ResourceNotFoundException: An error occurred (ResourceNotFoundException) when calling the DeleteLogGroup operation: The specified log group does not exist.
```
This happened cause of "racing condition" where the script was running multiple times at the same time (due to workflow matrix per example), and it looks for any log groups under `/aws/eks/*` and tries to delete it.
Instead of running the same script multiple times, it can just run 1 time as pre-requisite step for the whole action execution. 
### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR

**Note**: Not all the PRs require a new example and/or doc page. In general:
- Use an existing example when possible to demonstrate a new addons usage
- A new docs page under `docs/add-ons/*` is required for new a new addon

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
