### PR TITLE
feat: Bumping FSX CSI Driver to Version 0.9.0

### DIFF
--- a/modules/kubernetes-addons/aws-fsx-csi-driver/locals.tf
+++ b/modules/kubernetes-addons/aws-fsx-csi-driver/locals.tf
@@ -8,7 +8,7 @@ locals {
     name        = local.name
     chart       = local.name
     repository  = "https://kubernetes-sigs.github.io/aws-fsx-csi-driver/"
-    version     = "1.4.4"
+    version     = "1.5.0"
     namespace   = local.namespace
     description = "The Amazon FSx for Lustre CSI driver Helm chart deployment configuration"
   }


### PR DESCRIPTION
Bumping FSX CSI Driver to Version 0.9.0 (Helm version 1.5.0). This solves an issue with tagging of dynamically provisioned volumes (https://github.com/kubernetes-sigs/aws-fsx-csi-driver/issues/273)

### What does this PR do?

🛑 Please open an issue first to discuss any significant work and flesh out details/direction - we would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/aws-ia/terraform-aws-eks-blueprints/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

Bumping FSX CSI Driver to Version 0.9.0 (Helm version 1.5.0). This solves an issue with tagging of dynamically provisioned volumes (https://github.com/kubernetes-sigs/aws-fsx-csi-driver/issues/273)

### Motivation

<!-- What inspired you to submit this pull request? -->
- Resolves FSX CSI Driver issue https://github.com/kubernetes-sigs/aws-fsx-csi-driver/issues/273

### More

- [X ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR

**Note**: Not all the PRs require a new example and/or doc page. In general:
- Use an existing example when possible to demonstrate a new addons usage
- A new docs page under `docs/add-ons/*` is required for new a new addon

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
