### PR TITLE
fix: Add ${bootstrap_extra_args} to windows launch template

### DIFF
--- a/modules/launch-templates/templates/userdata-windows.tpl
+++ b/modules/launch-templates/templates/userdata-windows.tpl
@@ -21,7 +21,7 @@ if ($disks_to_adjust -ne $null) {
 [string]$EKSBinDir = "$env:ProgramFiles\Amazon\EKS"
 [string]$EKSBootstrapScriptName = 'Start-EKSBootstrap.ps1'
 [string]$EKSBootstrapScriptFile = "$EKSBinDir\$EKSBootstrapScriptName"
-& $EKSBootstrapScriptFile -EKSClusterName ${eks_cluster_id} -KubeletExtraArgs '${kubelet_extra_args}' 3>&1 4>&1 5>&1 6>&1
+& $EKSBootstrapScriptFile -EKSClusterName ${eks_cluster_id} ${bootstrap_extra_args} -KubeletExtraArgs '${kubelet_extra_args}' 3>&1 4>&1 5>&1 6>&1
 $LastError = if ($?) { 0 } else { $Error[0].Exception.HResult }
 
 ${post_userdata}


### PR DESCRIPTION
### What does this PR do?

Add ${bootstrap_extra_args} to windows launch template to allow pass in arguments directly to bootstrap, this feature exists in the linux launch template.

This enables customers to launch windows node in private subnets without internet access by pass in `-APIServerEndpoint <cluster-endpoint> -Base64ClusterCA <certificate-authority>` mentioned in [AWS Doc](https://docs.aws.amazon.com/eks/latest/userguide/private-clusters.html).

<!-- A brief description of the change being made with this pull request. -->

### Motivation

<!-- What inspired you to submit this pull request? -->
- Resolves #1239

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
