### PR TITLE
feat: Add username and password for Argocd repository 

### DIFF
--- a/modules/kubernetes-addons/argocd/README.md
+++ b/modules/kubernetes-addons/argocd/README.md
@@ -40,6 +40,7 @@ Application definitions, configurations, and environments should be declarative 
 | [kubectl_manifest.argocd_kustomize_application](https://registry.terraform.io/providers/gavinbunney/kubectl/latest/docs/resources/manifest) | resource |
 | [kubernetes_namespace_v1.this](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace_v1) | resource |
 | [kubernetes_secret.argocd_gitops](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
+| [kubernetes_secret.argocd_gitops_https](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
 | [aws_secretsmanager_secret.ssh_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret) | data source |
 | [aws_secretsmanager_secret_version.ssh_key_version](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret_version) | data source |
 

--- a/modules/kubernetes-addons/argocd/main.tf
+++ b/modules/kubernetes-addons/argocd/main.tf
@@ -137,7 +137,7 @@ resource "kubernetes_secret" "argocd_gitops" {
 }
 
 resource "kubernetes_secret" "argocd_gitops_https" {
-  for_each = { for k, v in var.applications : k => v if(try(v.username, null) != null)}
+  for_each = { for k, v in var.applications : k => v if(try(v.username, null) != null) }
 
   metadata {
     name      = "${each.key}-repo-secret"

--- a/modules/kubernetes-addons/argocd/main.tf
+++ b/modules/kubernetes-addons/argocd/main.tf
@@ -137,7 +137,7 @@ resource "kubernetes_secret" "argocd_gitops" {
 }
 
 resource "kubernetes_secret" "argocd_gitops_https" {
-  for_each = { for k, v in var.applications : k => v if (try(v.username, null)!= null)  && (try(v.password, null) != null) }
+  for_each = { for k, v in var.applications : k => v if(try(v.username, null) != null)}
 
   metadata {
     name      = "${each.key}-repo-secret"

--- a/modules/kubernetes-addons/argocd/main.tf
+++ b/modules/kubernetes-addons/argocd/main.tf
@@ -137,7 +137,7 @@ resource "kubernetes_secret" "argocd_gitops" {
 }
 
 resource "kubernetes_secret" "argocd_gitops_https" {
-  for_each = { for k, v in var.applications : k => v if try(v.username, null) && try(v.password, null) != null }
+  for_each = { for k, v in var.applications : k => v if (try(v.username, null)!= null)  && (try(v.password, null) != null) }
 
   metadata {
     name      = "${each.key}-repo-secret"


### PR DESCRIPTION
### What does this PR do?

Add the ability to connect Argocd to git repo using https and credentials 

### Motivation
In order to use Argocd, I'm need the ability to provide username and password to connect to a https git url

### More

- [X] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [X] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [X] Yes, I ran `pre-commit run -a` with this PR

**Note**: Not all the PRs require a new example and/or doc page. In general:
- Use an existing example when possible to demonstrate a new addons usage
- A new docs page under `docs/add-ons/*` is required for new a new addon

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes
I created a separate Kubernetes resources for repositories that need username and password.
