### PR TITLE
fix: Ensure only the 10.0.* subnet range is assigned to nodes for `vpc-cni-custom-networking` example

### DIFF
--- a/examples/vpc-cni-custom-networking/main.tf
+++ b/examples/vpc-cni-custom-networking/main.tf
@@ -80,7 +80,8 @@ module "eks" {
   }
 
   vpc_id                   = module.vpc.vpc_id
-  subnet_ids               = module.vpc.private_subnets
+  # We only want to assign the 10.0.* range subnets to the data plane
+  subnet_ids               = slice(module.vpc.private_subnets, 0, 3)
   control_plane_subnet_ids = module.vpc.intra_subnets
 
   eks_managed_node_groups = {


### PR DESCRIPTION
### What does this PR do?

- Ensure only the 10.0.* subnet range is assigned to nodes for `vpc-cni-custom-networking` example

### Motivation

- Resolves #1313
- https://github.com/aws-ia/terraform-aws-eks-blueprints/commit/a91b8409eac7442323de800584e762a525cde268#diff-c39da8e1f2726f8896d0ec2bb473a98f6e563d319802342dc59480b575d4aff4L61

### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR

**Note**: Not all the PRs require a new example and/or doc page. In general:
- Use an existing example when possible to demonstrate a new addons usage
- A new docs page under `docs/add-ons/*` is required for new a new addon

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
