### PR TITLE
chore: Minor typo on comments

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -82,9 +82,9 @@ output "worker_node_security_group_id" {
   value       = try(module.aws_eks.node_security_group_id, "EKS Node groups not enabled")
 }
 
-#-------------------------------
-# Managed Node Groups Outputs
-#-------------------------------
+#---------------------------------
+# Self-managed Node Groups Outputs
+#---------------------------------
 output "self_managed_node_groups" {
   description = "Outputs from EKS Self-managed node groups "
   value       = var.create_eks && length(var.self_managed_node_groups) > 0 ? module.aws_eks_self_managed_node_groups[*] : []
@@ -115,9 +115,9 @@ output "windows_node_group_aws_auth_config_map" {
   value       = local.windows_node_group_aws_auth_config_map[*]
 }
 
-#-------------------------------
-# Managed Node Groups Outputs
-#-------------------------------
+#--------------------------------
+# EKS Managed Node Groups Outputs
+#--------------------------------
 output "managed_node_groups" {
   description = "Outputs from EKS Managed node groups "
   value       = var.create_eks && length(var.managed_node_groups) > 0 ? module.aws_eks_managed_node_groups[*] : []


### PR DESCRIPTION

### What does this PR do?

Distinguish between self-managed and EKS managed.


### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [x] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR

**Note**: Not all the PRs require a new example and/or doc page. In general:
- Use an existing example when possible to demonstrate a new addons usage
- A new docs page under `docs/add-ons/*` is required for new a new addon

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
