### PR TITLE
fix: Resource ns for kube-system in csi provider not needed

### DIFF
--- a/modules/kubernetes-addons/csi-secrets-store-provider-aws/main.tf
+++ b/modules/kubernetes-addons/csi-secrets-store-provider-aws/main.tf
@@ -1,12 +1,6 @@
 locals {
-  name      = try(var.helm_config.name, "csi-secrets-store-provider-aws")
-  namespace = try(var.helm_config.namespace, local.name)
-}
+  name = try(var.helm_config.name, "csi-secrets-store-provider-aws")
 
-resource "kubernetes_namespace_v1" "csi_secrets_store_provider_aws" {
-  metadata {
-    name = local.namespace
-  }
 }
 
 module "helm_addon" {
@@ -19,7 +13,7 @@ module "helm_addon" {
       chart       = local.name
       repository  = "https://aws.github.io/eks-charts"
       version     = "0.0.3"
-      namespace   = kubernetes_namespace_v1.csi_secrets_store_provider_aws.metadata[0].name
+      namespace   = "kube-system"
       description = "A Helm chart to install the Secrets Store CSI Driver and the AWS Key Management Service Provider inside a Kubernetes cluster."
     },
     var.helm_config


### PR DESCRIPTION
### What does this PR do?

https://github.com/aws-ia/terraform-aws-eks-blueprints-addons/issues/22

### Motivation

correct the need to remove the requirement of generate the kube-system when it already exists. The chart just needs to have the optional choice to be deployed in rather than required.

### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR

**Note**: Not all the PRs require a new example and/or doc page. In general:
- Use an existing example when possible to demonstrate a new addons usage
- A new docs page under `docs/add-ons/*` is required for new a new addon

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
