### PR TITLE
docs: Update fully private cluster example README

### DIFF
--- a/examples/fully-private-eks-cluster/README.md
+++ b/examples/fully-private-eks-cluster/README.md
@@ -125,7 +125,7 @@ Create a Terraform variable definition file called base.tfvars and update the va
 
 ```shell script
 region             = "us-west-2"
-cluster_version    = "1.22"
+cluster_version    = "1.23"
 vpc_id             = "<vpc-id>"
 private_subnet_ids = ["<private-subnet-1>", "<private-subnet-2>", "<private-subnet-3>"]
 cluster_security_group_additional_rules = {
@@ -202,8 +202,6 @@ Create a Terraform variable definition file called base.tfvars and update the va
 ```shell script
 region         = "us-west-2"
 eks_cluster_id = "eks"
-cluster_version= "1.22"
-
 ```
 #### Step2: Run Terraform INIT
 Initialize a working directory with configuration files

--- a/examples/fully-private-eks-cluster/README.md
+++ b/examples/fully-private-eks-cluster/README.md
@@ -125,7 +125,7 @@ Create a Terraform variable definition file called base.tfvars and update the va
 
 ```shell script
 region             = "us-west-2"
-cluster_version    = "1.23"
+cluster_version    = "1.24"
 vpc_id             = "<vpc-id>"
 private_subnet_ids = ["<private-subnet-1>", "<private-subnet-2>", "<private-subnet-3>"]
 cluster_security_group_additional_rules = {

--- a/examples/fully-private-eks-cluster/eks/variables.tf
+++ b/examples/fully-private-eks-cluster/eks/variables.tf
@@ -1,7 +1,7 @@
 variable "cluster_version" {
-  description = "Kubernetes `<major>.<minor>` version to use for the EKS cluster (i.e.: `1.23`)"
+  description = "Kubernetes `<major>.<minor>` version to use for the EKS cluster (i.e.: `1.24`)"
   type        = string
-  default     = "1.23"
+  default     = "1.24"
 }
 
 variable "region" {


### PR DESCRIPTION
### What does this PR do?

Update default cluster version to 1.24 and removed unnecessary cluster version variable in tfvars.

### Motivation

<!-- What inspired you to submit this pull request? -->
- Resolves #<issue-number>

### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR

**Note**: Not all the PRs require a new example and/or doc page. In general:
- Use an existing example when possible to demonstrate a new addons usage
- A new docs page under `docs/add-ons/*` is required for new a new addon

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
