### PR TITLE
chore: Removing unused block for Data Route53

### DIFF
--- a/modules/kubernetes-addons/external-dns/main.tf
+++ b/modules/kubernetes-addons/external-dns/main.tf
@@ -72,9 +72,3 @@ resource "aws_iam_policy" "external_dns" {
   policy      = data.aws_iam_policy_document.external_dns_iam_policy_document.json
   tags        = var.addon_context.tags
 }
-
-# TODO - remove at next breaking change
-data "aws_route53_zone" "selected" {
-  name         = var.domain_name
-  private_zone = var.private_zone
-}


### PR DESCRIPTION
### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
Removes unused data block.

### Motivation

<!-- What inspired you to submit this pull request? -->
While trying to provision external dns on a cross account EKS where the Private Hosted Zone lies in one OU and then the EKS lies in another, this section fails. 

I am already passing the route 53 arn via variable and also attaching a cross account policy for external dns to read hosted zone from another OU. 

### More

- [X] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR

**Note**: Not all the PRs require a new example and/or doc page. In general:
- Use an existing example when possible to demonstrate a new addons usage
- A new docs page under `docs/add-ons/*` is required for new a new addon

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
