### PR TITLE
feat: Update `ipv6-eks-cluster` example to use EKS v19 module

### DIFF
--- a/examples/fargate-serverless/versions.tf
+++ b/examples/fargate-serverless/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.72"
+      version = ">= 4.27"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/examples/ipv6-eks-cluster/README.md
+++ b/examples/ipv6-eks-cluster/README.md
@@ -1,111 +1,68 @@
 # IPv6 EKS Cluster
 
-This example deploys VPC, Subnets and EKS Cluster with IPv6 networking enabled
+This example shows how to create an EKS cluster that utilizes IPv6 networking.
 
-- Creates a new sample VPC with IPv6, 3 Private Subnets and 3 Public Subnets
-- Creates Internet gateway for Public Subnets and NAT Gateway for Private Subnets
-- Creates EKS Cluster Control plane with one managed node group
+## Prerequisites:
 
-Checkout EKS the documentation for more details about [IPv6](https://docs.aws.amazon.com/eks/latest/userguide/cni-ipv6.html)
+Ensure that you have the following tools installed locally:
 
-## How to Deploy
+1. [aws cli](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html)
+2. [kubectl](https://Kubernetes.io/docs/tasks/tools/)
+3. [terraform](https://learn.hashicorp.com/tutorials/terraform/install-cli)
 
-### Prerequisites:
+## Deploy
 
-Ensure that you have installed the following tools in your Mac or Windows Laptop before start working with this module and run Terraform Plan and Apply
-
-1. [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html)
-2. [Kubectl](https://Kubernetes.io/docs/tasks/tools/)
-3. [Terraform](https://learn.hashicorp.com/tutorials/terraform/install-cli)
-
-### Deployment Steps
-
-#### Step 1: Clone the repo using the command below
+To provision this example:
 
 ```sh
-git clone https://github.com/aws-ia/terraform-aws-eks-blueprints.git
-```
-
-#### Step 2: Run Terraform INIT
-
-Initialize a working directory with configuration files
-
-```sh
-cd examples/ipv6-eks-cluster/
 terraform init
-```
-
-#### Step 3: Run Terraform PLAN
-
-Verify the resources created by this execution
-
-```sh
-export AWS_REGION=<ENTER YOUR REGION>   # Select your own region
-terraform plan
-```
-
-#### Step 4: Finally, Terraform APPLY
-
-**Deploy the pattern**
-
-```sh
 terraform apply
 ```
 
-Enter `yes` to apply.
+Enter `yes` at command prompt to apply
 
-#### Step 5: Verify EC2 instances running with IPv6 support
+## Validate
 
-```sh
-aws ec2 describe-instances --filters "Name=tag:eks:cluster-name,Values=ipv6-preprod-dev-eks" --query "Reservations[].Instances[? State.Name == 'running' ][].NetworkInterfaces[].Ipv6Addresses" --output table
-```
+The following command will update the `kubeconfig` on your local machine and allow you to interact with your EKS Cluster using `kubectl` to validate the CoreDNS deployment for Fargate.
 
-### Configure `kubectl` and test cluster
-
-EKS Cluster details can be extracted from terraform output or from AWS Console to get the name of cluster.
-This following command used to update the `kubeconfig` in your local machine where you run kubectl commands to interact with your EKS Cluster.
-
-#### Step 6: Run `update-kubeconfig` command
-
-`~/.kube/config` file gets updated with cluster details and certificate from the below command
+1. Run `update-kubeconfig` command:
 
 ```sh
-aws eks --region <enter-your-region> update-kubeconfig --name <cluster-name>
+aws eks --region <REGION> update-kubeconfig --name <CLUSTER_NAME>
 ```
 
-#### Step 7: List all the PODS running in `kube-system` and observe the **IP allocated**
+2. Test by listing all the pods running currently; the `IP` should be an IPv6 address.
 
 ```sh
-kubectl get pods -n kube-system  -o wide
+kubectl get pods -A -o wide
+
+# Output should look like below
+NAMESPACE     NAME                       READY   STATUS    RESTARTS   AGE     IP                                       NODE                                        NOMINATED NODE   READINESS GATES
+kube-system   aws-node-bhd2s             1/1     Running   0          3m5s    2600:1f13:6c4:a703:ecf8:3ac1:76b0:9303   ip-10-0-10-183.us-west-2.compute.internal   <none>           <none>
+kube-system   aws-node-nmdgq             1/1     Running   0          3m21s   2600:1f13:6c4:a705:a929:f8d4:9350:1b20   ip-10-0-12-188.us-west-2.compute.internal   <none>           <none>
+kube-system   coredns-799c5565b4-6wxrc   1/1     Running   0          10m     2600:1f13:6c4:a705:bbda::                ip-10-0-12-188.us-west-2.compute.internal   <none>           <none>
+kube-system   coredns-799c5565b4-fjq4q   1/1     Running   0          10m     2600:1f13:6c4:a705:bbda::1               ip-10-0-12-188.us-west-2.compute.internal   <none>           <none>
+kube-system   kube-proxy-58tp7           1/1     Running   0          4m25s   2600:1f13:6c4:a703:ecf8:3ac1:76b0:9303   ip-10-0-10-183.us-west-2.compute.internal   <none>           <none>
+kube-system   kube-proxy-hqkgw           1/1     Running   0          4m25s   2600:1f13:6c4:a705:a929:f8d4:9350:1b20   ip-10-0-12-188.us-west-2.compute.internal   <none>           <none>
 ```
 
-Output
+3. Test by listing all the nodes running currently; the `INTERNAL-IP` should be an IPv6 address.
 
-        NAME                                           READY   STATUS    RESTARTS   AGE    IP                                      NODE                                        NOMINATED NODE   READINESS GATES
-        aws-load-balancer-controller-bd6cb6fcc-4r8hw   1/1     Running   0          10m    2a05:d018:434:7702:2e8a::               ip-10-0-10-23.eu-west-1.compute.internal    <none>           <none>
-        aws-load-balancer-controller-bd6cb6fcc-z7m8p   1/1     Running   0          10m    2a05:d018:434:7703:6b5d::1              ip-10-0-11-186.eu-west-1.compute.internal   <none>           <none>
-        aws-node-f7s6m                                 1/1     Running   0          140m   2a05:d018:434:7702:3784:d6b:fc0d:e156   ip-10-0-10-23.eu-west-1.compute.internal    <none>           <none>
-        aws-node-lg5rb                                 1/1     Running   0          142m   2a05:d018:434:7703:b3eb:2aa:aa4a:c838   ip-10-0-11-186.eu-west-1.compute.internal   <none>           <none>
-        coredns-57b66fb77c-hk5ks                       1/1     Running   0          144m   2a05:d018:434:7702:2e8a::1              ip-10-0-10-23.eu-west-1.compute.internal    <none>           <none>
-        coredns-57b66fb77c-j69fq                       1/1     Running   0          144m   2a05:d018:434:7703:6b5d::               ip-10-0-11-186.eu-west-1.compute.internal   <none>           <none>
-        kube-proxy-k992g                               1/1     Running   0          3h1m   2a05:d018:434:7702:3784:d6b:fc0d:e156   ip-10-0-10-23.eu-west-1.compute.internal    <none>           <none>
-        kube-proxy-nzfrq                               1/1     Running   0          3h1m   2a05:d018:434:7703:b3eb:2aa:aa4a:c838   ip-10-0-11-186.eu-west-1.compute.internal   <none>           <none>
+```sh
+kubectl nodes -A -o wide
 
+# Output should look like below
+NAME                                        STATUS   ROLES    AGE     VERSION               INTERNAL-IP                              EXTERNAL-IP   OS-IMAGE         KERNEL-VERSION                 CONTAINER-RUNTIME
+ip-10-0-10-183.us-west-2.compute.internal   Ready    <none>   4m57s   v1.24.7-eks-fb459a0   2600:1f13:6c4:a703:ecf8:3ac1:76b0:9303   <none>        Amazon Linux 2   5.4.226-129.415.amzn2.x86_64   containerd://1.6.6
+ip-10-0-12-188.us-west-2.compute.internal   Ready    <none>   4m57s   v1.24.7-eks-fb459a0   2600:1f13:6c4:a705:a929:f8d4:9350:1b20   <none>        Amazon Linux 2   5.4.226-129.415.amzn2.x86_64   containerd://1.6.6
+```
 
-## Cleanup
+## Destroy
 
-To clean up your environment, destroy the Terraform modules in reverse order.
-
-Destroy the Kubernetes Add-ons, EKS cluster with Node groups and VPC
+To teardown and remove the resources created in this example:
 
 ```sh
 terraform destroy -target="module.eks_blueprints_kubernetes_addons" -auto-approve
-terraform destroy -target="module.eks_blueprints" -auto-approve
-terraform destroy -target="module.vpc" -auto-approve
-```
-
-Finally, destroy any additional resources that are not in the above modules
-
-```sh
+terraform destroy -target="module.eks" -auto-approve
 terraform destroy -auto-approve
 ```

--- a/examples/ipv6-eks-cluster/main.tf
+++ b/examples/ipv6-eks-cluster/main.tf
@@ -3,21 +3,21 @@ provider "aws" {
 }
 
 provider "kubernetes" {
-  host                   = module.eks_blueprints.eks_cluster_endpoint
-  cluster_ca_certificate = base64decode(module.eks_blueprints.eks_cluster_certificate_authority_data)
+  host                   = module.eks.cluster_endpoint
+  cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
   token                  = data.aws_eks_cluster_auth.this.token
 }
 
 provider "helm" {
   kubernetes {
-    host                   = module.eks_blueprints.eks_cluster_endpoint
-    cluster_ca_certificate = base64decode(module.eks_blueprints.eks_cluster_certificate_authority_data)
+    host                   = module.eks.cluster_endpoint
+    cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
     token                  = data.aws_eks_cluster_auth.this.token
   }
 }
 
 data "aws_eks_cluster_auth" "this" {
-  name = module.eks_blueprints.eks_cluster_id
+  name = module.eks.cluster_name
 }
 
 data "aws_availability_zones" "available" {}
@@ -35,58 +35,54 @@ locals {
   }
 }
 
-#---------------------------------------------------------------
-# EKS Blueprints
-#---------------------------------------------------------------
+################################################################################
+# Cluster
+################################################################################
 
-module "eks_blueprints" {
-  source = "../.."
+#tfsec:ignore:aws-eks-enable-control-plane-logging
+module "eks" {
+  source  = "terraform-aws-modules/eks/aws"
+  version = "~> 19.5"
 
-  cluster_name      = local.name
-  cluster_version   = "1.24"
+  cluster_name                   = local.name
+  cluster_version                = "1.24"
+  cluster_endpoint_public_access = true
+
+  # IPV6
   cluster_ip_family = "ipv6"
 
-  vpc_id             = module.vpc.vpc_id
-  private_subnet_ids = module.vpc.private_subnets
+  # We are using the IRSA created below for permissions
+  # However, we have to deploy with the policy attached FIRST (when creating a fresh cluster)
+  # and then turn this off after the cluster/node group is created. Without this initial policy,
+  # the VPC CNI fails to assign IPs and nodes cannot join the cluster
+  # See https://github.com/aws/containers-roadmap/issues/1666 for more context
+  create_cni_ipv6_iam_policy = true
 
-  managed_node_groups = {
-    mg_5 = {
-      node_group_name = "mng-ondemand"
-      instance_types  = ["m5.large"]
-      min_size        = 2
-      desired_size    = 2
-      max_size        = 10
-      subnet_ids      = module.vpc.private_subnets
+  cluster_addons = {
+    coredns    = {}
+    kube-proxy = {}
+    vpc-cni    = {}
+  }
+
+  vpc_id     = module.vpc.vpc_id
+  subnet_ids = module.vpc.private_subnets
+
+  eks_managed_node_groups = {
+    initial = {
+      instance_types = ["m5.large"]
+
+      min_size     = 1
+      max_size     = 3
+      desired_size = 2
     }
   }
 
   tags = local.tags
 }
 
-module "eks_blueprints_kubernetes_addons" {
-  source = "../../modules/kubernetes-addons"
-
-  eks_cluster_id       = module.eks_blueprints.eks_cluster_id
-  eks_cluster_endpoint = module.eks_blueprints.eks_cluster_endpoint
-  eks_oidc_provider    = module.eks_blueprints.oidc_provider
-  eks_cluster_version  = module.eks_blueprints.eks_cluster_version
-
-  enable_ipv6 = true # Enable Ipv6 network. Attaches new VPC CNI policy to the IRSA role
-
-  # EKS Managed Add-ons
-  enable_amazon_eks_coredns    = true
-  enable_amazon_eks_kube_proxy = true
-  enable_amazon_eks_vpc_cni    = true
-
-  # Add-ons
-  enable_aws_load_balancer_controller = true
-
-  tags = local.tags
-}
-
-#---------------------------------------------------------------
+################################################################################
 # Supporting Resources
-#---------------------------------------------------------------
+################################################################################
 
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
@@ -119,13 +115,11 @@ module "vpc" {
   default_security_group_tags   = { Name = "${local.name}-default" }
 
   public_subnet_tags = {
-    "kubernetes.io/cluster/${local.name}" = "shared"
-    "kubernetes.io/role/elb"              = 1
+    "kubernetes.io/role/elb" = 1
   }
 
   private_subnet_tags = {
-    "kubernetes.io/cluster/${local.name}" = "shared"
-    "kubernetes.io/role/internal-elb"     = 1
+    "kubernetes.io/role/internal-elb" = 1
   }
 
   tags = local.tags

--- a/examples/ipv6-eks-cluster/outputs.tf
+++ b/examples/ipv6-eks-cluster/outputs.tf
@@ -1,4 +1,4 @@
 output "configure_kubectl" {
   description = "Configure kubectl: make sure you're logged in with the correct AWS profile and run the following command to update your kubeconfig"
-  value       = module.eks_blueprints.configure_kubectl
+  value       = "aws eks --region ${local.region} update-kubeconfig --name ${module.eks.cluster_name}"
 }

--- a/examples/ipv6-eks-cluster/versions.tf
+++ b/examples/ipv6-eks-cluster/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.72"
+      version = ">= 4.27"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/examples/vpc-cni-custom-networking/main.tf
+++ b/examples/vpc-cni-custom-networking/main.tf
@@ -59,7 +59,6 @@ module "eks" {
   cluster_version                = local.cluster_version
   cluster_endpoint_public_access = true
 
-  # EKS Addons
   cluster_addons = {
     coredns    = {}
     kube-proxy = {}


### PR DESCRIPTION
### What does this PR do?

- Update `ipv6-eks-cluster` example to use EKS v19 module

### Motivation

-  Keeps example aligned with current practices and features of Amazon EKS

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR

**Note**: Not all the PRs require a new example and/or doc page. In general:
- Use an existing example when possible to demonstrate a new addons usage
- A new docs page under `docs/add-ons/*` is required for new a new addon

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
