### PR TITLE
feat: Update serverless clusters running EKS Farage to maximize resource utilization on CoreDNS

### DIFF
--- a/examples/analytics/emr-on-eks-fargate/main.tf
+++ b/examples/analytics/emr-on-eks-fargate/main.tf
@@ -54,15 +54,23 @@ module "eks" {
       configuration_values = jsonencode({
         computeType = "Fargate"
         # Ensure that the we fully utilize the minimum amount of resources that are supplied by
-        # Fargate https://docs.aws.amazon.com/AmazonECS/latest/developerguide/AWS_Fargate.html
+        # Fargate https://docs.aws.amazon.com/eks/latest/userguide/fargate-pod-configuration.html
+        # Fargate adds 256 MB to each pod's memory reservation for the required Kubernetes
+        # components (kubelet, kube-proxy, and containerd). Fargate rounds up to the following
+        # compute configuration that most closely matches the sum of vCPU and memory requests in
+        # order to ensure pods always have the resources that they need to run.
         resources = {
           limits = {
-            cpu    = "0.25"
-            memory = "250Mi" # Going above this value will allocate a task with 1Gb of memory
+            cpu = "0.25"
+            # We are targetting the smallest Task size of 512Mb, so we subtract 256Mb from the
+            # request/limit to ensure we can fit within that task
+            memory = "256M"
           }
           requests = {
-            cpu    = "0.25"
-            memory = "250Mi" # Going above this value will allocate a task with 1Gb of memory
+            cpu = "0.25"
+            # We are targetting the smallest Task size of 512Mb, so we subtract 256Mb from the
+            # request/limit to ensure we can fit within that task
+            memory = "256M"
           }
         }
       })

--- a/examples/analytics/emr-on-eks-fargate/main.tf
+++ b/examples/analytics/emr-on-eks-fargate/main.tf
@@ -53,6 +53,18 @@ module "eks" {
     coredns = {
       configuration_values = jsonencode({
         computeType = "Fargate"
+        # Ensure that the we fully utilize the minimum amount of resources that are supplied by
+        # Fargate https://docs.aws.amazon.com/AmazonECS/latest/developerguide/AWS_Fargate.html
+        resources = {
+          limits = {
+            cpu    = "0.25"
+            memory = "250Mi" # Going above this value will allocate a task with 1Gb of memory
+          }
+          requests = {
+            cpu    = "0.25"
+            memory = "250Mi" # Going above this value will allocate a task with 1Gb of memory
+          }
+        }
       })
     }
     kube-proxy = {}

--- a/examples/fargate-serverless/README.md
+++ b/examples/fargate-serverless/README.md
@@ -45,7 +45,7 @@ aws eks --region <REGION> update-kubeconfig --name <CLUSTER_NAME>
 kubectl get pods -A
 
 # Output should look like below
-ame-2048      deployment-2048-7ff458c9f-mb5xs                 1/1     Running   0          5h23m
+game-2048      deployment-2048-7ff458c9f-mb5xs                 1/1     Running   0          5h23m
 game-2048     deployment-2048-7ff458c9f-qc99d                 1/1     Running   0          4h23m
 game-2048     deployment-2048-7ff458c9f-rm26f                 1/1     Running   0          4h23m
 game-2048     deployment-2048-7ff458c9f-vzjhm                 1/1     Running   0          4h23m

--- a/examples/fargate-serverless/main.tf
+++ b/examples/fargate-serverless/main.tf
@@ -52,6 +52,18 @@ module "eks" {
     coredns = {
       configuration_values = jsonencode({
         computeType = "Fargate"
+        # Ensure that the we fully utilize the minimum amount of resources that are supplied by
+        # Fargate https://docs.aws.amazon.com/AmazonECS/latest/developerguide/AWS_Fargate.html
+        resources = {
+          limits = {
+            cpu    = "0.25"
+            memory = "250Mi" # Going above this value will allocate a task with 1Gb of memory
+          }
+          requests = {
+            cpu    = "0.25"
+            memory = "250Mi" # Going above this value will allocate a task with 1Gb of memory
+          }
+        }
       })
     }
     kube-proxy = {}

--- a/examples/fargate-serverless/main.tf
+++ b/examples/fargate-serverless/main.tf
@@ -53,15 +53,23 @@ module "eks" {
       configuration_values = jsonencode({
         computeType = "Fargate"
         # Ensure that the we fully utilize the minimum amount of resources that are supplied by
-        # Fargate https://docs.aws.amazon.com/AmazonECS/latest/developerguide/AWS_Fargate.html
+        # Fargate https://docs.aws.amazon.com/eks/latest/userguide/fargate-pod-configuration.html
+        # Fargate adds 256 MB to each pod's memory reservation for the required Kubernetes
+        # components (kubelet, kube-proxy, and containerd). Fargate rounds up to the following
+        # compute configuration that most closely matches the sum of vCPU and memory requests in
+        # order to ensure pods always have the resources that they need to run.
         resources = {
           limits = {
-            cpu    = "0.25"
-            memory = "250Mi" # Going above this value will allocate a task with 1Gb of memory
+            cpu = "0.25"
+            # We are targetting the smallest Task size of 512Mb, so we subtract 256Mb from the
+            # request/limit to ensure we can fit within that task
+            memory = "256M"
           }
           requests = {
-            cpu    = "0.25"
-            memory = "250Mi" # Going above this value will allocate a task with 1Gb of memory
+            cpu = "0.25"
+            # We are targetting the smallest Task size of 512Mb, so we subtract 256Mb from the
+            # request/limit to ensure we can fit within that task
+            memory = "256M"
           }
         }
       })

--- a/examples/karpenter/main.tf
+++ b/examples/karpenter/main.tf
@@ -71,6 +71,18 @@ module "eks" {
     coredns = {
       configuration_values = jsonencode({
         computeType = "Fargate"
+        # Ensure that the we fully utilize the minimum amount of resources that are supplied by
+        # Fargate https://docs.aws.amazon.com/AmazonECS/latest/developerguide/AWS_Fargate.html
+        resources = {
+          limits = {
+            cpu    = "0.25"
+            memory = "250Mi" # Going above this value will allocate a task with 1Gb of memory
+          }
+          requests = {
+            cpu    = "0.25"
+            memory = "250Mi" # Going above this value will allocate a task with 1Gb of memory
+          }
+        }
       })
     }
     kube-proxy = {}

--- a/examples/karpenter/main.tf
+++ b/examples/karpenter/main.tf
@@ -72,15 +72,23 @@ module "eks" {
       configuration_values = jsonencode({
         computeType = "Fargate"
         # Ensure that the we fully utilize the minimum amount of resources that are supplied by
-        # Fargate https://docs.aws.amazon.com/AmazonECS/latest/developerguide/AWS_Fargate.html
+        # Fargate https://docs.aws.amazon.com/eks/latest/userguide/fargate-pod-configuration.html
+        # Fargate adds 256 MB to each pod's memory reservation for the required Kubernetes
+        # components (kubelet, kube-proxy, and containerd). Fargate rounds up to the following
+        # compute configuration that most closely matches the sum of vCPU and memory requests in
+        # order to ensure pods always have the resources that they need to run.
         resources = {
           limits = {
-            cpu    = "0.25"
-            memory = "250Mi" # Going above this value will allocate a task with 1Gb of memory
+            cpu = "0.25"
+            # We are targetting the smallest Task size of 512Mb, so we subtract 256Mb from the
+            # request/limit to ensure we can fit within that task
+            memory = "256M"
           }
           requests = {
-            cpu    = "0.25"
-            memory = "250Mi" # Going above this value will allocate a task with 1Gb of memory
+            cpu = "0.25"
+            # We are targetting the smallest Task size of 512Mb, so we subtract 256Mb from the
+            # request/limit to ensure we can fit within that task
+            memory = "256M"
           }
         }
       })


### PR DESCRIPTION
### What does this PR do?

- Update serverless clusters running EKS Farage to maximize resource utilization on CoreDNS

### Motivation

- When running on EKS Fargate, pods are assigned Fargate task sizes that meet the resource request/limits specified. If a user requests values that are much lower than the closest task size, these resources will go to waste. Instead, users should calculate the request/limits they require, find the closest Fargate task size, and then increase their requests/limits to fit within that next closest task size to maximize resources that are provisioned. You can see the Fargate resource graduations here https://docs.aws.amazon.com/AmazonECS/latest/developerguide/AWS_Fargate.html
- Resolves #1327

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR

**Note**: Not all the PRs require a new example and/or doc page. In general:
- Use an existing example when possible to demonstrate a new addons usage
- A new docs page under `docs/add-ons/*` is required for new a new addon

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
