### PR TITLE
Removing docker folder redirect

### DIFF
--- a/modules/launch-templates/templates/userdata-windows.tpl
+++ b/modules/launch-templates/templates/userdata-windows.tpl
@@ -17,23 +17,6 @@ if ($disks_to_adjust -ne $null) {
   }
 }
 
-# Redirect Docker files to new the disk
-Stop-Service -Name "docker" -Force -NoWait
-
-$dockerdataredirect = @'
-{
-    "data-root": "D:\\ProgramData\\Docker"
-}
-'@
-
-$daemon_file = "C:\ProgramData\docker\config\daemon.json"
-$directory = "D:\ProgramData\docker"
-New-Item $directory -ItemType Directory
-New-Item $daemon_file -ItemType File
-Add-Content $daemon_file $dockerdataredirect
-
-Start-Service -Name "docker"
-
 # Bootstrap and join the cluster
 [string]$EKSBinDir = "$env:ProgramFiles\Amazon\EKS"
 [string]$EKSBootstrapScriptName = 'Start-EKSBootstrap.ps1'


### PR DESCRIPTION
Last month I proposed a change in the docker folder redirect in order to avoid cuncurrent I/Os with the Windows OS, however, by doing so, all cached images already present with the EKS Optimized AMIs is lost, as a net effect it will loose the pre-cached container images on the AMI, thereby increasing pull times.

Also, on EKS 1.24 Dockershim won't be available and this script would break the bootstrap process.

### What does this PR do?

🛑 Please open an issue first to discuss any significant work and flesh out details/direction - we would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/aws-ia/terraform-aws-eks-blueprints/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

<!-- A brief description of the change being made with this pull request. -->

### Motivation

<!-- What inspired you to submit this pull request? -->
- Resolves #<issue-number>

### More

- [X ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR

**Note**: Not all the PRs require a new example and/or doc page. In general:
- Use an existing example when possible to demonstrate a new addons usage
- A new docs page under `docs/add-ons/*` is required for new a new addon

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
![Screen Shot 2022-11-16 at 9 36 45 AM](https://user-images.githubusercontent.com/26945091/202224673-cdb328d5-b768-4385-944b-6c2d76de4f76.png)
![Screen Shot 2022-11-16 at 9 31 04 AM](https://user-images.githubusercontent.com/26945091/202224675-5c386ed1-42a7-49b4-8f97-6b5ee6bef40c.png)
![Screen Shot 2022-11-16 at 9 30 46 AM](https://user-images.githubusercontent.com/26945091/202224678-fda80d75-8469-4205-92c3-1ba359aec5fa.png)
