### PR TITLE
Fix fargate profile for loop examples

### DIFF
--- a/examples/fargate-serverless/main.tf
+++ b/examples/fargate-serverless/main.tf
@@ -87,7 +87,7 @@ module "eks" {
 
   fargate_profiles = merge(
     { for i in range(3) :
-      "app-wildcard-${element(split("-", local.azs[i]), 2)}" => {
+      "app-wildcard-${element(split(",", local.azs[i]), 2)}" => {
         selectors = [
           { namespace = "app-*" }
         ]
@@ -96,7 +96,7 @@ module "eks" {
       }
     },
     { for i in range(3) :
-      "kube-system-${element(split("-", local.azs[i]), 2)}" => {
+      "kube-system-${element(split(",", local.azs[i]), 2)}" => {
         selectors = [
           { namespace = "kube-system" }
         ]


### PR DESCRIPTION
Split az array on comma instead of dash

### What does this PR do?

Changes examples that create multiple fargate profiles to split the az array on the correct character.

🛑 Please open an issue first to discuss any significant work and flesh out details/direction - we would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/aws-ia/terraform-aws-eks-blueprints/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

<!-- A brief description of the change being made with this pull request. -->

### Motivation

You get an error if you try to run the examples with fargate profiles
```
Error: Duplicate object key
│ 
│   on main.tf line 90, in module "eks":
│   89:     { for i in range(3) :
│   90:       "app-wildcard-${element(split("-", local.azs[i]), 2)}" => {
│   91:         selectors = [
│   92:           { namespace = "app-*" }
│   93:         ]
│   94:         # We want to create a profile per AZ for high availability
│   95:         subnet_ids = [element(module.vpc.private_subnets, i)]
│   96:       }
│   97:     },
│     ├────────────────
│     │ local.azs is list of string with 3 elements
│ 
│ Two different items produced the key "app-wildcard-2" in this 'for' expression. If duplicates are expected, use the ellipsis (...) after the value expression to enable grouping by key.
```

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR

**Note**: Not all the PRs require a new example and/or doc page. In general:
- Use an existing example when possible to demonstrate a new addons usage
- A new docs page under `docs/add-ons/*` is required for new a new addon

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
