### PR TITLE
fix: Exclude correct example folder path

### DIFF
--- a/.github/scripts/plan-examples.py
+++ b/.github/scripts/plan-examples.py
@@ -16,7 +16,7 @@ def get_examples():
         'examples/fully-private-eks-cluster/add-ons',
         'examples/ai-ml/ray',  # excluded until #887 is fixed,
         'examples/crossplane' #example removed
-        'examples/upgrade/blue-green-route53'
+        'examples/upgrade/blue-green-route53/core-infra'
     }
 
     projects = {


### PR DESCRIPTION
### What does this PR do?
- Correcting example folder path to exclude for terraform plan CI check.
 
🛑 Please open an issue first to discuss any significant work and flesh out details/direction - we would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/aws-ia/terraform-aws-eks-blueprints/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

<!-- A brief description of the change being made with this pull request. -->

### Motivation

<!-- What inspired you to submit this pull request? -->
- PRs showing failure on CI because the terraform plan action is not skipping the blue-green-route53 example properly.
examples:
https://github.com/aws-ia/terraform-aws-eks-blueprints/actions/runs/4078739311/jobs/7029677318
https://github.com/aws-ia/terraform-aws-eks-blueprints/actions/runs/4013393770/jobs/6923388512


### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR

**Note**: Not all the PRs require a new example and/or doc page. In general:
- Use an existing example when possible to demonstrate a new addons usage
- A new docs page under `docs/add-ons/*` is required for new a new addon

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
