### PR TITLE
feat: Update `ipv4-prefix-delegation` example to use EKS v19 module

### DIFF
--- a/examples/ipv4-prefix-delegation/main.tf
+++ b/examples/ipv4-prefix-delegation/main.tf
@@ -100,7 +100,7 @@ module "eks" {
     }
   }
 
-  tags = module.tags.tags
+  tags = local.tags
 }
 
 data "aws_eks_addon_version" "latest" {

--- a/examples/ipv4-prefix-delegation/main.tf
+++ b/examples/ipv4-prefix-delegation/main.tf
@@ -3,24 +3,23 @@ provider "aws" {
 }
 
 provider "kubernetes" {
-  host                   = module.eks_blueprints.eks_cluster_endpoint
-  cluster_ca_certificate = base64decode(module.eks_blueprints.eks_cluster_certificate_authority_data)
+  host                   = module.eks.cluster_endpoint
+  cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
   token                  = data.aws_eks_cluster_auth.this.token
 }
 
 provider "helm" {
   kubernetes {
-    host                   = module.eks_blueprints.eks_cluster_endpoint
-    cluster_ca_certificate = base64decode(module.eks_blueprints.eks_cluster_certificate_authority_data)
+    host                   = module.eks.cluster_endpoint
+    cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
     token                  = data.aws_eks_cluster_auth.this.token
   }
 }
 
 data "aws_eks_cluster_auth" "this" {
-  name = module.eks_blueprints.eks_cluster_id
+  name = module.eks.cluster_name
 }
 
-data "aws_caller_identity" "current" {}
 data "aws_availability_zones" "available" {}
 
 locals {
@@ -38,141 +37,83 @@ locals {
   }
 }
 
-#---------------------------------------------------------------
-# EKS Blueprints
-#---------------------------------------------------------------
+################################################################################
+# Cluster
+################################################################################
 
-module "eks_blueprints" {
-  source = "../.."
+#tfsec:ignore:aws-eks-enable-control-plane-logging
+module "eks" {
+  source  = "terraform-aws-modules/eks/aws"
+  version = "~> 19.5"
 
-  cluster_name    = local.name
-  cluster_version = local.cluster_version
+  cluster_name                   = local.name
+  cluster_version                = local.cluster_version
+  cluster_endpoint_public_access = true
 
-  vpc_id             = module.vpc.vpc_id
-  private_subnet_ids = module.vpc.private_subnets
+  # EKS Addons
+  cluster_addons = {
+    coredns    = {}
+    kube-proxy = {}
+    vpc-cni = {
+      most_recent = true
+      configuration_values = jsonencode({
+        env = {
+          # Reference docs https://docs.aws.amazon.com/eks/latest/userguide/cni-increase-ip-addresses.html
+          ENABLE_PREFIX_DELEGATION = "true"
+          WARM_PREFIX_TARGET       = "1"
+        }
+      })
+    }
+  }
 
-  # https://github.com/aws-ia/terraform-aws-eks-blueprints/issues/485
-  # https://github.com/aws-ia/terraform-aws-eks-blueprints/issues/494
-  cluster_kms_key_additional_admin_arns = [data.aws_caller_identity.current.arn]
+  vpc_id     = module.vpc.vpc_id
+  subnet_ids = module.vpc.private_subnets
 
-  managed_node_groups = {
-    custom_ami = {
-      node_group_name = "custom-ami" # Max 40 characters for node group name
+  eks_managed_node_groups = {
+    initial = {
+      instance_types = ["m5.large"]
 
       min_size     = 1
       max_size     = 1
       desired_size = 1
 
-      custom_ami_id  = data.aws_ssm_parameter.eks_optimized_ami.value
-      instance_types = ["m5.xlarge"]
+      # See issue https://github.com/awslabs/amazon-eks-ami/issues/844
+      pre_bootstrap_user_data = <<-EOT
+        #!/bin/bash
+        set -ex
 
-      create_launch_template = true
-      launch_template_os     = "amazonlinux2eks"
+        # https://docs.aws.amazon.com/eks/latest/userguide/choosing-instance-type.html#determine-max-pods
+        MAX_PODS=$(/etc/eks/max-pods-calculator.sh --instance-type-from-imds \
+          --cni-version ${trimprefix(data.aws_eks_addon_version.latest["vpc-cni"].version, "v")} \
+          --cni-prefix-delegation-enabled)
 
-      # https://docs.aws.amazon.com/eks/latest/userguide/choosing-instance-type.html#determine-max-pods
-      pre_userdata = <<-EOT
-        MAX_PODS=$(/etc/eks/max-pods-calculator.sh --instance-type-from-imds --cni-version ${trimprefix(data.aws_eks_addon_version.latest["vpc-cni"].version, "v")} --cni-prefix-delegation-enabled)
+        # These settings opt out of the default behavior and use the maximum number of pods, with a cap of 110 due to
+        # Kubernetes guidance https://kubernetes.io/docs/setup/best-practices/cluster-large/
+        # See more info here https://docs.aws.amazon.com/eks/latest/userguide/cni-increase-ip-addresses.html
+        cat <<-EOF > /etc/profile.d/bootstrap.sh
+          export USE_MAX_PODS=false
+          export KUBELET_EXTRA_ARGS="--max-pods=$${MAX_PODS}"
+        EOF
+        # Source extra environment variables in bootstrap script
+        sed -i '/^set -o errexit/a\\nsource /etc/profile.d/bootstrap.sh' /etc/eks/bootstrap.sh
       EOT
-
-      # These settings opt out of the default behavior and use the maximum number of pods, with a cap of 110 due to
-      # Kubernetes guidance https://kubernetes.io/docs/setup/best-practices/cluster-large/
-      # See more info here https://docs.aws.amazon.com/eks/latest/userguide/cni-increase-ip-addresses.html
-      kubelet_extra_args   = "--max-pods=$${MAX_PODS}"
-      bootstrap_extra_args = "--use-max-pods false"
     }
   }
 
-  tags = local.tags
-}
-
-module "eks_blueprints_kubernetes_addons" {
-  source = "../../modules/kubernetes-addons"
-
-  eks_cluster_id       = module.eks_blueprints.eks_cluster_id
-  eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint
-  eks_oidc_provider    = module.eks_blueprints.oidc_provider
-  eks_cluster_version  = module.eks_blueprints.eks_cluster_version
-
-  enable_amazon_eks_vpc_cni = true
-  amazon_eks_vpc_cni_config = {
-    # Version 1.9.0 or later (for version 1.20 or earlier clusters or 1.21 or later clusters configured for IPv4)
-    # or 1.10.1 or later (for version 1.21 or later clusters configured for IPv6) of the Amazon VPC CNI
-    addon_version     = data.aws_eks_addon_version.latest["vpc-cni"].version
-    resolve_conflicts = "OVERWRITE"
-  }
-
-  tags = local.tags
-
-  depends_on = [
-    # Modify VPC CNI ahead of addons
-    null_resource.kubectl_set_env
-  ]
+  tags = module.tags.tags
 }
 
 data "aws_eks_addon_version" "latest" {
   for_each = toset(["vpc-cni"])
 
   addon_name         = each.value
-  kubernetes_version = module.eks_blueprints.eks_cluster_version
+  kubernetes_version = local.cluster_version
   most_recent        = true
 }
 
-#---------------------------------------------------------------
-# Modify VPC CNI deployment
-#---------------------------------------------------------------
-
-locals {
-  kubeconfig = yamlencode({
-    apiVersion      = "v1"
-    kind            = "Config"
-    current-context = "terraform"
-    clusters = [{
-      name = module.eks_blueprints.eks_cluster_id
-      cluster = {
-        certificate-authority-data = module.eks_blueprints.eks_cluster_certificate_authority_data
-        server                     = module.eks_blueprints.eks_cluster_endpoint
-      }
-    }]
-    contexts = [{
-      name = "terraform"
-      context = {
-        cluster = module.eks_blueprints.eks_cluster_id
-        user    = "terraform"
-      }
-    }]
-    users = [{
-      name = "terraform"
-      user = {
-        token = data.aws_eks_cluster_auth.this.token
-      }
-    }]
-  })
-}
-
-resource "null_resource" "kubectl_set_env" {
-  triggers = {}
-
-  provisioner "local-exec" {
-    interpreter = ["/bin/bash", "-c"]
-    environment = {
-      KUBECONFIG = base64encode(local.kubeconfig)
-    }
-
-    # Reference docs https://docs.aws.amazon.com/eks/latest/userguide/cni-increase-ip-addresses.html
-    command = <<-EOT
-      kubectl set env daemonset aws-node -n kube-system ENABLE_PREFIX_DELEGATION=true --kubeconfig <(echo $KUBECONFIG | base64 -d)
-      kubectl set env daemonset aws-node -n kube-system WARM_PREFIX_TARGET=1 --kubeconfig <(echo $KUBECONFIG | base64 -d)
-    EOT
-  }
-}
-
-#---------------------------------------------------------------
+################################################################################
 # Supporting Resources
-#---------------------------------------------------------------
-
-data "aws_ssm_parameter" "eks_optimized_ami" {
-  name = "/aws/service/eks/optimized-ami/${local.cluster_version}/amazon-linux-2/recommended/image_id"
-}
+################################################################################
 
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
@@ -198,13 +139,11 @@ module "vpc" {
   default_security_group_tags   = { Name = "${local.name}-default" }
 
   public_subnet_tags = {
-    "kubernetes.io/cluster/${local.name}" = "shared"
-    "kubernetes.io/role/elb"              = 1
+    "kubernetes.io/role/elb" = 1
   }
 
   private_subnet_tags = {
-    "kubernetes.io/cluster/${local.name}" = "shared"
-    "kubernetes.io/role/internal-elb"     = 1
+    "kubernetes.io/role/internal-elb" = 1
   }
 
   tags = local.tags

--- a/examples/ipv4-prefix-delegation/outputs.tf
+++ b/examples/ipv4-prefix-delegation/outputs.tf
@@ -1,4 +1,4 @@
 output "configure_kubectl" {
   description = "Configure kubectl: make sure you're logged in with the correct AWS profile and run the following command to update your kubeconfig"
-  value       = module.eks_blueprints.configure_kubectl
+  value       = "aws eks --region ${local.region} update-kubeconfig --name ${module.eks.cluster_name}"
 }

--- a/examples/ipv4-prefix-delegation/versions.tf
+++ b/examples/ipv4-prefix-delegation/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.72"
+      version = ">= 4.27"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"


### PR DESCRIPTION
### What does this PR do?

- Update `ipv4-prefix-delegation` example to use EKS v19 module

### Motivation

-  Keeps example aligned with current practices and features of Amazon EKS

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR

**Note**: Not all the PRs require a new example and/or doc page. In general:
- Use an existing example when possible to demonstrate a new addons usage
- A new docs page under `docs/add-ons/*` is required for new a new addon

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
