### PR TITLE
fix: Added tags for cert-manager-irsa policy for issue #1216

### DIFF
--- a/modules/kubernetes-addons/cert-manager/main.tf
+++ b/modules/kubernetes-addons/cert-manager/main.tf
@@ -44,4 +44,6 @@ resource "aws_iam_policy" "cert_manager" {
   name        = "${var.addon_context.eks_cluster_id}-${local.helm_config["name"]}-irsa"
   path        = var.addon_context.irsa_iam_role_path
   policy      = data.aws_iam_policy_document.cert_manager_iam_policy_document.json
+  
+  tags = var.addon_context.tags
 }

--- a/modules/kubernetes-addons/cert-manager/main.tf
+++ b/modules/kubernetes-addons/cert-manager/main.tf
@@ -44,6 +44,5 @@ resource "aws_iam_policy" "cert_manager" {
   name        = "${var.addon_context.eks_cluster_id}-${local.helm_config["name"]}-irsa"
   path        = var.addon_context.irsa_iam_role_path
   policy      = data.aws_iam_policy_document.cert_manager_iam_policy_document.json
-  
   tags = var.addon_context.tags
 }

--- a/modules/kubernetes-addons/cert-manager/main.tf
+++ b/modules/kubernetes-addons/cert-manager/main.tf
@@ -44,5 +44,5 @@ resource "aws_iam_policy" "cert_manager" {
   name        = "${var.addon_context.eks_cluster_id}-${local.helm_config["name"]}-irsa"
   path        = var.addon_context.irsa_iam_role_path
   policy      = data.aws_iam_policy_document.cert_manager_iam_policy_document.json
-  tags = var.addon_context.tags
+  tags        = var.addon_context.tags
 }


### PR DESCRIPTION
tags are not being applied policy created for cert manager irsa even when I pass the parameters.  See https://github.com/aws-ia/terraform-aws-eks-blueprints/issues/1216 for more info

### What does this PR do?
This supports addition for tags for cert-manager-irsa policy created

### Motivation

I was trying to add tags to my cert-manager-irsa policy for least privilege but since there was no provision for tags I wasn't able to do that

- Resolves #1216

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR

