### PR TITLE
feat: Add support for `me-central-1` region

### DIFF
--- a/modules/kubernetes-addons/locals.tf
+++ b/modules/kubernetes-addons/locals.tf
@@ -86,6 +86,7 @@ locals {
       eu-west-2      = "602401143452.dkr.ecr.eu-west-2.amazonaws.com",
       eu-west-3      = "602401143452.dkr.ecr.eu-west-3.amazonaws.com",
       me-south-1     = "558608220178.dkr.ecr.me-south-1.amazonaws.com",
+      me-central-1   = "759879836304.dkr.ecr.me-central-1.amazonaws.com",
       sa-east-1      = "602401143452.dkr.ecr.sa-east-1.amazonaws.com",
       us-east-1      = "602401143452.dkr.ecr.us-east-1.amazonaws.com",
       us-east-2      = "602401143452.dkr.ecr.us-east-2.amazonaws.com",


### PR DESCRIPTION
### What does this PR do?

adding support for me-central-1 region

<!-- A brief description of the change being made with this pull request. -->

### Motivation

<!-- What inspired you to submit this pull request? -->
I am deploying service in me-central-1 and found this issue hence trying to fix this on priority

### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR

**Note**: Not all the PRs require a new example and/or doc page. In general:
- Use an existing example when possible to demonstrate a new addons usage
- A new docs page under `docs/add-ons/*` is required for new a new addon

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
