### PR TITLE
fix(strimzi-kafka-operator): Support creating namespace

### DIFF
--- a/examples/gitops/argocd/main.tf
+++ b/examples/gitops/argocd/main.tf
@@ -123,6 +123,7 @@ module "eks_blueprints_kubernetes_addons" {
   enable_vpa                            = true
   enable_yunikorn                       = true
   enable_argo_rollouts                  = true
+  enable_strimzi_kafka_operator         = true
 
   tags = local.tags
 }

--- a/modules/kubernetes-addons/strimzi-kafka-operator/main.tf
+++ b/modules/kubernetes-addons/strimzi-kafka-operator/main.tf
@@ -11,6 +11,11 @@ locals {
     description      = "Strimzi - Apache Kafka on Kubernetes"
   }
   helm_config = merge(local.default_helm_config, var.helm_config)
+  irsa_config = {
+    kubernetes_namespace              = local.helm_config["namespace"]
+    create_kubernetes_namespace       = try(local.helm_config["create_namespace"], true)
+    create_kubernetes_service_account = false
+  }
 }
 
 #-------------------------------------------------
@@ -19,6 +24,7 @@ locals {
 module "helm_addon" {
   source            = "../helm-addon"
   helm_config       = local.helm_config
+  irsa_config       = var.manage_via_gitops ? local.irsa_config : null
   addon_context     = var.addon_context
   manage_via_gitops = var.manage_via_gitops
 }


### PR DESCRIPTION
### What does this PR do?

Makes sure a Kubernetes namespace for the `strimzi-kafka-operator` add-on is being created if `argocd_manage_add_ons = true`.

### Motivation

<!-- What inspired you to submit this pull request? -->
- Resolves #1309

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [x] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR

**Note**: Not all the PRs require a new example and/or doc page. In general:
- Use an existing example when possible to demonstrate a new addons usage
- A new docs page under `docs/add-ons/*` is required for new a new addon

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
After applying these changes, the namespace is created as expected:
```
$ terraform state list | grep strimz
module.kubernetes_addons.module.strimzi_kafka_operator[0].module.helm_addon.module.irsa[0].kubernetes_namespace_v1.irsa[0]

$ kubectl get namespace strimzi
NAME      STATUS   AGE
strimzi   Active   99m
```