### PR TITLE
chore: Update update `karpenter` addon to v0.20.0

### DIFF
--- a/examples/karpenter/main.tf
+++ b/examples/karpenter/main.tf
@@ -109,12 +109,12 @@ module "eks_blueprints" {
   # You can also make uses on nodeSelector and Taints/tolerations to spread workloads on MNG or Karpenter provisioners
   managed_node_groups = {
     mg_5 = {
-      node_group_name = "managed-ondemand"
+      node_group_name = local.node_group_name
       instance_types  = ["m5.large"]
 
       subnet_ids   = module.vpc.private_subnets
-      max_size     = 2
-      desired_size = 1
+      max_size     = 5
+      desired_size = 2
       min_size     = 1
       update_config = [{
         max_unavailable_percentage = 30

--- a/modules/kubernetes-addons/karpenter/locals.tf
+++ b/modules/kubernetes-addons/karpenter/locals.tf
@@ -17,7 +17,7 @@ locals {
       name       = local.name
       chart      = local.name
       repository = "oci://public.ecr.aws/karpenter"
-      version    = "v0.19.3"
+      version    = "v0.20.0"
       namespace  = local.name
       values = [
         <<-EOT


### PR DESCRIPTION
### What does this PR do?

update karpenter to [v0.20.0](https://github.com/aws/karpenter/releases/tag/v0.20.0)

### Motivation

Improvements and fixes. Specially multi-node consolidation

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR

**Note**: Not all the PRs require a new example and/or doc page. In general:
- Use an existing example when possible to demonstrate a new addons usage
- A new docs page under `docs/add-ons/*` is required for new a new addon

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
Karpenter example deployment:
tested karpenter example with terraform v1.3.6 using `sample_deployment_lt.yaml` and `sample_deployment.yaml`
and all 6 pods were successfully scheduled from both deployments.
![image](https://user-images.githubusercontent.com/3725386/206854128-f045d8d1-58f4-4a28-8959-3d3e5c98bd31.png)
Note that karpenter only seems to work if we provision 2 managed nodes (one instance per node). It wasn't provisioning nodes with just one managed node (which is kind of strange since one pod of karpenter should also work in my opinion. Related https://github.com/aws-ia/terraform-aws-eks-blueprints/pull/990). Anyways, I think I should also update karpenter example in a seperate PR (managed node desired_size = 2)