### PR TITLE
fix: Disable proportional autoscaler for CoreDNS for fully private cluster

### DIFF
--- a/examples/fully-private-eks-cluster/add-ons/main.tf
+++ b/examples/fully-private-eks-cluster/add-ons/main.tf
@@ -35,9 +35,12 @@ module "eks_blueprints_kubernetes_addons" {
   eks_oidc_provider    = replace(data.aws_eks_cluster.cluster.identity[0].oidc[0].issuer, "https://", "")
   eks_cluster_version  = data.aws_eks_cluster.cluster.version
 
-  # EKS Addons
+  # EKS Managed Addons
   enable_amazon_eks_vpc_cni            = true
   enable_amazon_eks_coredns            = true
   enable_amazon_eks_kube_proxy         = true
   enable_amazon_eks_aws_ebs_csi_driver = true
+
+  # Disable coredns_cluster_proportional_autoscaler, it is enabled by default
+  enable_coredns_cluster_proportional_autoscaler = false
 }


### PR DESCRIPTION
### What does this PR do?

Fix the fully-private-eks-cluster in example folder.

<!-- A brief description of the change being made with this pull request. -->

### Motivation

Since the feature #1033, cluster proportional autoscaler for CoreDNS is enabled by default. 
However, it downloads Helm chart from the internet which results in timeout failure for a fully private cluster. 

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR

**Note**: Not all the PRs require a new example and/or doc page. In general:
- Use an existing example when possible to demonstrate a new addons usage
- A new docs page under `docs/add-ons/*` is required for new a new addon

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
