### PR TITLE
Karpenter permission to create ServiceLinkedRole

### DIFF
--- a/modules/kubernetes-addons/karpenter/data.tf
+++ b/modules/kubernetes-addons/karpenter/data.tf
@@ -26,6 +26,7 @@ data "aws_iam_policy_document" "karpenter" {
       "ec2:DescribeSubnets",
       "ec2:RunInstances",
       "iam:PassRole",
+      "iam:CreateServiceLinkedRole",
       "pricing:GetProducts",
       "ssm:GetParameter",
     ]


### PR DESCRIPTION
Grant Karpenter permission to `iam:CreateServiceLinkedRole`. This is needed so that Karpenter can create the ServiceLinkedRole required for EC2 Spot Instances. Without this permission, Karpenter fails to create nodes with the following error:
```
ERROR   controller.provisioner  launching node, creating cloud provider instance, with fleet error(s), AuthFailure.ServiceLinkedRoleCreationNotPermitted: The provided credentials do not have permission to create the service-linked role for EC2 Spot Instances.; launching node, creating cloud provider instance, with fleet error(s), AuthFailure.ServiceLinkedRoleCreationNotPermitted: The provided credentials do not have permission to create the service-linked role for EC2 Spot Instances. 
```

### What does this PR do?

🛑 Please open an issue first to discuss any significant work and flesh out details/direction - we would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/aws-ia/terraform-aws-eks-blueprints/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

<!-- A brief description of the change being made with this pull request. -->

### Motivation

<!-- What inspired you to submit this pull request? -->
- Resolves #<issue-number>

### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR

**Note**: Not all the PRs require a new example and/or doc page. In general:
- Use an existing example when possible to demonstrate a new addons usage
- A new docs page under `docs/add-ons/*` is required for new a new addon

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
