### PR TITLE
feat: Helm chart secrets-store-csi-driver-provider-aws

### DIFF
--- a/modules/kubernetes-addons/csi-secrets-store-provider-aws/main.tf
+++ b/modules/kubernetes-addons/csi-secrets-store-provider-aws/main.tf
@@ -1,10 +1,17 @@
 locals {
   name      = try(var.helm_config.name, "csi-secrets-store-provider-aws")
-  namespace = try(var.helm_config.namespace, "secrets-store-csi-driver")
+  namespace = try(var.helm_config.namespace, "kube-system")
+}
+
+resource "kubernetes_namespace_v1" "csi_secrets_store_provider_aws" {
+  count = try(var.helm_config["create_namespace"], true) && local.namespace != "kube-system" ? 1 : 0
+  metadata {
+    name = local.namespace
+  }
 }
 
 module "helm_addon" {
-  source = "../helm-addon"
+  source = "github.com/aws-ia/terraform-aws-eks-blueprints/modules/kubernetes-addons/helm-addon"
 
   # https://github.com/aws/eks-charts/blob/master/stable/csi-secrets-store-provider-aws/Chart.yaml
   helm_config = merge(

--- a/modules/kubernetes-addons/csi-secrets-store-provider-aws/main.tf
+++ b/modules/kubernetes-addons/csi-secrets-store-provider-aws/main.tf
@@ -11,7 +11,7 @@ resource "kubernetes_namespace_v1" "csi_secrets_store_provider_aws" {
 }
 
 module "helm_addon" {
-  source = "github.com/aws-ia/terraform-aws-eks-blueprints/modules/kubernetes-addons/helm-addon"
+  source = "../helm-addon"
 
   # https://github.com/aws/secrets-store-csi-driver-provider-aws/blob/main/charts/secrets-store-csi-driver-provider-aws/Chart.yaml
   helm_config = merge(

--- a/modules/kubernetes-addons/csi-secrets-store-provider-aws/main.tf
+++ b/modules/kubernetes-addons/csi-secrets-store-provider-aws/main.tf
@@ -1,6 +1,6 @@
 locals {
-  name      = try(var.helm_config.name, "csi-secrets-store-provider-aws")
-  namespace = try(var.helm_config.namespace, "kube-system")
+  name      = try(var.helm_config.name, "secrets-store-csi-driver-provider-aws")
+  namespace = try(var.helm_config.namespace, local.name)
 }
 
 resource "kubernetes_namespace_v1" "csi_secrets_store_provider_aws" {
@@ -11,17 +11,17 @@ resource "kubernetes_namespace_v1" "csi_secrets_store_provider_aws" {
 }
 
 module "helm_addon" {
-  source = "../helm-addon"
+  source = "github.com/aws-ia/terraform-aws-eks-blueprints/modules/kubernetes-addons/helm-addon"
 
-  # https://github.com/aws/eks-charts/blob/master/stable/csi-secrets-store-provider-aws/Chart.yaml
+  # https://github.com/aws/secrets-store-csi-driver-provider-aws/blob/main/charts/secrets-store-csi-driver-provider-aws/Chart.yaml
   helm_config = merge(
     {
       name        = local.name
-      chart       = local.name
-      repository  = "https://aws.github.io/eks-charts"
-      version     = "0.0.3"
+      repository  = "https://aws.github.io/secrets-store-csi-driver-provider-aws"
+      chart       = "secrets-store-csi-driver-provider-aws"
+      version     = "0.2.0"
       namespace   = local.namespace
-      description = "A Helm chart to install the Secrets Store CSI Driver and the AWS Key Management Service Provider inside a Kubernetes cluster."
+      description = "A Helm chart for the AWS Secrets Manager and Config Provider for Secret Store CSI Driver"
     },
     var.helm_config
   )

--- a/modules/kubernetes-addons/csi-secrets-store-provider-aws/main.tf
+++ b/modules/kubernetes-addons/csi-secrets-store-provider-aws/main.tf
@@ -1,14 +1,6 @@
 locals {
   name      = try(var.helm_config.name, "csi-secrets-store-provider-aws")
-  namespace = try(var.helm_config.namespace, "kube-system")
-}
-
-resource "kubernetes_namespace_v1" "csi_secrets_store_provider_aws" {
-  count = local.namespace == "kube-system" ? 0 : 1
-
-  metadata {
-    name = local.namespace
-  }
+  namespace = try(var.helm_config.namespace, "secrets-store-csi-driver")
 }
 
 module "helm_addon" {

--- a/modules/kubernetes-addons/csi-secrets-store-provider-aws/main.tf
+++ b/modules/kubernetes-addons/csi-secrets-store-provider-aws/main.tf
@@ -4,6 +4,8 @@ locals {
 }
 
 resource "kubernetes_namespace_v1" "csi_secrets_store_provider_aws" {
+  count = local.namespace == "kube-system" ? 0 : 1
+
   metadata {
     name = local.namespace
   }
@@ -19,7 +21,7 @@ module "helm_addon" {
       chart       = local.name
       repository  = "https://aws.github.io/eks-charts"
       version     = "0.0.3"
-      namespace   = kubernetes_namespace_v1.csi_secrets_store_provider_aws.metadata[0].name
+      namespace   = local.namespace
       description = "A Helm chart to install the Secrets Store CSI Driver and the AWS Key Management Service Provider inside a Kubernetes cluster."
     },
     var.helm_config

--- a/modules/kubernetes-addons/csi-secrets-store-provider-aws/main.tf
+++ b/modules/kubernetes-addons/csi-secrets-store-provider-aws/main.tf
@@ -11,7 +11,7 @@ resource "kubernetes_namespace_v1" "csi_secrets_store_provider_aws" {
 }
 
 module "helm_addon" {
-  source = "github.com/aws-ia/terraform-aws-eks-blueprints/modules/kubernetes-addons/helm-addon"
+  source = "../helm-addon"
 
   # https://github.com/aws/eks-charts/blob/master/stable/csi-secrets-store-provider-aws/Chart.yaml
   helm_config = merge(


### PR DESCRIPTION
### What does this PR do?

- Replaces https://github.com/aws/eks-charts/tree/master/stable/csi-secrets-store-provider-aws in favor of https://github.com/aws/secrets-store-csi-driver-provider-aws/tree/main/charts/secrets-store-csi-driver-provider-aws.
- adds a check to the addon's namespace creation to not create kube-system.

### Motivation

- Resolves #1306 

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR

**Note**: Not all the PRs require a new example and/or doc page. In general:
- Use an existing example when possible to demonstrate a new addons usage
- A new docs page under `docs/add-ons/*` is required for new a new addon

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

This is now working in my own eks cluster with the default `secrets-store-csi-driver` addon (`enable_secrets_store_csi_driver = true`). I have not thoroughly tested - I only have this working currently w/ no helm_config overrides passed to the addon module. Probably should be tested with namespace = "kube-system" for example.
