### PR TITLE
chore: Update `ENI_CONFIG_LABEL_DEF` for VPC CNI to use current label spec

### DIFF
--- a/examples/vpc-cni-custom-networking/main.tf
+++ b/examples/vpc-cni-custom-networking/main.tf
@@ -99,7 +99,7 @@ resource "aws_eks_addon" "vpc_cni" {
     env = {
       # Reference https://aws.github.io/aws-eks-best-practices/reliability/docs/networkmanagement/#cni-custom-networking
       AWS_VPC_K8S_CNI_CUSTOM_NETWORK_CFG = "true"
-      ENI_CONFIG_LABEL_DEF               = "failure-domain.beta.kubernetes.io/zone"
+      ENI_CONFIG_LABEL_DEF               = "topology.kubernetes.io/zone"
 
       # Reference docs https://docs.aws.amazon.com/eks/latest/userguide/cni-increase-ip-addresses.html
       ENABLE_PREFIX_DELEGATION = "true"


### PR DESCRIPTION
### What does this PR do?

🛑 Please open an issue first to discuss any significant work and flesh out details/direction - we would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/aws-ia/terraform-aws-eks-blueprints/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

<!-- A brief description of the change being made with this pull request. -->
## Description
`failure-domain.beta.kubernetes.io/zone` is deprecated. 

This change updates the `vpc-cni` configuration` ENI_CONFIG_LABEL_DEF=topology.kubernetes.io/zone`
https://docs.aws.amazon.com/eks/latest/userguide/cni-custom-network.html#custom-networking-configure-kubernetes
### Motivation

<!-- What inspired you to submit this pull request? -->
Keeping up with EKS 1.24
