### PR TITLE
fix: Append KUBELET_EXTRA_ARGS to bootstrap.sh default flags

### DIFF
--- a/examples/ipv4-prefix-delegation/main.tf
+++ b/examples/ipv4-prefix-delegation/main.tf
@@ -96,6 +96,7 @@ module "eks" {
         EOF
         # Source extra environment variables in bootstrap script
         sed -i '/^set -o errexit/a\\nsource /etc/profile.d/bootstrap.sh' /etc/eks/bootstrap.sh
+        sed -i 's/KUBELET_EXTRA_ARGS=$2/KUBELET_EXTRA_ARGS="$2 $KUBELET_EXTRA_ARGS"/' /etc/eks/bootstrap.sh
       EOT
     }
   }

--- a/examples/vpc-cni-custom-networking/main.tf
+++ b/examples/vpc-cni-custom-networking/main.tf
@@ -114,6 +114,7 @@ module "eks" {
         EOF
         # Source extra environment variables in bootstrap script
         sed -i '/^set -o errexit/a\\nsource /etc/profile.d/bootstrap.sh' /etc/eks/bootstrap.sh
+        sed -i 's/KUBELET_EXTRA_ARGS=$2/KUBELET_EXTRA_ARGS="$2 $KUBELET_EXTRA_ARGS"/' /etc/eks/bootstrap.sh
       EOT
     }
   }


### PR DESCRIPTION
### What does this PR do?

Update example when using ipv4 prefix delegation to append the max pods values using KUBELET_EXTRA_ARGS to the bootstrap.sh flag to override the value provided by the EKS service.

### Motivation

When using managed groups with EKS and using the EKS default template, the service will calculate and pass the kubelet flag for max pods. 

- Resolves #1312

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR

**Note**: Not all the PRs require a new example and/or doc page. In general:
- Use an existing example when possible to demonstrate a new addons usage
- A new docs page under `docs/add-ons/*` is required for new a new addon

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
