### PR TITLE
feat(examples/karpenter): Improvements

### DIFF
--- a/examples/karpenter/main.tf
+++ b/examples/karpenter/main.tf
@@ -114,7 +114,7 @@ module "eks_blueprints" {
 
       subnet_ids   = module.vpc.private_subnets
       max_size     = 2
-      desired_size = 1
+      desired_size = 2
       min_size     = 1
       update_config = [{
         max_unavailable_percentage = 30

--- a/examples/karpenter/main.tf
+++ b/examples/karpenter/main.tf
@@ -109,7 +109,7 @@ module "eks_blueprints" {
   # You can also make uses on nodeSelector and Taints/tolerations to spread workloads on MNG or Karpenter provisioners
   managed_node_groups = {
     mg_5 = {
-      node_group_name = "managed-ondemand"
+      node_group_name = local.node_group_name
       instance_types  = ["m5.large"]
 
       subnet_ids   = module.vpc.private_subnets


### PR DESCRIPTION
### What does this PR do?

1. karpenter module provisions 2 karpenter pods (with topology spread constraints). 1 pod remains in pending state forever. That's why I have changed desired_size of manged node group to 2
2. Terraform Locals has `node_group_name` but it wasn't used while creating managed node group. I have used that variable to prevent duplicate declaration of "managed-ondemand" value


### Motivation
Check : https://github.com/aws-ia/terraform-aws-eks-blueprints/pull/1244

### More

- [X] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [X] Yes, I ran `pre-commit run -a` with this PR

**Note**: Not all the PRs require a new example and/or doc page. In general:
- Use an existing example when possible to demonstrate a new addons usage
- A new docs page under `docs/add-ons/*` is required for new a new addon

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

Tested in https://github.com/aws-ia/terraform-aws-eks-blueprints/pull/1244
