### PR TITLE
feat: Update `fargate-serverless` example to use the EKS module

### DIFF
--- a/examples/fargate-serverless/README.md
+++ b/examples/fargate-serverless/README.md
@@ -2,7 +2,7 @@
 
 This example shows how to provision a serverless cluster (serverless data plane) using Fargate Profiles.
 
-This example solution has been developed to work around these current limitations and provides:
+This example solution provides:
 
 - AWS EKS Cluster (control plane)
 - AWS EKS Fargate Profiles for the `kube-system` namespace which is used by the `coredns`, `vpc-cni`, and `kube-proxy` addons, as well as profile that will match on `app-*` namespaces using a wildcard pattern.

--- a/examples/fargate-serverless/README.md
+++ b/examples/fargate-serverless/README.md
@@ -2,20 +2,13 @@
 
 This example shows how to provision a serverless cluster (serverless data plane) using Fargate Profiles.
 
-There are some challenges to achieve this, primarily around the management and usage of CoreDNS on Fargate. There are alternative solutions shown on the internet, typically utilizing a `kubectl patch ...` command to update the compute type of the template spec annotation. This approach does work, but with the downside that the EKS service will eventually update the CoreDNS deployment and overwrite the patch, causing the CoreDNS deployment to fail due to insufficient capacity (it will be looking for EC2 compute when only Fargate is available).
-
-The `preserve` setting was added to the addons API, allowing users to remove the addon from EKS API control and instead manage the addon themselves without disrupting the currently running software (preserves what currently exists, but now in the user's control, not the EKS API's control). However, this requires managing the addon first (as an EKS managed addon) and unfortunately this does not work for CoreDNS when using Fargate Profiles at this time. When trying to manage the CoreDNS addon, the addon deployment will fail due to the default compute type of EC2.
-
 This example solution has been developed to work around these current limitations and provides:
 
 - AWS EKS Cluster (control plane)
-- AWS EKS Fargate Profiles for the `default` namespace and `kube-system` namespace. This covers the two core namespaces, including the namespace used by the `coredns`, `vpc-cni`, and `kube-proxy` addons, while additional profiles can be added as needed.
-- AWS EKS managed addons `vpc-cni` and `kube-proxy`
-- Self-managed CoreDNS addon deployed through a Helm chart. The default CoreDNS deployment provided by AWS EKS is removed and replaced with a self-managed CoreDNS deployment, while the `kube-dns` service is updated to allow Helm to assume control.
+- AWS EKS Fargate Profiles for the `kube-system` namespace which is used by the `coredns`, `vpc-cni`, and `kube-proxy` addons, as well as profile that will match on `app-*` namespaces using a wildcard pattern.
+- AWS EKS managed addons `coredns`, `vpc-cni` and `kube-proxy`
 - AWS Load Balancer Controller add-on deployed through a Helm chart. The default AWS Load Balancer Controller add-on configuration is overridden so that it can be deployed on Fargate compute.
 - A [sample-app](./sample-app) is provided to demonstrates how to configure the Ingress so that application can be accessed over the internet.
-
-⚠️ The management of CoreDNS as demonstrated in this example is intended to be used on new clusters. Existing clusters with existing workloads will see downtime if the CoreDNS deployment is modified as shown here.
 
 ## Prerequisites:
 
@@ -88,6 +81,6 @@ To teardown and remove the resources created in this example:
 
 ```sh
 terraform destroy -target="module.eks_blueprints_kubernetes_addons" -auto-approve
-terraform destroy -target="module.eks_blueprints" -auto-approve
+terraform destroy -target="module.eks" -auto-approve
 terraform destroy -auto-approve
 ```

--- a/examples/fargate-serverless/main.tf
+++ b/examples/fargate-serverless/main.tf
@@ -39,6 +39,7 @@ locals {
 # Cluster
 ################################################################################
 
+#tfsec:ignore:aws-eks-enable-control-plane-logging
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
   version = "~> 19.5"

--- a/examples/fargate-serverless/main.tf
+++ b/examples/fargate-serverless/main.tf
@@ -3,24 +3,23 @@ provider "aws" {
 }
 
 provider "kubernetes" {
-  host                   = module.eks_blueprints.eks_cluster_endpoint
-  cluster_ca_certificate = base64decode(module.eks_blueprints.eks_cluster_certificate_authority_data)
+  host                   = module.eks.cluster_endpoint
+  cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
   token                  = data.aws_eks_cluster_auth.this.token
 }
 
 provider "helm" {
   kubernetes {
-    host                   = module.eks_blueprints.eks_cluster_endpoint
-    cluster_ca_certificate = base64decode(module.eks_blueprints.eks_cluster_certificate_authority_data)
+    host                   = module.eks.cluster_endpoint
+    cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
     token                  = data.aws_eks_cluster_auth.this.token
   }
 }
 
 data "aws_eks_cluster_auth" "this" {
-  name = module.eks_blueprints.eks_cluster_id
+  name = module.eks.cluster_name
 }
 
-data "aws_caller_identity" "current" {}
 data "aws_availability_zones" "available" {}
 
 locals {
@@ -36,85 +35,73 @@ locals {
   }
 }
 
-#---------------------------------------------------------------
-# EKS Blueprints
-#---------------------------------------------------------------
+################################################################################
+# Cluster
+################################################################################
 
-module "eks_blueprints" {
-  source = "../.."
+module "eks" {
+  source  = "terraform-aws-modules/eks/aws"
+  version = "~> 19.5"
 
-  cluster_name    = local.name
-  cluster_version = "1.24"
+  cluster_name                   = local.name
+  cluster_version                = "1.24"
+  cluster_endpoint_public_access = true
 
-  vpc_id             = module.vpc.vpc_id
-  private_subnet_ids = module.vpc.private_subnets
-
-  # https://github.com/aws-ia/terraform-aws-eks-blueprints/issues/485
-  # https://github.com/aws-ia/terraform-aws-eks-blueprints/issues/494
-  cluster_kms_key_additional_admin_arns = [data.aws_caller_identity.current.arn]
-
-  fargate_profiles = {
-    # Providing compute for default namespace
-    default = {
-      fargate_profile_name = "default"
-      fargate_profile_namespaces = [
-        {
-          namespace = "default"
-      }]
-      subnet_ids = module.vpc.private_subnets
+  cluster_addons = {
+    coredns = {
+      configuration_values = jsonencode({
+        computeType = "Fargate"
+      })
     }
-    # Providing compute for kube-system namespace where core addons reside
-    kube_system = {
-      fargate_profile_name = "kube-system"
-      fargate_profile_namespaces = [
-        {
-          namespace = "kube-system"
-      }]
-      subnet_ids = module.vpc.private_subnets
-    }
-    # Sample application
-    app = {
-      fargate_profile_name = "app-wildcard"
-      fargate_profile_namespaces = [
-        {
-          namespace = "app-*"
-      }]
-      subnet_ids = module.vpc.private_subnets
-    }
+    kube-proxy = {}
+    vpc-cni    = {}
   }
+
+  vpc_id     = module.vpc.vpc_id
+  subnet_ids = module.vpc.private_subnets
+
+  # Fargate profiles use the cluster primary security group so these are not utilized
+  create_cluster_security_group = false
+  create_node_security_group    = false
+
+  fargate_profiles = merge(
+    { for i in range(3) :
+      "app-wildcard-${element(split("-", local.azs[i]), 2)}" => {
+        selectors = [
+          { namespace = "app-*" }
+        ]
+        # We want to create a profile per AZ for high availability
+        subnet_ids = [element(module.vpc.private_subnets, i)]
+      }
+    },
+    { for i in range(3) :
+      "kube-system-${element(split("-", local.azs[i]), 2)}" => {
+        selectors = [
+          { namespace = "kube-system" }
+        ]
+        # We want to create a profile per AZ for high availability
+        subnet_ids = [element(module.vpc.private_subnets, i)]
+      }
+    }
+  )
 
   tags = local.tags
 }
 
+################################################################################
+# Kubernetes Addons
+################################################################################
+
 module "eks_blueprints_kubernetes_addons" {
   source = "../../modules/kubernetes-addons"
 
-  eks_cluster_id       = module.eks_blueprints.eks_cluster_id
-  eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint
-  eks_oidc_provider    = module.eks_blueprints.oidc_provider
-  eks_cluster_version  = module.eks_blueprints.eks_cluster_version
+  eks_cluster_id       = module.eks.cluster_name
+  eks_cluster_endpoint = module.eks.cluster_endpoint
+  eks_oidc_provider    = module.eks.oidc_provider
+  eks_cluster_version  = module.eks.cluster_version
 
   # Wait on the `kube-system` profile before provisioning addons
-  data_plane_wait_arn = module.eks_blueprints.fargate_profiles["kube_system"].eks_fargate_profile_arn
-
-  enable_amazon_eks_vpc_cni = true
-  amazon_eks_vpc_cni_config = {
-    most_recent = true
-  }
-
-  enable_amazon_eks_kube_proxy = true
-  amazon_eks_kube_proxy_config = {
-    most_recent = true
-  }
-
-  enable_self_managed_coredns                    = true
-  remove_default_coredns_deployment              = true
-  enable_coredns_cluster_proportional_autoscaler = true
-  self_managed_coredns_helm_config = {
-    # Sets the correct annotations to ensure the Fargate provisioner is used and not the EC2 provisioner
-    compute_type       = "fargate"
-    kubernetes_version = module.eks_blueprints.eks_cluster_version
-  }
+  data_plane_wait_arn = join(",", [for prof in module.eks.fargate_profiles : prof.fargate_profile_arn])
 
   # Sample application
   enable_app_2048 = true
@@ -142,9 +129,9 @@ module "eks_blueprints_kubernetes_addons" {
   tags = local.tags
 }
 
-#---------------------------------------------------------------
+################################################################################
 # Supporting Resources
-#---------------------------------------------------------------
+################################################################################
 
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"

--- a/examples/fargate-serverless/outputs.tf
+++ b/examples/fargate-serverless/outputs.tf
@@ -1,4 +1,4 @@
 output "configure_kubectl" {
   description = "Configure kubectl: make sure you're logged in with the correct AWS profile and run the following command to update your kubeconfig"
-  value       = module.eks_blueprints.configure_kubectl
+  value       = "aws eks --region ${local.region} update-kubeconfig --name ${module.eks.cluster_name}"
 }


### PR DESCRIPTION
### What does this PR do?

- Update the `fargate-serverless` example to use the `terraform-aws-eks` module for cluster creation and EKS addons
- Simplify example now that EKS addons support custom configuration; demonstrate how CoreDNS can be patched for Fargate only clusters

### Motivation

- Updates examples to reflect latest features and patterns supported by Amazon EKS

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR

**Note**: Not all the PRs require a new example and/or doc page. In general:
- Use an existing example when possible to demonstrate a new addons usage
- A new docs page under `docs/add-ons/*` is required for new a new addon

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
