### PR TITLE
docs: Typo within gitops/argocd example

### DIFF
--- a/examples/gitops/argocd/main.tf
+++ b/examples/gitops/argocd/main.tf
@@ -144,13 +144,13 @@ resource "bcrypt_hash" "argo" {
 }
 
 #tfsec:ignore:aws-ssm-secret-use-customer-key
-resource "aws_secretsmanager_secret" "arogcd" {
+resource "aws_secretsmanager_secret" "argocd" {
   name                    = "argocd"
   recovery_window_in_days = 0 # Set to zero for this example to force delete during Terraform destroy
 }
 
-resource "aws_secretsmanager_secret_version" "arogcd" {
-  secret_id     = aws_secretsmanager_secret.arogcd.id
+resource "aws_secretsmanager_secret_version" "argocd" {
+  secret_id     = aws_secretsmanager_secret.argocd.id
   secret_string = random_password.argocd.result
 }
 


### PR DESCRIPTION
### What does this PR do?

Fixes two typos within the examples/gitops/argocd/main.tf