### PR TITLE
fix: Add missing argocd_gitops_config to kube-stack-prometheus

### DIFF
--- a/modules/kubernetes-addons/kube-prometheus-stack/main.tf
+++ b/modules/kubernetes-addons/kube-prometheus-stack/main.tf
@@ -1,6 +1,10 @@
 locals {
   name      = try(var.helm_config.name, "kube-prometheus-stack")
   namespace = try(var.helm_config.namespace, local.name)
+
+  argocd_gitops_config = {
+    enable             = true
+  }
 }
 
 resource "kubernetes_namespace_v1" "prometheus" {

--- a/modules/kubernetes-addons/kube-prometheus-stack/outputs.tf
+++ b/modules/kubernetes-addons/kube-prometheus-stack/outputs.tf
@@ -17,3 +17,8 @@ output "service_account" {
   description = "Name of Kubernetes service account"
   value       = module.helm_addon.service_account
 }
+
+output "argocd_gitops_config" {
+  description = "Configuration used for managing the add-on with ArgoCD"
+  value       = var.manage_via_gitops ? local.argocd_gitops_config : null
+}


### PR DESCRIPTION
### What does this PR do?

🛑 Please open an issue first to discuss any significant work and flesh out details/direction - we would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/aws-ia/terraform-aws-eks-blueprints/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

<!-- A brief description of the change being made with this pull request. -->
- adding missing argocd_gitops_config to kube-stack-prometheus while using argo.

### Motivation

<!-- What inspired you to submit this pull request? -->
- Post merge of https://github.com/aws-ia/terraform-aws-eks-blueprints/pull/1295 new issue reported where argocd_gitops_config is missing

### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR

**Note**: Not all the PRs require a new example and/or doc page. In general:
- Use an existing example when possible to demonstrate a new addons usage
- A new docs page under `docs/add-ons/*` is required for new a new addon

### For Moderators

- [ ] E2E Test successfully complete before merge? - Testing right now e2e gitops example with enable_kube_prometheus_stack = true

### Additional Notes

<!-- Anything else we should know when reviewing? -->
