### PR TITLE
fix: Argocd addons error, bool expressions must have consistent types

### DIFF
--- a/modules/kubernetes-addons/argocd/main.tf
+++ b/modules/kubernetes-addons/argocd/main.tf
@@ -69,7 +69,7 @@ resource "helm_release" "argocd_application" {
       { repoUrl = each.value.repo_url },
       each.value.values,
       local.global_application_values,
-      each.value.add_on_application ? var.addon_config : {}
+      each.value.add_on_application ? var.addon_config : null
     ))
     type = "auto"
   }


### PR DESCRIPTION
Fixes `The true and false result expressions must have consistent types` 

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [-] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [-] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [-] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR


### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
