### PR TITLE
feat: Update `emr-on-eks-fargate` example to use v19 of the EKS module

### DIFF
--- a/examples/analytics/emr-on-eks-fargate/main.tf
+++ b/examples/analytics/emr-on-eks-fargate/main.tf
@@ -16,16 +16,8 @@ provider "helm" {
   }
 }
 
-provider "kubectl" {
-  apply_retry_count      = 10
-  host                   = module.eks.cluster_endpoint
-  cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
-  load_config_file       = false
-  token                  = data.aws_eks_cluster_auth.this.token
-}
-
 data "aws_eks_cluster_auth" "this" {
-  name = module.eks.cluster_id
+  name = module.eks.cluster_name
 }
 
 data "aws_caller_identity" "current" {}
@@ -44,18 +36,28 @@ locals {
   }
 }
 
-#---------------------------------------------------------------
-# EKS Blueprints
-#---------------------------------------------------------------
+################################################################################
+# Cluster
+################################################################################
 
+#tfsec:ignore:aws-eks-enable-control-plane-logging
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 18.30"
+  version = "~> 19.5"
 
-  cluster_name    = local.name
-  cluster_version = "1.24"
+  cluster_name                   = local.name
+  cluster_version                = "1.24"
+  cluster_endpoint_public_access = true
 
-  cluster_enabled_log_types = ["api", "authenticator", "audit", "scheduler", "controllerManager"]
+  cluster_addons = {
+    coredns = {
+      configuration_values = jsonencode({
+        computeType = "Fargate"
+      })
+    }
+    kube-proxy = {}
+    vpc-cni    = {}
+  }
 
   vpc_id     = module.vpc.vpc_id
   subnet_ids = module.vpc.private_subnets
@@ -73,44 +75,45 @@ module "eks" {
     },
   ]
 
-  fargate_profiles = {
-    kube_system = {
-      name = "kube-system"
-      selectors = [
-        { namespace = "kube-system" }
-      ]
-    }
-    # Wildcard profile for EMR namespaces (prefix with `emr-`)
-    emr_wildcard = {
-      name = "emr-wildcard"
-      selectors = [
-        { namespace = "emr-*" }
-      ]
-    }
-  }
+  fargate_profiles = merge(
+    { for i in range(3) :
+      "kube-system-${element(split("-", local.azs[i]), 2)}" => {
+        selectors = [
+          { namespace = "kube-system" }
+        ]
+        # We want to create a profile per AZ for high availability
+        subnet_ids = [element(module.vpc.private_subnets, i)]
+      }
+    },
+    { for i in range(3) :
+      "emr-wildcard-${element(split("-", local.azs[i]), 2)}" => {
+        selectors = [
+          { namespace = "emr-*" }
+        ]
+        # We want to create a profile per AZ for high availability
+        subnet_ids = [element(module.vpc.private_subnets, i)]
+      }
+    },
+  )
 
   tags = local.tags
 }
 
+################################################################################
+# Kubernetes Addons
+################################################################################
+
 module "eks_blueprints_kubernetes_addons" {
   source = "../../../modules/kubernetes-addons"
 
-  eks_cluster_id        = module.eks.cluster_id
+  eks_cluster_id        = module.eks.cluster_name
   eks_cluster_endpoint  = module.eks.cluster_endpoint
   eks_oidc_provider     = module.eks.oidc_provider
   eks_oidc_provider_arn = module.eks.oidc_provider_arn
   eks_cluster_version   = module.eks.cluster_version
 
   # Wait on the `kube-system` profile before provisioning addons
-  data_plane_wait_arn = module.eks.aws_auth_configmap_yaml
-
-  enable_self_managed_coredns       = true
-  remove_default_coredns_deployment = true
-  self_managed_coredns_helm_config = {
-    # Sets the correct annotations to ensure the Fargate provisioner is used and not the EC2 provisioner
-    compute_type       = "fargate"
-    kubernetes_version = module.eks.cluster_version
-  }
+  data_plane_wait_arn = join(",", [for prof in module.eks.fargate_profiles : prof.fargate_profile_arn])
 
   # Enable Fargate logging
   enable_fargate_fluentbit = true
@@ -149,9 +152,9 @@ module "eks_blueprints_kubernetes_addons" {
   tags = local.tags
 }
 
-#---------------------------------------------------------------
+################################################################################
 # Sample Spark Job
-#---------------------------------------------------------------
+################################################################################
 
 resource "null_resource" "s3_sync" {
   provisioner "local-exec" {
@@ -174,7 +177,7 @@ resource "time_sleep" "coredns" {
   # In practice, this generally won't be necessary since the cluster will be provisioned long before jobs are scheduled on the cluster
   # However, for this example, its necessary to ensure CoreDNS is ready before we schedule the example job
   triggers = {
-    coredns = module.eks_blueprints_kubernetes_addons.aws_coredns.service_account
+    coredns = module.eks.cluster_addons["coredns"].id
   }
 }
 
@@ -222,9 +225,9 @@ resource "null_resource" "start_job_run" {
   ]
 }
 
-#---------------------------------------------------------------
+################################################################################
 # Supporting Resources
-#---------------------------------------------------------------
+################################################################################
 
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"

--- a/examples/analytics/emr-on-eks-fargate/outputs.tf
+++ b/examples/analytics/emr-on-eks-fargate/outputs.tf
@@ -1,6 +1,6 @@
 output "configure_kubectl" {
   description = "Configure kubectl: make sure you're logged in with the correct AWS profile and run the following command to update your kubeconfig"
-  value       = "aws eks --region ${local.region} update-kubeconfig --name ${module.eks.cluster_id}"
+  value       = "aws eks --region ${local.region} update-kubeconfig --name ${module.eks.cluster_name}"
 }
 
 output "emr_on_eks" {

--- a/examples/analytics/emr-on-eks-fargate/versions.tf
+++ b/examples/analytics/emr-on-eks-fargate/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.72"
+      version = ">= 4.47"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
@@ -17,10 +17,6 @@ terraform {
     null = {
       source  = "hashicorp/null"
       version = ">= 3.0"
-    }
-    kubectl = {
-      source  = "gavinbunney/kubectl"
-      version = ">= 1.14"
     }
     time = {
       source  = "hashicorp/time"


### PR DESCRIPTION
### What does this PR do?

- Update `emr-on-eks-fargate` example to use v19 of the EKS module
- Update example to patch CoreDNS addon for Fargate

### Motivation

- Keeps example aligned with current practices and features of Amazon EKS

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR

**Note**: Not all the PRs require a new example and/or doc page. In general:
- Use an existing example when possible to demonstrate a new addons usage
- A new docs page under `docs/add-ons/*` is required for new a new addon

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
