### PR TITLE
chore: Add depends_on

### DIFF
--- a/modules/irsa/main.tf
+++ b/modules/irsa/main.tf
@@ -29,6 +29,10 @@ resource "kubernetes_service_account_v1" "irsa" {
   }
 
   automount_service_account_token = true
+
+  depends_on = [
+    kubernetes_namespace_v1.irsa
+  ]
 }
 
 # NOTE: Don't change the condition from StringLike to StringEquals. We are using wild characters for service account hence StringLike is required.

--- a/modules/kubernetes-addons/app-2048/main.tf
+++ b/modules/kubernetes-addons/app-2048/main.tf
@@ -43,6 +43,8 @@ resource "kubernetes_deployment_v1" "this" {
       }
     }
   }
+
+  depends_on = [kubernetes_namespace_v1.this]
 }
 
 resource "kubernetes_service_v1" "this" {
@@ -65,6 +67,8 @@ resource "kubernetes_service_v1" "this" {
 
     type = "NodePort"
   }
+
+  depends_on = [kubernetes_namespace_v1.this]
 }
 
 resource "kubernetes_ingress_v1" "this" {
@@ -99,4 +103,6 @@ resource "kubernetes_ingress_v1" "this" {
       }
     }
   }
+
+  depends_on = [kubernetes_namespace_v1.this]
 }

--- a/modules/kubernetes-addons/opentelemetry-operator/main.tf
+++ b/modules/kubernetes-addons/opentelemetry-operator/main.tf
@@ -137,6 +137,8 @@ resource "kubernetes_role_binding_v1" "adot" {
     kind      = "Role"
     name      = local.eks_addon_role_name
   }
+
+  depends_on = [kubernetes_namespace_v1.adot]
 }
 
 resource "kubernetes_cluster_role_v1" "adot" {
@@ -265,6 +267,8 @@ resource "kubernetes_cluster_role_v1" "adot" {
     resources  = ["subjectaccessreviews"]
     verbs      = ["create"]
   }
+
+  depends_on = [kubernetes_namespace_v1.adot]
 }
 
 resource "kubernetes_cluster_role_binding_v1" "adot" {
@@ -294,5 +298,8 @@ module "helm_addon" {
   helm_config   = local.helm_config
   addon_context = var.addon_context
 
-  depends_on = [module.cert_manager]
+  depends_on = [
+    module.cert_manager,
+    kubernetes_namespace_v1.adot
+  ]
 }

--- a/modules/kubernetes-addons/prometheus/main.tf
+++ b/modules/kubernetes-addons/prometheus/main.tf
@@ -63,6 +63,8 @@ module "helm_addon" {
   ] : []
 
   addon_context = var.addon_context
+
+  depends_on = [kubernetes_namespace_v1.prometheus]
 }
 
 resource "kubernetes_namespace_v1" "prometheus" {

--- a/modules/kubernetes-addons/spark-k8s-operator/main.tf
+++ b/modules/kubernetes-addons/spark-k8s-operator/main.tf
@@ -29,4 +29,6 @@ module "helm_addon" {
 
   manage_via_gitops = var.manage_via_gitops
   addon_context     = var.addon_context
+
+  depends_on = [kubernetes_namespace_v1.this]
 }

--- a/modules/kubernetes-addons/traefik/main.tf
+++ b/modules/kubernetes-addons/traefik/main.tf
@@ -30,4 +30,6 @@ module "helm_addon" {
 
   manage_via_gitops = var.manage_via_gitops
   addon_context     = var.addon_context
+
+  depends_on = [kubernetes_namespace_v1.this]
 }

--- a/modules/kubernetes-addons/vpa/main.tf
+++ b/modules/kubernetes-addons/vpa/main.tf
@@ -29,4 +29,6 @@ module "helm_addon" {
 
   manage_via_gitops = var.manage_via_gitops
   addon_context     = var.addon_context
+
+  depends_on = [kubernetes_namespace_v1.vpa]
 }


### PR DESCRIPTION
### What does this PR do?

Just added depends_on.

### Motivation

I ran into a problem when doing terraform destroy.
namespace and service account exist.
If the namespace deletion is accomplished first, terraform will not be able to accomplish the deletion of the service account resource.
This problem can be avoided by explicitly adding depends_on.

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [x] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [x] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [x] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR

**Note**: Not all the PRs require a new example and/or doc page. In general:
- Use an existing example when possible to demonstrate a new addons usage
- A new docs page under `docs/add-ons/*` is required for new a new addon

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
