### PR TITLE
fix: Use existing namespace in csi-secrets-store-provider-aws, use valaus file if such is added

### DIFF
--- a/modules/kubernetes-addons/csi-secrets-store-provider-aws/README.md
+++ b/modules/kubernetes-addons/csi-secrets-store-provider-aws/README.md
@@ -5,7 +5,12 @@
 AWS Secrets Manager and Config Provider for Secret Store CSI Driver allows you to get secret contents stored in AWS Key Management Service instance and use the Secrets Store CSI driver interface to mount them into Kubernetes pods.
 
 # Helm Chart
-
+* Upgrade from previous version: the `kubernetes_namespace_v1` resource was updated to use `count` for conditioning, move the terrafom state resource to have `[0]` suffix; ie:
+```bash
+terraform state mv \
+    module.kubernetes_aadons[0].csi_secrets_store_provider_aws[0].kubernetes_namespace_v1.csi_secrets_store_provider_aws \
+    module.kubernetes_addons[0].csi_secrets_store_provider_aws[0].kubernetes_namespace_v1.csi_secrets_store_provider_aws[0]
+```
 ### Instructions to use the Helm Chart
 
 See the [csi-secrets-store-provider-aws](https://github.com/aws/eks-charts/tree/master/stable/csi-secrets-store-provider-aws).

--- a/modules/kubernetes-addons/csi-secrets-store-provider-aws/README.md
+++ b/modules/kubernetes-addons/csi-secrets-store-provider-aws/README.md
@@ -10,16 +10,21 @@ AWS Secrets Manager and Config Provider for Secret Store CSI Driver allows you t
 
 See the [csi-secrets-store-provider-aws](https://github.com/aws/eks-charts/tree/master/stable/csi-secrets-store-provider-aws).
 
-<!--- BEGIN_TF_DOCS --->
+[Secrets Store CSI Driver](https://secrets-store-csi-driver.sigs.k8s.io/getting-started/installation.html) to be provisioned.
+
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
-[Secrets Store CSI Driver](https://secrets-store-csi-driver.sigs.k8s.io/getting-started/installation.html) to be provisioned.
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
+| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.10 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | >= 2.10 |
 
 ## Modules
 
@@ -31,20 +36,23 @@ See the [csi-secrets-store-provider-aws](https://github.com/aws/eks-charts/tree/
 
 | Name | Type |
 |------|------|
-| [kubernetes_namespace.csi_secrets_store_provider_aws](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace) | resource |
+| [kubernetes_namespace_v1.csi_secrets_store_provider_aws](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace_v1) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_addon_context"></a> [addon\_context](#input\_addon\_context) | Input configuration for the addon | <pre>object({<br>    aws_caller_identity_account_id = string<br>    aws_caller_identity_arn        = string<br>    aws_eks_cluster_endpoint       = string<br>    aws_partition_id               = string<br>    aws_region_name                = string<br>    eks_cluster_id                 = string<br>    eks_oidc_issuer_url            = string<br>    eks_oidc_provider_arn          = string<br>    tags                           = map(string)<br>  })</pre> | n/a | yes |
-| <a name="input_helm_config"></a> [helm\_config](#input\_helm\_config) | Cluster Autoscaler Helm Config | `any` | `{}` | no |
-| <a name="input_manage_via_gitops"></a> [manage\_via\_gitops](#input\_manage\_via\_gitops) | Determines if the add-on should be managed via GitOps. | `bool` | `false` | no |
+| <a name="input_addon_context"></a> [addon\_context](#input\_addon\_context) | Input configuration for the addon | <pre>object({<br>    aws_caller_identity_account_id = string<br>    aws_caller_identity_arn        = string<br>    aws_eks_cluster_endpoint       = string<br>    aws_partition_id               = string<br>    aws_region_name                = string<br>    eks_cluster_id                 = string<br>    eks_oidc_issuer_url            = string<br>    eks_oidc_provider_arn          = string<br>    tags                           = map(string)<br>    irsa_iam_role_path             = string<br>    irsa_iam_permissions_boundary  = string<br>  })</pre> | n/a | yes |
+| <a name="input_helm_config"></a> [helm\_config](#input\_helm\_config) | CSI Secrets Store Provider AWS Helm Configurations | `any` | `{}` | no |
+| <a name="input_manage_via_gitops"></a> [manage\_via\_gitops](#input\_manage\_via\_gitops) | Determines if the add-on should be managed via GitOps | `bool` | `false` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
 | <a name="output_argocd_gitops_config"></a> [argocd\_gitops\_config](#output\_argocd\_gitops\_config) | Configuration used for managing the add-on with ArgoCD |
-
-<!--- END_TF_DOCS --->
+| <a name="output_irsa_arn"></a> [irsa\_arn](#output\_irsa\_arn) | IAM role ARN for the service account |
+| <a name="output_irsa_name"></a> [irsa\_name](#output\_irsa\_name) | IAM role name for the service account |
+| <a name="output_release_metadata"></a> [release\_metadata](#output\_release\_metadata) | Map of attributes of the Helm release metadata |
+| <a name="output_service_account"></a> [service\_account](#output\_service\_account) | Name of Kubernetes service account |
+<!-- END_TF_DOCS -->

--- a/modules/kubernetes-addons/csi-secrets-store-provider-aws/locals.tf
+++ b/modules/kubernetes-addons/csi-secrets-store-provider-aws/locals.tf
@@ -1,5 +1,5 @@
 locals {
-  default_helm_values = [file("${path.module}/values.yaml")]
+  default_helm_values = [try(file("${path.module}/values.yaml"), null)]
 
   name      = "csi-secrets-store-provider-aws"
   namespace = "csi-secrets-store-provider-aws"

--- a/modules/kubernetes-addons/csi-secrets-store-provider-aws/locals.tf
+++ b/modules/kubernetes-addons/csi-secrets-store-provider-aws/locals.tf
@@ -1,0 +1,24 @@
+locals {
+  default_helm_values = [file("${path.module}/values.yaml")]
+
+  name      = "csi-secrets-store-provider-aws"
+  namespace = "csi-secrets-store-provider-aws"
+
+  # https://github.com/argoproj/argo-helm/blob/main/charts/argo-cd/Chart.yaml
+  default_helm_config = {
+    name             = local.name
+    chart            = local.name
+    repository       = "https://aws.github.io/eks-charts"
+    version          = "0.0.3"
+    namespace        = local.namespace
+    create_namespace = true
+    values           = local.default_helm_values
+    description      = "A Helm chart to install the Secrets Store CSI Driver and the AWS Key Management Service Provider inside a Kubernetes cluster."
+    wait             = false
+  }
+
+  helm_config = merge(
+    local.default_helm_config,
+    var.helm_config
+  )
+}

--- a/modules/kubernetes-addons/csi-secrets-store-provider-aws/main.tf
+++ b/modules/kubernetes-addons/csi-secrets-store-provider-aws/main.tf
@@ -1,30 +1,19 @@
-locals {
-  name      = try(var.helm_config.name, "csi-secrets-store-provider-aws")
-  namespace = try(var.helm_config.namespace, local.name)
-}
-
-resource "kubernetes_namespace_v1" "csi_secrets_store_provider_aws" {
-  metadata {
-    name = local.namespace
-  }
-}
-
 module "helm_addon" {
   source = "../helm-addon"
 
   # https://github.com/aws/eks-charts/blob/master/stable/csi-secrets-store-provider-aws/Chart.yaml
-  helm_config = merge(
-    {
-      name        = local.name
-      chart       = local.name
-      repository  = "https://aws.github.io/eks-charts"
-      version     = "0.0.3"
-      namespace   = kubernetes_namespace_v1.csi_secrets_store_provider_aws.metadata[0].name
-      description = "A Helm chart to install the Secrets Store CSI Driver and the AWS Key Management Service Provider inside a Kubernetes cluster."
-    },
-    var.helm_config
-  )
+
+  helm_config = local.helm_config
 
   manage_via_gitops = var.manage_via_gitops
   addon_context     = var.addon_context
+
+  depends_on = [kubernetes_namespace_v1.csi_secrets_store_provider_aws]
+}
+
+resource "kubernetes_namespace_v1" "csi_secrets_store_provider_aws" {
+  count = try(local.helm_config["create_namespace"], true) && local.helm_config["namespace"] != "kube-system" ? 1 : 0
+  metadata {
+    name = local.helm_config["namespace"]
+  }
 }


### PR DESCRIPTION
### What does this PR do?

🛑 Please open an issue first to discuss any significant work and flesh out details/direction - we would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/aws-ia/terraform-aws-eks-blueprints/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

<!-- A brief description of the change being made with this pull request. -->

### Motivation
We use this module with addons, personally I'm trying to switch totally to addons, with lots of argocd.
Additionally to contribue to the project that I use.

<!-- What inspired you to submit this pull request? -->
- Resolves #1172 

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR

**Note**: Not all the PRs require a new example and/or doc page. In general:
- Use an existing example when possible to demonstrate a new addons usage
- A new docs page under `docs/add-ons/*` is required for new a new addon

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->

Applied changes below:
```bash
  # module.kubernetes_addons.module.csi_secrets_store_provider_aws[0].module.helm_addon.helm_release.addon[0] will be created
  + resource "helm_release" "addon" {
      + atomic                     = false
      + chart                      = "csi-secrets-store-provider-aws"
      + cleanup_on_fail            = false
      + create_namespace           = false
      + dependency_update          = false
      + description                = "A Helm chart to install the Secrets Store CSI Driver and the AWS Key Management Service Provider inside a Kubernetes cluster."
      + disable_crd_hooks          = false
      + disable_openapi_validation = false
      + disable_webhooks           = false
      + force_update               = false
      + id                         = (known after apply)
      + lint                       = false
      + manifest                   = (known after apply)
      + max_history                = 0
      + metadata                   = (known after apply)
      + name                       = "csi-secrets-store-provider-aws"
      + namespace                  = "kube-system"
      + pass_credentials           = false
      + recreate_pods              = false
      + render_subchart_notes      = true
      + replace                    = false
      + repository                 = "https://aws.github.io/eks-charts"
      + reset_values               = false
      + reuse_values               = false
      + skip_crds                  = false
      + status                     = "deployed"
      + timeout                    = 1200
      + values                     = [
          + <<-EOT
                rbac:
                  install: true
                  pspEnabled: false
                
                secrets-store-csi-driver:
                  syncSecret.enabled: true
            EOT,
        ]
      + verify                     = false
      + version                    = "0.0.3"
      + wait                       = false
      + wait_for_jobs              = false

      + postrender {}
    }

Plan: 1 to add, 1 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

module.kubernetes_addons.module.csi_secrets_store_provider_aws[0].module.helm_addon.helm_release.addon[0]: Creating...
module.kubernetes_addons.module.argocd[0].module.helm_addon.helm_release.addon[0]: Modifying... [id=argo-cd]
module.kubernetes_addons.module.csi_secrets_store_provider_aws[0].module.helm_addon.helm_release.addon[0]: Still creating... [10s elapsed]
module.kubernetes_addons.module.argocd[0].module.helm_addon.helm_release.addon[0]: Still modifying... [id=argo-cd, 10s elapsed]
module.kubernetes_addons.module.csi_secrets_store_provider_aws[0].module.helm_addon.helm_release.addon[0]: Creation complete after 20s [id=csi-secrets-store-provider-aws]
module.kubernetes_addons.module.argocd[0].module.helm_addon.helm_release.addon[0]: Still modifying... [id=argo-cd, 20s elapsed]
module.kubernetes_addons.module.argocd[0].module.helm_addon.helm_release.addon[0]: Still modifying... [id=argo-cd, 30s elapsed]
module.kubernetes_addons.module.argocd[0].module.helm_addon.helm_release.addon[0]: Still modifying... [id=argo-cd, 40s elapsed]
module.kubernetes_addons.module.argocd[0].module.helm_addon.helm_release.addon[0]: Still modifying... [id=argo-cd, 50s elapsed]
module.kubernetes_addons.module.argocd[0].module.helm_addon.helm_release.addon[0]: Still modifying... [id=argo-cd, 1m0s elapsed]
module.kubernetes_addons.module.argocd[0].module.helm_addon.helm_release.addon[0]: Modifications complete after 1m4s [id=argo-cd]
Releasing state lock. This may take a few moments...

Apply complete! Resources: 1 added, 1 changed, 0 destroyed.
```

* Performed the apply in the ctual cluster after reviewing the plan with source for my fork repo, the output of helm ls -A:
```
NAME                            NAMESPACE       REVISION        UPDATED                                 STATUS          CHART                                   APP VERSION
argo-cd                         argocd          4               2022-11-15 11:16:31.3427213 +0200 IST   deployed        argo-cd-5.8.3                           v2.5.0
aws-load-balancer-controller    kube-system     1               2022-11-13 18:18:53.2770895 +0200 IST   deployed        aws-load-balancer-controller-1.4.5      v2.4.4
cluster-autoscaler              kube-system     1               2022-11-13 18:18:51.3985822 +0200 IST   deployed        cluster-autoscaler-9.21.0               1.23.0
csi-secrets-store-provider-aws  kube-system     1               2022-11-15 11:16:30.8940736 +0200 IST   deployed        csi-secrets-store-provider-aws-0.0.3    1.0.r2-6-gee95299-2022.04.14.21.07
kubecost                        kubecost        1               2022-11-13 18:18:40.9034549 +0200 IST   deployed        cost-analyzer-1.97.0                    1.97.0
metrics-server                  kube-system     1               2022-11-13 18:18:38.4616786 +0200 IST   deployed        metrics-server-3.8.2                    0.6.1
```

Also updated the README file in the module, addiitonally, from the existing example in the examples/secrets-management/csi-secrets-driver, it would fail originally since initially this is how I tried to apply it, which means the whole example is not efficient due to #1138 issue.

I don't think that this fix requires additional example as it add the capabilities as the most addons are utilized.