### PR TITLE
Fix karpenter sqs discover url

### DIFF
--- a/docs/add-ons/karpenter.md
+++ b/docs/add-ons/karpenter.md
@@ -21,7 +21,7 @@ You can optionally customize the Helm chart that deploys `Karpenter` via the fol
     name                       = "karpenter"
     chart                      = "karpenter"
     repository                 = "https://charts.karpenter.sh"
-    version                    = "0.6.3"
+    version                    = "0.19.3"
     namespace                  = "karpenter"
     values = [templatefile("${path.module}/values.yaml", {
          eks_cluster_id       = var.eks_cluster_id,

--- a/modules/kubernetes-addons/karpenter/data.tf
+++ b/modules/kubernetes-addons/karpenter/data.tf
@@ -52,7 +52,7 @@ data "aws_iam_policy_document" "karpenter" {
         "sqs:GetQueueUrl",
         "sqs:ReceiveMessage",
       ]
-      resources = [data.sqs_queue_arn.karpenter.arn]
+      resources = [data.aws_sqs_queue.karpenter.arn]
     }
   }
 }

--- a/modules/kubernetes-addons/karpenter/data.tf
+++ b/modules/kubernetes-addons/karpenter/data.tf
@@ -1,3 +1,7 @@
+data "aws_sqs_queue" "karpenter" {
+  name = var.sqs_queue_name
+}
+
 data "aws_iam_policy_document" "karpenter" {
   statement {
     sid       = "Karpenter"
@@ -39,7 +43,7 @@ data "aws_iam_policy_document" "karpenter" {
   }
 
   dynamic "statement" {
-    for_each = var.sqs_queue_arn != "" ? [1] : []
+    for_each = var.sqs_queue_name != "" ? [1] : []
 
     content {
       actions = [
@@ -48,7 +52,7 @@ data "aws_iam_policy_document" "karpenter" {
         "sqs:GetQueueUrl",
         "sqs:ReceiveMessage",
       ]
-      resources = [var.sqs_queue_arn]
+      resources = [data.sqs_queue_arn.karpenter.arn]
     }
   }
 }

--- a/modules/kubernetes-addons/karpenter/locals.tf
+++ b/modules/kubernetes-addons/karpenter/locals.tf
@@ -26,7 +26,7 @@ locals {
               clusterName: ${var.addon_context.eks_cluster_id}
               clusterEndpoint: ${var.addon_context.aws_eks_cluster_endpoint}
               defaultInstanceProfile: ${var.node_iam_instance_profile}
-              interruptionQueueName: ${var.sqs_queue_arn}
+              interruptionQueueName: ${var.sqs_queue_name}
         EOT
       ]
       description = "karpenter Helm Chart for Node Autoscaling"

--- a/modules/kubernetes-addons/karpenter/variables.tf
+++ b/modules/kubernetes-addons/karpenter/variables.tf
@@ -22,8 +22,8 @@ variable "node_iam_instance_profile" {
   default     = ""
 }
 
-variable "sqs_queue_arn" {
-  description = "(Optional) ARN of SQS used by Karpenter when native node termination handling is enabled"
+variable "sqs_queue_name" {
+  description = "(Optional) Name of SQS used by Karpenter when native node termination handling is enabled"
   type        = string
   default     = ""
 }

--- a/modules/kubernetes-addons/main.tf
+++ b/modules/kubernetes-addons/main.tf
@@ -320,7 +320,7 @@ module "karpenter" {
   helm_config               = var.karpenter_helm_config
   irsa_policies             = var.karpenter_irsa_policies
   node_iam_instance_profile = var.karpenter_node_iam_instance_profile
-  sqs_queue_arn             = var.karpenter_sqs_queue_arn
+  sqs_queue_name            = var.karpenter_sqs_queue_name
   manage_via_gitops         = var.argocd_manage_add_ons
   addon_context             = local.addon_context
 }

--- a/modules/kubernetes-addons/variables.tf
+++ b/modules/kubernetes-addons/variables.tf
@@ -867,7 +867,7 @@ variable "karpenter_node_iam_instance_profile" {
   default     = ""
 }
 
-variable "karpenter_sqs_queue_arn" {
+variable "karpenter_sqs_queue_name" {
   description = "(Optional) ARN of SQS used by Karpenter when native node termination handling is enabled"
   type        = string
   default     = ""

--- a/modules/kubernetes-addons/variables.tf
+++ b/modules/kubernetes-addons/variables.tf
@@ -868,7 +868,7 @@ variable "karpenter_node_iam_instance_profile" {
 }
 
 variable "karpenter_sqs_queue_name" {
-  description = "(Optional) ARN of SQS used by Karpenter when native node termination handling is enabled"
+  description = "(Optional) Name of SQS used by Karpenter when native node termination handling is enabled"
   type        = string
   default     = ""
 }


### PR DESCRIPTION
### What does this PR do?

Fix Karpenter unable to discover AWS SQS queue url when node termination handler enabled.

### Motivation

Fix issue [#1246](https://github.com/aws-ia/terraform-aws-eks-blueprints/issues/1246)

### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR

**Note**: Not all the PRs require a new example and/or doc page. In general:
- Use an existing example when possible to demonstrate a new addons usage
- A new docs page under `docs/add-ons/*` is required for new a new addon

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes
