### PR TITLE
fix: Optional namespace creation

### DIFF
--- a/modules/kubernetes-addons/csi-secrets-store-provider-aws/main.tf
+++ b/modules/kubernetes-addons/csi-secrets-store-provider-aws/main.tf
@@ -4,6 +4,8 @@ locals {
 }
 
 resource "kubernetes_namespace_v1" "csi_secrets_store_provider_aws" {
+  count = try(var.helm_config.create_namespace, true) ? 1 : 0
+
   metadata {
     name = local.namespace
   }
@@ -19,7 +21,7 @@ module "helm_addon" {
       chart       = local.name
       repository  = "https://aws.github.io/eks-charts"
       version     = "0.0.3"
-      namespace   = kubernetes_namespace_v1.csi_secrets_store_provider_aws.metadata[0].name
+      namespace   = try(kubernetes_namespace_v1.csi_secrets_store_provider_aws[0].metadata[0].name, local.namespace)
       description = "A Helm chart to install the Secrets Store CSI Driver and the AWS Key Management Service Provider inside a Kubernetes cluster."
     },
     var.helm_config

--- a/modules/kubernetes-addons/secrets-store-csi-driver/locals.tf
+++ b/modules/kubernetes-addons/secrets-store-csi-driver/locals.tf
@@ -1,5 +1,6 @@
 locals {
-  name = "secrets-store-csi-driver"
+  name      = "secrets-store-csi-driver"
+  namespace = try(var.helm_config.namespace, "kube-system")
 
   # https://github.com/kubernetes-sigs/secrets-store-csi-driver/blob/main/charts/secrets-store-csi-driver/Chart.yaml
   default_helm_config = {
@@ -7,7 +8,6 @@ locals {
     chart       = local.name
     repository  = "https://kubernetes-sigs.github.io/secrets-store-csi-driver/charts"
     version     = "1.2.4"
-    namespace   = local.name
     description = "A Helm chart to install the Secrets Store CSI Driver"
   }
 

--- a/modules/kubernetes-addons/secrets-store-csi-driver/main.tf
+++ b/modules/kubernetes-addons/secrets-store-csi-driver/main.tf
@@ -1,6 +1,8 @@
 resource "kubernetes_namespace_v1" "secrets_store_csi_driver" {
+  count = try(var.helm_config.create_namespace, true) ? 1 : 0
+
   metadata {
-    name = local.name
+    name = local.namespace
 
     labels = {
       "app.kubernetes.io/managed-by" = "terraform-aws-eks-blueprints"
@@ -11,8 +13,11 @@ resource "kubernetes_namespace_v1" "secrets_store_csi_driver" {
 module "helm_addon" {
   source            = "../helm-addon"
   manage_via_gitops = var.manage_via_gitops
-  helm_config       = local.helm_config
-  addon_context     = var.addon_context
-
-  depends_on = [kubernetes_namespace_v1.secrets_store_csi_driver]
+  helm_config = merge(
+    {
+      namespace = try(kubernetes_namespace_v1.secrets_store_csi_driver[0].metadata[0].name, local.namespace)
+    },
+    local.helm_config
+  )
+  addon_context = var.addon_context
 }


### PR DESCRIPTION
### What does this PR do?

Make namespace creation optional for addon `csi-secrets-store-provider-aws` and use same default namespace for addon `secrets-store-csi-driver`.

### Motivation

<!-- What inspired you to submit this pull request? -->
- Resolves aws-ia/terraform-aws-eks-blueprints#1306

### For Moderators

- [ ] E2E Test successfully complete before merge?

