### PR TITLE
docs: Fix https://https:// in README

### DIFF
--- a/modules/kubernetes-addons/consul/README.md
+++ b/modules/kubernetes-addons/consul/README.md
@@ -1,6 +1,6 @@
 # Consul
 Deploying  Consul on EKS cluster
-For more details checkout [Consul](https://https://developer.hashicorp.com/consul/tutorials/get-started-kubernetes/kubernetes-gs-deploy) docs
+For more details checkout [Consul](https://developer.hashicorp.com/consul/tutorials/get-started-kubernetes/kubernetes-gs-deploy) docs
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements


### PR DESCRIPTION
Fix a typo in URL which fails to render
within https://github.com/aws-ia/terraform-aws-eks-blueprints/blob/main/docs/add-ons/consul.md?plain=1
From "https://https://" to "https://" in
"For more details checkout [Consul](https://https://developer.hashicorp.com/consul/tutorials/get-started-kubernetes/kubernetes-gs-deploy) docs

### More

- [ X] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ X] Yes, I ran `pre-commit run -a` with this PR

**Note**: Not all the PRs require a new example and/or doc page. In general:
- Use an existing example when possible to demonstrate a new addons usage
- A new docs page under `docs/add-ons/*` is required for new a new addon

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes
My first PR on this project.