### PR TITLE
feat: Update Karpenter to to `0.21.1`

### DIFF
--- a/modules/kubernetes-addons/karpenter/locals.tf
+++ b/modules/kubernetes-addons/karpenter/locals.tf
@@ -17,7 +17,7 @@ locals {
       name       = local.name
       chart      = local.name
       repository = "oci://public.ecr.aws/karpenter"
-      version    = "v0.20.0"
+      version    = "v0.21.1"
       namespace  = local.name
       values = [
         <<-EOT


### PR DESCRIPTION
### What does this PR do?

pdate karpenter to [v0.21.1](https://github.com/aws/karpenter/releases/tag/v0.21.1)

### Motivation

Improvements and fixes. Drift feature https://karpenter.sh/preview/concepts/settings/#feature-gates which is hard to test because of https://github.com/aws-ia/terraform-aws-eks-blueprints/issues/512 (pass helm values without overriding/deleting default values)

### More

- [X] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR

**Note**: Not all the PRs require a new example and/or doc page. In general:
- Use an existing example when possible to demonstrate a new addons usage
- A new docs page under `docs/add-ons/*` is required for new a new addon

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes
Karpenter example deployment:
tested karpenter example with terraform v1.3.6 using sample_deployment_lt.yaml and sample_deployment.yaml
and all 6 pods were successfully scheduled from both deployments.
![image](https://user-images.githubusercontent.com/3725386/210166897-a0659086-b02f-4a25-bb3c-0c0a6e419066.png)

