### PR TITLE
feat: Adding `configuration_values` support to Managed EKS add-ons

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ If you are interested in contributing to EKS Blueprints, see the [Contribution g
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.72 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.47 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.4.1 |
 | <a name="requirement_http"></a> [http](#requirement\_http) | 2.4.1 |
 | <a name="requirement_kubectl"></a> [kubectl](#requirement\_kubectl) | >= 1.14 |
@@ -60,7 +60,7 @@ If you are interested in contributing to EKS Blueprints, see the [Contribution g
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.72 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.47 |
 | <a name="provider_http"></a> [http](#provider\_http) | 2.4.1 |
 | <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | >= 2.10 |
 

--- a/docs/add-ons/managed-add-ons.md
+++ b/docs/add-ons/managed-add-ons.md
@@ -18,7 +18,7 @@ Note: EKS managed Add-ons can be converted to self-managed add-on with `preserve
 This option makes the add-on a self-managed add-on, rather than an Amazon EKS add-on.
 There is no downtime while deleting EKS managed Add-ons when `preserve=true`. This is a default option for `enable_amazon_eks_vpc_cni` , `enable_amazon_eks_coredns` and `enable_amazon_eks_kube_proxy`.
 
-Checkout this [doc](https://docs.aws.amazon.com/eks/latest/userguide/managing-vpc-cni.html#updating-vpc-cni-eks-add-on) for more details.
+Checkout this [doc](https://docs.aws.amazon.com/eks/latest/userguide/managing-vpc-cni.html#updating-vpc-cni-eks-add-on) for more details. Custom add-on configuration can be passed using [configuration_values](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_addon) as a single JSON string while creating or updating the add-on.
 
 ```
 # EKS Addons
@@ -33,7 +33,13 @@ Checkout this [doc](https://docs.aws.amazon.com/eks/latest/userguide/managing-vp
     service_account_role_arn = ""
     preserve                 = true
     additional_iam_policies  = []
-    tags                     = {}
+    configuration_values = jsonencode({
+      env = {
+        ENABLE_PREFIX_DELEGATION = "true"
+        WARM_PREFIX_TARGET       = "1"
+      }
+    })
+    tags = {}
   }
 
   enable_amazon_eks_coredns = true # default is false
@@ -47,6 +53,7 @@ Checkout this [doc](https://docs.aws.amazon.com/eks/latest/userguide/managing-vp
     service_account_role_arn = ""
     preserve                 = true
     additional_iam_policies  = []
+    configuration_values     = ""
     tags                     = {}
   }
 
@@ -61,6 +68,7 @@ Checkout this [doc](https://docs.aws.amazon.com/eks/latest/userguide/managing-vp
     service_account_role_arn = ""
     preserve                 = true
     additional_iam_policies  = []
+    configuration_values     = ""
     tags                     = {}
   }
 
@@ -74,6 +82,7 @@ Checkout this [doc](https://docs.aws.amazon.com/eks/latest/userguide/managing-vp
     namespace                = "kube-system"
     additional_iam_policies  = []
     service_account_role_arn = ""
+    configuration_values     = ""
     tags                     = {}
   }
 ```

--- a/modules/kubernetes-addons/aws-coredns/main.tf
+++ b/modules/kubernetes-addons/aws-coredns/main.tf
@@ -18,6 +18,7 @@ resource "aws_eks_addon" "coredns" {
   resolve_conflicts        = try(var.addon_config.resolve_conflicts, "OVERWRITE")
   service_account_role_arn = try(var.addon_config.service_account_role_arn, null)
   preserve                 = try(var.addon_config.preserve, true)
+  configuration_values     = try(var.addon_config.configuration_values, null)
 
   tags = merge(
     var.addon_context.tags,

--- a/modules/kubernetes-addons/aws-ebs-csi-driver/main.tf
+++ b/modules/kubernetes-addons/aws-ebs-csi-driver/main.tf
@@ -21,6 +21,7 @@ resource "aws_eks_addon" "aws_ebs_csi_driver" {
   resolve_conflicts        = try(var.addon_config.resolve_conflicts, "OVERWRITE")
   service_account_role_arn = local.create_irsa ? module.irsa_addon[0].irsa_iam_role_arn : try(var.addon_config.service_account_role_arn, null)
   preserve                 = try(var.addon_config.preserve, true)
+  configuration_values     = try(var.addon_config.configuration_values, null)
 
   tags = merge(
     var.addon_context.tags,

--- a/modules/kubernetes-addons/aws-kube-proxy/main.tf
+++ b/modules/kubernetes-addons/aws-kube-proxy/main.tf
@@ -15,6 +15,7 @@ resource "aws_eks_addon" "kube_proxy" {
   resolve_conflicts        = try(var.addon_config.resolve_conflicts, "OVERWRITE")
   service_account_role_arn = try(var.addon_config.service_account_role_arn, null)
   preserve                 = try(var.addon_config.preserve, true)
+  configuration_values     = try(var.addon_config.configuration_values, null)
 
   tags = merge(
     var.addon_context.tags,

--- a/modules/kubernetes-addons/aws-vpc-cni/main.tf
+++ b/modules/kubernetes-addons/aws-vpc-cni/main.tf
@@ -18,6 +18,7 @@ resource "aws_eks_addon" "vpc_cni" {
   resolve_conflicts        = try(var.addon_config.resolve_conflicts, "OVERWRITE")
   service_account_role_arn = local.create_irsa ? module.irsa_addon[0].irsa_iam_role_arn : try(var.addon_config.service_account_role_arn, null)
   preserve                 = try(var.addon_config.preserve, true)
+  configuration_values     = try(var.addon_config.configuration_values, null)
 
   tags = merge(
     var.addon_context.tags,

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.72"
+      version = ">= 4.47"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"


### PR DESCRIPTION
### What does this PR do?

- Adding new `configuration_values` field to EKS Managed addons. This feature allows users to modify the addon config values during the creation and update. See the [link](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_addon#example-add-on-usage-with-custom-configuration_values) for more details


🛑 Please open an issue first to discuss any significant work and flesh out details/direction - we would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/aws-ia/terraform-aws-eks-blueprints/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

<!-- A brief description of the change being made with this pull request. -->
 Closes #1401

### Motivation

<!-- What inspired you to submit this pull request? -->
- Resolves #<issue-number>

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [x] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR

**Note**: Not all the PRs require a new example and/or doc page. In general:
- Use an existing example when possible to demonstrate a new addons usage
- A new docs page under `docs/add-ons/*` is required for new a new addon

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
