### PR TITLE
feat: Bump argocd version

### DIFF
--- a/modules/kubernetes-addons/argocd/locals.tf
+++ b/modules/kubernetes-addons/argocd/locals.tf
@@ -9,7 +9,7 @@ locals {
     name             = local.name
     chart            = local.name
     repository       = "https://argoproj.github.io/argo-helm"
-    version          = "5.8.3"
+    version          = "5.13.8"
     namespace        = local.namespace
     create_namespace = true
     values           = local.default_helm_values

--- a/modules/kubernetes-addons/argocd/values.yaml
+++ b/modules/kubernetes-addons/argocd/values.yaml
@@ -13,3 +13,8 @@ repoServer:
   autoscaling:
     enabled: true
     minReplicas: 2
+
+configs:
+  cm:
+    #use annotation for tracking but keep labels for compatibility with other tools
+    application.resourceTrackingMethod: annotation+label


### PR DESCRIPTION
### What does this PR do?

🛑 Please open an issue first to discuss any significant work and flesh out details/direction - we would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/aws-ia/terraform-aws-eks-blueprints/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

<!-- A brief description of the change being made with this pull request. -->

This PR bumps argocd version to latest available (5.13.8) and also adds Resource Tracking to the `argocd-cm` ConfigMap.  We use the `annotation+label` option for tracking so that argocd uses annotation `argocd.argoproj.io/tracking-id` but we keep the label for components that still need compatibility with other tools that require the instance label. 

### Motivation

Latest version gives us the latest features and fixes including a fix that enables resource tracking of resources that are created as a result of external components like Crossplane compositions. This enables argocd to keep track of resources that it directly doesn't create such as namespace scoped claims for crossplane resources based on compositions (xrd). 

<!-- What inspired you to submit this pull request? -->
- Resolves #1174 

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [N/A] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [N/A] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [N/A] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR

**Note**: Not all the PRs require a new example and/or doc page. In general:
- Use an existing example when possible to demonstrate a new addons usage
- A new docs page under `docs/add-ons/*` is required for new a new addon

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
