### PR TITLE
feat: Upgrade `stateful` example to use v19 of EKS module

### DIFF
--- a/examples/fargate-serverless/versions.tf
+++ b/examples/fargate-serverless/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.0.0"
+  required_version = ">= 1.0"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.27"
+      version = ">= 4.47"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/examples/ipv4-prefix-delegation/versions.tf
+++ b/examples/ipv4-prefix-delegation/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.0.0"
+  required_version = ">= 1.0"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.27"
+      version = ">= 4.47"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/examples/ipv6-eks-cluster/versions.tf
+++ b/examples/ipv6-eks-cluster/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.0.0"
+  required_version = ">= 1.0"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.27"
+      version = ">= 4.47"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/examples/karpenter/versions.tf
+++ b/examples/karpenter/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0.0"
+  required_version = ">= 1.0"
 
   required_providers {
     aws = {

--- a/examples/stateful/outputs.tf
+++ b/examples/stateful/outputs.tf
@@ -1,4 +1,4 @@
 output "configure_kubectl" {
   description = "Configure kubectl: make sure you're logged in with the correct AWS profile and run the following command to update your kubeconfig"
-  value       = module.eks_blueprints.configure_kubectl
+  value       = "aws eks --region ${local.region} update-kubeconfig --name ${module.eks.cluster_name}"
 }

--- a/examples/stateful/versions.tf
+++ b/examples/stateful/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.0.0"
+  required_version = ">= 1.0"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.72"
+      version = ">= 4.47"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/examples/vpc-cni-custom-networking/main.tf
+++ b/examples/vpc-cni-custom-networking/main.tf
@@ -79,7 +79,7 @@ module "eks" {
     }
   }
 
-  vpc_id                   = module.vpc.vpc_id
+  vpc_id = module.vpc.vpc_id
   # We only want to assign the 10.0.* range subnets to the data plane
   subnet_ids               = slice(module.vpc.private_subnets, 0, 3)
   control_plane_subnet_ids = module.vpc.intra_subnets

--- a/examples/vpc-cni-custom-networking/versions.tf
+++ b/examples/vpc-cni-custom-networking/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.0.0"
+  required_version = ">= 1.0"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.27"
+      version = ">= 4.47"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"


### PR DESCRIPTION
### What does this PR do?

- Upgrade `stateful` example to use v19 of EKS module

### Motivation

- Keeps example aligned with current practices and features of Amazon EKS

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR

**Note**: Not all the PRs require a new example and/or doc page. In general:
- Use an existing example when possible to demonstrate a new addons usage
- A new docs page under `docs/add-ons/*` is required for new a new addon

### For Moderators

- Successfully provisioned but took two applies due to token timeout with use of static token in provider

### Additional Notes

<!-- Anything else we should know when reviewing? -->
