### PR TITLE
feat: Add gitops support for `aws-node-termination-handler`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.4.0
     hooks:
       - id: trailing-whitespace
         args: ['--markdown-linebreak-ext=md']
@@ -10,7 +10,7 @@ repos:
       - id: detect-aws-credentials
         args: ['--allow-missing-credentials']
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.76.0
+    rev: v1.77.0
     hooks:
       - id: terraform_fmt
       - id: terraform_docs

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @askulkarni2 @csantanapr @vara-bonthu @bryantbiggs @Zvikan
+* @aws-ia/internal-terraform-eks-admins

--- a/docs/add-ons/aws-node-termination-handler.md
+++ b/docs/add-ons/aws-node-termination-handler.md
@@ -40,3 +40,22 @@ To validate that controller is running, ensure that controller deployment is in 
 $ kubectl get deployments -n kube-system
 aws-node-termination-handler  1/1   1   1   5d9h
 ```
+
+### GitOps Configuration
+The following properties are made available for use when managing the add-on via GitOps.
+
+GitOps with ArgoCD Add-on repo is located [here](https://github.com/aws-samples/eks-blueprints-add-ons/blob/main/chart/values.yaml)
+
+When enabling NTH for GitOps, be sure that you are using `self_managed_node_groups` as this module will check to ensure that it finds valid backing autoscaling groups.
+
+If you're using `managed_node_groups`, NTH isn't required as per the following - https://github.com/aws/aws-node-termination-handler/issues/186
+```
+Amazon EKS automatically drains nodes using the Kubernetes API during terminations or updates. Updates respect the pod disruption budgets that you set for your pods.
+```
+
+```hcl
+  awsNodeTerminationHandler = {
+    enable             = true
+    serviceAccountName = "<service_account>"
+  }
+```

--- a/docs/core-concepts.md
+++ b/docs/core-concepts.md
@@ -14,7 +14,7 @@ This document provides a high level overview of the Core Concepts that are embed
 
 A `cluster` is simply an EKS cluster. EKS Blueprints provides for customizing the compute options you leverage with your `clusters`. The framework currently supports `EC2`, `Fargate` and `BottleRocket` instances. It also supports managed and self-managed node groups. To specify the type of compute you want to use for your `cluster`, you use the `managed_node_groups`, `self_managed_nodegroups`, or `fargate_profiles` variables.
 
-See our [Node Groups](https://aws-ia.github.io/terraform-aws-eks-blueprints/latest/node-groups/) documentation and our [Node Group example directory](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples/node-groups) for detailed information.
+See our [Node Groups](https://aws-ia.github.io/terraform-aws-eks-blueprints/main/node-groups/) documentation and our [Node Group example directory](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples/node-groups) for detailed information.
 
 ## Add-on
 
@@ -34,4 +34,4 @@ See our [`Teams`](teams.md) documentation page for detailed information.
 
 `Applications` represent the actual workloads that run within a Kubernetes cluster. The framework leverages a GitOps approach for deploying applications onto clusters.
 
-See our [`Applications`](https://aws-ia.github.io/terraform-aws-eks-blueprints/latest/add-ons/argocd/#bootstrapping) documentation for detailed information.
+See our [`Applications`](https://aws-ia.github.io/terraform-aws-eks-blueprints/main/add-ons/argocd/#bootstrapping) documentation for detailed information.

--- a/docs/node-groups.md
+++ b/docs/node-groups.md
@@ -1,6 +1,6 @@
 # Node Groups
 
-The framework uses dedicated sub modules for creating [AWS Managed Node Groups](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/modules/aws-eks-managed-node-groups), [Self-managed Node groups](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/modules/aws-eks-self-managed-node-groups) and [Fargate profiles](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/modules/aws-eks-fargate-profiles). These modules provide flexibility to add or remove managed/self-managed node groups/fargate profiles by simply adding/removing map of values to input config. See [example](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples/eks-cluster-with-new-vpc).
+The framework uses dedicated sub modules for creating AWS Managed Node Groups, Self-managed Node groups and Fargate profiles. These modules provide flexibility to add or remove managed/self-managed node groups/fargate profiles by simply adding/removing map of values to input config.
 
 The `aws-auth` ConfigMap handled by this module allow your nodes to join your cluster, and you also use this ConfigMap to add RBAC access to IAM users and roles.
 Each Node Group can have dedicated IAM role, Launch template and Security Group to improve the security.
@@ -448,7 +448,7 @@ The below example demonstrates the minimum configuration required to deploy a ma
       capacity_type   = "SPOT"
       instance_types  = ["m5.large", "m4.large", "m6a.large", "m5a.large", "m5d.large"] // Instances with same specs for memory and CPU so Cluster Autoscaler scales efficiently
       subnet_ids      = []  # Mandatory Public or Private Subnet IDs
-      disk_size       = 100 # disk_size will be ignored when using Launch Templates  
+      disk_size       = 100 # disk_size will be ignored when using Launch Templates
       k8s_taints      = [{ key = "spotInstance", value = "true", effect = "NO_SCHEDULE" }] // Avoid scheduling stateful workloads in SPOT nodes
     }
 ```

--- a/modules/kubernetes-addons/aws-node-termination-handler/README.md
+++ b/modules/kubernetes-addons/aws-node-termination-handler/README.md
@@ -47,11 +47,13 @@ This project ensures that the Kubernetes control plane responds appropriately to
 | <a name="input_autoscaling_group_names"></a> [autoscaling\_group\_names](#input\_autoscaling\_group\_names) | EKS Node Group ASG names | `list(string)` | n/a | yes |
 | <a name="input_helm_config"></a> [helm\_config](#input\_helm\_config) | AWS Node Termination Handler Helm Chart Configuration | `any` | `{}` | no |
 | <a name="input_irsa_policies"></a> [irsa\_policies](#input\_irsa\_policies) | Additional IAM policies for a IAM role for service accounts | `list(string)` | `[]` | no |
+| <a name="input_manage_via_gitops"></a> [manage\_via\_gitops](#input\_manage\_via\_gitops) | Determines if the add-on should be managed via GitOps. | `bool` | `false` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
+| <a name="output_argocd_gitops_config"></a> [argocd\_gitops\_config](#output\_argocd\_gitops\_config) | Configuration used for managing the add-on with ArgoCD |
 | <a name="output_irsa_arn"></a> [irsa\_arn](#output\_irsa\_arn) | IAM role ARN for the service account |
 | <a name="output_irsa_name"></a> [irsa\_name](#output\_irsa\_name) | IAM role name for the service account |
 | <a name="output_release_metadata"></a> [release\_metadata](#output\_release\_metadata) | Map of attributes of the Helm release metadata |

--- a/modules/kubernetes-addons/aws-node-termination-handler/locals.tf
+++ b/modules/kubernetes-addons/aws-node-termination-handler/locals.tf
@@ -37,6 +37,11 @@ locals {
     }
   ]
 
+  argocd_gitops_config = {
+    enable             = true
+    serviceAccountName = local.service_account
+  }
+
   irsa_config = {
     kubernetes_namespace              = local.namespace
     kubernetes_service_account        = local.service_account

--- a/modules/kubernetes-addons/aws-node-termination-handler/main.tf
+++ b/modules/kubernetes-addons/aws-node-termination-handler/main.tf
@@ -1,9 +1,10 @@
 module "helm_addon" {
-  source        = "../helm-addon"
-  helm_config   = local.helm_config
-  irsa_config   = local.irsa_config
-  addon_context = var.addon_context
-  set_values    = local.set_values
+  source            = "../helm-addon"
+  manage_via_gitops = var.manage_via_gitops
+  helm_config       = local.helm_config
+  irsa_config       = local.irsa_config
+  addon_context     = var.addon_context
+  set_values        = local.set_values
 }
 
 resource "aws_autoscaling_lifecycle_hook" "aws_node_termination_handler_hook" {

--- a/modules/kubernetes-addons/aws-node-termination-handler/outputs.tf
+++ b/modules/kubernetes-addons/aws-node-termination-handler/outputs.tf
@@ -17,3 +17,8 @@ output "service_account" {
   description = "Name of Kubernetes service account"
   value       = module.helm_addon.service_account
 }
+
+output "argocd_gitops_config" {
+  description = "Configuration used for managing the add-on with ArgoCD"
+  value       = var.manage_via_gitops ? local.argocd_gitops_config : null
+}

--- a/modules/kubernetes-addons/aws-node-termination-handler/variables.tf
+++ b/modules/kubernetes-addons/aws-node-termination-handler/variables.tf
@@ -4,6 +4,12 @@ variable "helm_config" {
   default     = {}
 }
 
+variable "manage_via_gitops" {
+  description = "Determines if the add-on should be managed via GitOps."
+  type        = bool
+  default     = false
+}
+
 variable "autoscaling_group_names" {
   description = "EKS Node Group ASG names"
   type        = list(string)

--- a/modules/kubernetes-addons/locals.tf
+++ b/modules/kubernetes-addons/locals.tf
@@ -11,6 +11,7 @@ locals {
     awsFSxCsiDriver           = var.enable_aws_fsx_csi_driver ? module.aws_fsx_csi_driver[0].argocd_gitops_config : null
     awsForFluentBit           = var.enable_aws_for_fluentbit ? module.aws_for_fluent_bit[0].argocd_gitops_config : null
     awsLoadBalancerController = var.enable_aws_load_balancer_controller ? module.aws_load_balancer_controller[0].argocd_gitops_config : null
+    awsNodeTerminationHandler = var.enable_aws_node_termination_handler ? module.aws_node_termination_handler[0].argocd_gitops_config : null
     certManager               = var.enable_cert_manager ? module.cert_manager[0].argocd_gitops_config : null
     clusterAutoscaler         = var.enable_cluster_autoscaler ? module.cluster_autoscaler[0].argocd_gitops_config : null
     corednsAutoscaler         = var.enable_amazon_eks_coredns && var.enable_coredns_autoscaler && length(var.coredns_autoscaler_helm_config) > 0 ? module.coredns_autoscaler[0].argocd_gitops_config : null

--- a/modules/kubernetes-addons/main.tf
+++ b/modules/kubernetes-addons/main.tf
@@ -189,6 +189,7 @@ module "aws_node_termination_handler" {
   count                   = var.enable_aws_node_termination_handler && (length(var.auto_scaling_group_names) > 0 || var.enable_karpenter) ? 1 : 0
   source                  = "./aws-node-termination-handler"
   helm_config             = var.aws_node_termination_handler_helm_config
+  manage_via_gitops       = var.argocd_manage_add_ons
   irsa_policies           = var.aws_node_termination_handler_irsa_policies
   autoscaling_group_names = var.auto_scaling_group_names
   addon_context           = local.addon_context


### PR DESCRIPTION
### What does this PR do?
Adds GitOps enablement for AWS Node Termination Handler as per.
- Resolves #1194
- https://github.com/aws-samples/eks-blueprints-add-ons/issues/32

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [x] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [x] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR

**Note**: Not all the PRs require a new example and/or doc page. In general:
- Use an existing example when possible to demonstrate a new addons usage
- A new docs page under `docs/add-ons/*` is required for new a new addon

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes
Confirmed that main EKS Blueprints modules handle IAM/IRSA for NTH and hands off helm chart deployment to ArgoCD in a test EKS cluster deployed from forked local copies of this repo and eks-blueprints-add-ons.

Also updated the doc for NTH to include that it is intending to be used for EKS clusters with `self_managed_node_groups` as NTH shouldn't be necessary when using EKS `managed_node_groups` as per the comments in this issue - https://github.com/aws/aws-node-termination-handler/issues/186
<!-- Anything else we should know when reviewing? -->
