### PR TITLE
fix: Adding changes for support eks_cluster_id on add-ons documentation

### DIFF
--- a/docs/add-ons/index.md
+++ b/docs/add-ons/index.md
@@ -24,7 +24,7 @@ In order to deploy an add-on with default configuration, simply enable the add-o
 module "eks_blueprints_kubernetes_addons" {
   source = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons"
 
-  cluster_id                    = <EKS-CLUSTER-ID>
+  eks_cluster_id = <EKS-CLUSTER-ID>
 
   # EKS Addons
 


### PR DESCRIPTION
### What does this PR do?

🛑 Please open an issue first to discuss any significant work and flesh out details/direction - we would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/aws-ia/terraform-aws-eks-blueprints/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

<!-- A brief description of the change being made with this pull request. -->

### Motivation

Hi folks I'm doing this PR because I was following the instructions to use eks_blueprints_kubernetes_addons module in this section --> https://aws-ia.github.io/terraform-aws-eks-blueprints/main/add-ons/ but when I was trying to deploy my add-ons I received the following error:

`╷
│ Error: Missing required argument
│
│   on ../../modules/eks_custom_networking/main.tf line 102, in module "eks_blueprints_kubernetes_addons":
│  102: module "eks_blueprints_kubernetes_addons" {
│
│ The argument "eks_cluster_id" is required, but no definition was found.
╵
╷
│ Error: Unsupported argument
│
│   on ../../modules/eks_custom_networking/main.tf line 105, in module "eks_blueprints_kubernetes_addons":
│  105:   cluster_id = module.eks_blueprints.eks_cluster_id
│
│ An argument named "cluster_id" is not expected here.`

and that is because we must use **eks_cluster_id** and in the example you can see **cluster_id**, so then that is the reason because I'm sending this PR to improve the documentation.

<!-- What inspired you to submit this pull request? -->
- To Improve the documentation because I think this is a great projecto and I wouldn't like that the users discard this project only because the examples isn't works.

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [x] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR

**Note**: Not all the PRs require a new example and/or doc page. In general:
- Use an existing example when possible to demonstrate a new addons usage
- A new docs page under `docs/add-ons/*` is required for new a new addon

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->

Yes, you can see here -> https://github.com/aws-ia/terraform-aws-eks-blueprints/blob/main/modules/kubernetes-addons/variables.tf#L1 that terraform variable eks_cluster_id is the only required and cluster_id doesn't exist in the kubernetes-addons module.