### PR TITLE
fix: Added required rules for adot cluster role

### DIFF
--- a/modules/kubernetes-addons/opentelemetry-operator/main.tf
+++ b/modules/kubernetes-addons/opentelemetry-operator/main.tf
@@ -265,6 +265,26 @@ resource "kubernetes_cluster_role_v1" "adot" {
     resources  = ["subjectaccessreviews"]
     verbs      = ["create"]
   }
+  rule {
+    api_groups = ["networking.k8s.io"]
+    resources  = ["ingresses"]
+    verbs      = ["create", "delete", "get", "list", "patch", "update", "watch"]
+  }
+  rule {
+    api_groups = [""]
+    resources  = ["endpoints"]
+    verbs      = ["get"]
+  }
+  rule {
+    api_groups = [""]
+    resources  = ["nodes/proxy"]
+    verbs      = ["get", "list", "watch"]
+  }
+  rule {
+    api_groups = ["extensions"]
+    resources  = ["ingresses"]
+    verbs      = ["get"]
+  }
 }
 
 resource "kubernetes_cluster_role_binding_v1" "adot" {


### PR DESCRIPTION
### What does this PR do?

With this PR I added required permissions for ADOT cluster role

<!-- A brief description of the change being made with this pull request. -->

### Motivation

<!-- What inspired you to submit this pull request? -->
I tried to use opentelemetry addon to install ADOT addon into EKS cluster and ran into issues
<img width="1226" alt="image" src="https://user-images.githubusercontent.com/53223543/208918428-0f4c5531-8890-4f15-943c-5c0ce05205e1.png">

Than I checked what AWS requires for installing ADOT addon (https://amazon-eks.s3.amazonaws.com/docs/addons-otel-permissions.yaml) and figured out that there are several rules that are not in ClusterRole for opentelemetry. I cloned module and added them, after that I successfully installed ADOT into EKS 
### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR

**Note**: Not all the PRs require a new example and/or doc page. In general:
- Use an existing example when possible to demonstrate a new addons usage
- A new docs page under `docs/add-ons/*` is required for new a new addon

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
