### PR TITLE
feat: Add `crowdstrike-falcon` addon

### DIFF
--- a/docs/add-ons/crowdstrike-falcon.md
+++ b/docs/add-ons/crowdstrike-falcon.md
@@ -1,8 +1,9 @@
 # CrowdStrike Falcon
 
-`falcon` is a terraform module that can automate the deployment of CrowdStrike Falcon Sensor and the Kubernetes Protection Agent on a Kubernetes cluster.
+[`terraform-kubectl-falcon`](https://github.com/CrowdStrike/terraform-kubectl-falcon) is a Terraform module that can automate the deployment of CrowdStrike Falcon Sensor and the Kubernetes Protection Agent on a Kubernetes cluster.
 
 ## Falcon Operator
+
 Falcon Operator is a Kubernetes operator that manages the deployment of the CrowdStrike Falcon Sensor on a Kubernetes cluster. The CrowdStrike Falcon Sensor provides runtime protection for workloads running on a Kubernetes cluster.
 
 More information can be found in the [Operator submodule](https://github.com/CrowdStrike/terraform-kubectl-falcon/blob/main/modules/operator/README.md).
@@ -11,38 +12,12 @@ More information can be found in the [Operator submodule](https://github.com/Cro
 
 The Kubernetes Protection Agent provides visibility into the cluster by collecting event information from the Kubernetes layer. These events are correlated to sensor events and cloud events to provide complete cluster visibility.
 
-More information can be found in the [KPA submodule](https://github.com/CrowdStrike/terraform-kubectl-falcon/blob/main/modules/k8s-protection-agent/README.md).
+More information can be found in the [KPA sub-module](https://github.com/CrowdStrike/terraform-kubectl-falcon/blob/main/modules/k8s-protection-agent/README.md).
 
 ## Usage
 
-Refer to the [`falcon module`](https://github.com/CrowdStrike/terraform-kubectl-falcon) documentation for the most up-to-date information on inputs and outputs.
+Refer to the [`terraform-kubectl-falcon`](https://github.com/CrowdStrike/terraform-kubectl-falcon) documentation for the most up-to-date information on inputs and outputs.
 
 ## Example
 
-You will call the `falcon` module similar to how you would call any other terraform module. 
-
-A full end to end example of using the `falcon` module with `eks_blueprints` can be found in the [examples](https://github.com/CrowdStrike/terraform-kubectl-falcon/tree/v0.1.0/examples/aws-eks-blueprint-example) directory of the `falcon` module.
-
-```hcl
-#---------------------------------------------------------------
-# EKS Blueprints
-#---------------------------------------------------------------
-
-module "eks_blueprints" {
-  # EKS Blueprints Module Configuration
-}
-
-module "eks_blueprints_kubernetes_addons" {
-  # Blueprints Kubernetes Add-ons Module configuration
-}
-
-#---------------------------------------------------------------
-# CrowdStrike Falcon
-#---------------------------------------------------------------
-
-module "crowdstrike_falcon" {
-  source = "github.com/CrowdStrike/terraform-kubectl-falcon?ref=<release>"
-
-  #  CrowdStrike Falcon Module Configuration
-}
-```
+A full end to end example of using the `terraform-kubectl-falcon` module with `eks_blueprints` can be found in the [examples](https://github.com/CrowdStrike/terraform-kubectl-falcon/tree/v0.1.0/examples/aws-eks-blueprint-example) directory of the `terraform-kubectl-falcon` module.

--- a/docs/add-ons/crowdstrike-falcon.md
+++ b/docs/add-ons/crowdstrike-falcon.md
@@ -1,0 +1,46 @@
+# CrowdStrike Falcon
+
+`falcon` is a terraform module that can automate the deployment of CrowdStrike Falcon Sensor and the Kubernetes Protection Agent on a Kubernetes cluster.
+
+## Falcon Operator
+Falcon Operator is a Kubernetes operator that manages the deployment of the CrowdStrike Falcon Sensor on a Kubernetes cluster. The CrowdStrike Falcon Sensor provides runtime protection for workloads running on a Kubernetes cluster.
+
+More information can be found in the [Operator submodule](https://github.com/CrowdStrike/terraform-kubectl-falcon/blob/main/modules/operator/README.md).
+
+## Kubernetes Protection Agent (KPA)
+
+The Kubernetes Protection Agent provides visibility into the cluster by collecting event information from the Kubernetes layer. These events are correlated to sensor events and cloud events to provide complete cluster visibility.
+
+More information can be found in the [KPA submodule](https://github.com/CrowdStrike/terraform-kubectl-falcon/blob/main/modules/k8s-protection-agent/README.md).
+
+## Usage
+
+Refer to the [`falcon module`](https://github.com/CrowdStrike/terraform-kubectl-falcon) documentation for the most up-to-date information on inputs and outputs.
+
+## Example
+
+You will call the `falcon` module similar to how you would call any other terraform module. The [module documentation](https://github.com/CrowdStrike/terraform-kubectl-falcon) provides a list of all the inputs and outputs.
+
+```hcl
+#---------------------------------------------------------------
+# EKS Blueprints
+#---------------------------------------------------------------
+
+module "eks_blueprints" {
+  # EKS Blueprints Module Configuration
+}
+
+module "eks_blueprints_kubernetes_addons" {
+  # Blueprints Kubernetes Add-ons Module configuration
+}
+
+#---------------------------------------------------------------
+# CrowdStrike Falcon
+#---------------------------------------------------------------
+
+module "crowdstrike_falcon" {
+  source = "github.com/crowdstrike/terraform-modules//falcon/k8s-protection-agent?ref=<release>"
+
+  #  CrowdStrike Falcon Module Configuration
+}
+```

--- a/docs/add-ons/crowdstrike-falcon.md
+++ b/docs/add-ons/crowdstrike-falcon.md
@@ -19,7 +19,9 @@ Refer to the [`falcon module`](https://github.com/CrowdStrike/terraform-kubectl-
 
 ## Example
 
-You will call the `falcon` module similar to how you would call any other terraform module. The [module documentation](https://github.com/CrowdStrike/terraform-kubectl-falcon) provides a list of all the inputs and outputs.
+You will call the `falcon` module similar to how you would call any other terraform module. 
+
+A full end to end example of using the `falcon` module with `eks_blueprints` can be found in the [examples](https://github.com/CrowdStrike/terraform-kubectl-falcon/tree/v0.1.0/examples/aws-eks-blueprint-example) directory of the `falcon` module.
 
 ```hcl
 #---------------------------------------------------------------

--- a/docs/add-ons/crowdstrike-falcon.md
+++ b/docs/add-ons/crowdstrike-falcon.md
@@ -39,7 +39,7 @@ module "eks_blueprints_kubernetes_addons" {
 #---------------------------------------------------------------
 
 module "crowdstrike_falcon" {
-  source = "github.com/crowdstrike/terraform-modules//falcon/k8s-protection-agent?ref=<release>"
+  source = "github.com/CrowdStrike/terraform-kubectl-falcon?ref=<release>"
 
   #  CrowdStrike Falcon Module Configuration
 }


### PR DESCRIPTION
### What does this PR do?
 
add the `crowdstrike-falcon` partner documentation

<!-- A brief description of the change being made with this pull request. -->

### Motivation

<!-- What inspired you to submit this pull request? -->
Make it easy to boostrap falcon in AWS EKS

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [n/a] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [n/a] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [x] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->

Below is the result of running the `crowdstrike-falcon` example
![completed_run](https://user-images.githubusercontent.com/35144141/213914432-d274a074-bd0b-478e-893e-97113983848e.png)

`kubectl` of the operator and KPA
![kubectl](https://user-images.githubusercontent.com/35144141/213914437-16eabe17-2202-4dd9-aaa7-158b72a6e736.png)


