### PR TITLE
feat: Allow passing an existing role ARN to IRSA module

### DIFF
--- a/modules/irsa/README.md
+++ b/modules/irsa/README.md
@@ -57,6 +57,7 @@ No modules.
 | <a name="input_eks_oidc_provider_arn"></a> [eks\_oidc\_provider\_arn](#input\_eks\_oidc\_provider\_arn) | EKS OIDC Provider ARN e.g., arn:aws:iam::<ACCOUNT-ID>:oidc-provider/<var.eks\_oidc\_provider> | `string` | n/a | yes |
 | <a name="input_irsa_iam_permissions_boundary"></a> [irsa\_iam\_permissions\_boundary](#input\_irsa\_iam\_permissions\_boundary) | IAM permissions boundary for IRSA roles | `string` | `""` | no |
 | <a name="input_irsa_iam_policies"></a> [irsa\_iam\_policies](#input\_irsa\_iam\_policies) | IAM Policies for IRSA IAM role | `list(string)` | `[]` | no |
+| <a name="input_irsa_iam_role_arn"></a> [irsa\_iam\_role\_arn](#input\_irsa\_iam\_role\_arn) | Existing IAM role name for IRSA | `string` | `""` | no |
 | <a name="input_irsa_iam_role_name"></a> [irsa\_iam\_role\_name](#input\_irsa\_iam\_role\_name) | IAM role name for IRSA | `string` | `""` | no |
 | <a name="input_irsa_iam_role_path"></a> [irsa\_iam\_role\_path](#input\_irsa\_iam\_role\_path) | IAM role path for IRSA roles | `string` | `"/"` | no |
 | <a name="input_kubernetes_namespace"></a> [kubernetes\_namespace](#input\_kubernetes\_namespace) | Kubernetes Namespace name | `string` | n/a | yes |

--- a/modules/irsa/main.tf
+++ b/modules/irsa/main.tf
@@ -30,9 +30,12 @@ resource "kubernetes_secret_v1" "irsa" {
 resource "kubernetes_service_account_v1" "irsa" {
   count = var.create_kubernetes_service_account ? 1 : 0
   metadata {
-    name        = var.kubernetes_service_account
-    namespace   = try(kubernetes_namespace_v1.irsa[0].metadata[0].name, var.kubernetes_namespace)
-    annotations = var.irsa_iam_policies != null ? { "eks.amazonaws.com/role-arn" : aws_iam_role.irsa[0].arn } : null
+    name      = var.kubernetes_service_account
+    namespace = try(kubernetes_namespace_v1.irsa[0].metadata[0].name, var.kubernetes_namespace)
+
+    annotations = var.irsa_iam_policies != null || var.irsa_iam_role_arn != "" ? {
+      "eks.amazonaws.com/role-arn" : (var.irsa_iam_policies != null ? one(aws_iam_role.irsa[*].arn) : (var.irsa_iam_role_arn != "" ? var.irsa_iam_role_arn : null))
+    } : null
   }
 
   dynamic "image_pull_secret" {

--- a/modules/irsa/variables.tf
+++ b/modules/irsa/variables.tf
@@ -44,6 +44,12 @@ variable "irsa_iam_role_name" {
   default     = ""
 }
 
+variable "irsa_iam_role_arn" {
+  type        = string
+  description = "Existing IAM role name for IRSA"
+  default     = ""
+}
+
 variable "irsa_iam_role_path" {
   description = "IAM role path for IRSA roles"
   type        = string


### PR DESCRIPTION
### What does this PR do?

🛑 Please open an issue first to discuss any significant work and flesh out details/direction - we would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/aws-ia/terraform-aws-eks-blueprints/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

<!-- A brief description of the change being made with this pull request. -->

### Motivation

<!-- What inspired you to submit this pull request? -->
- Allows reusing an existing role
- Closes #1262
- Closes #1123

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR

**Note**: Not all the PRs require a new example and/or doc page. In general:
- Use an existing example when possible to demonstrate a new addons usage
- A new docs page under `docs/add-ons/*` is required for new a new addon

### For Moderators

- [x] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->

```hcl
  # module.pipeline.module.irsa.kubernetes_service_account_v1.irsa[0] will be created
  + resource "kubernetes_service_account_v1" "irsa" {
      + automount_service_account_token = true
      + default_secret_name             = (known after apply)
      + id                              = (known after apply)

      + metadata {
          + annotations      = {
              + "eks.amazonaws.com/role-arn" = "<redacted>"
            }
          + generation       = (known after apply)
          + name             = "<redacted>-sa"
          + namespace        = "default"
          + resource_version = (known after apply)
          + uid              = (known after apply)
        }
    }
```