### PR TITLE
feat: Add optional path variable for the platform_team_eks_access aws_iam_policy

### DIFF
--- a/modules/aws-eks-teams/README.md
+++ b/modules/aws-eks-teams/README.md
@@ -164,6 +164,7 @@ No modules.
 | <a name="input_application_teams"></a> [application\_teams](#input\_application\_teams) | Map of maps of teams to create | `any` | `{}` | no |
 | <a name="input_eks_cluster_id"></a> [eks\_cluster\_id](#input\_eks\_cluster\_id) | EKS Cluster name | `string` | n/a | yes |
 | <a name="input_iam_role_permissions_boundary"></a> [iam\_role\_permissions\_boundary](#input\_iam\_role\_permissions\_boundary) | ARN of the policy that is used to set the permissions boundary for the IAM role | `string` | `null` | no |
+| <a name="input_path"></a> [path](#input\_path) | Path in which to create the platform\_team\_eks\_access policy | `string` | `"/"` | no |
 | <a name="input_platform_teams"></a> [platform\_teams](#input\_platform\_teams) | Map of maps of teams to create | `any` | `{}` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | `{}` | no |
 

--- a/modules/aws-eks-teams/main.tf
+++ b/modules/aws-eks-teams/main.tf
@@ -205,7 +205,7 @@ resource "aws_iam_role" "platform_team" {
 resource "aws_iam_policy" "platform_team_eks_access" {
   count       = length(var.platform_teams) > 0 ? 1 : 0
   name        = "${var.eks_cluster_id}-PlatformTeamEKSAccess"
-  path        = "/"
+  path        = var.path
   description = "Platform Team EKS Console Access"
   policy      = data.aws_iam_policy_document.platform_team_eks_access[0].json
   tags        = var.tags

--- a/modules/aws-eks-teams/variables.tf
+++ b/modules/aws-eks-teams/variables.tf
@@ -26,3 +26,9 @@ variable "iam_role_permissions_boundary" {
   type        = string
   default     = null
 }
+
+variable "path" {
+  description = "Path in which to create the platform_team_eks_access policy"
+  type        = string
+  default     = "/"
+}


### PR DESCRIPTION

### What does this PR do?

Adds an optional path variable for the `platform_team_eks_access` `aws_iam_policy`.

### Motivation

Needed a custom path for the resource aws_iam_policy.platform_team_eks_access, since the roles used to deploy the resources have strict permissions on certain policy paths.

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR

**Note**: Not all the PRs require a new example and/or doc page. In general:
- Use an existing example when possible to demonstrate a new addons usage
- A new docs page under `docs/add-ons/*` is required for new a new addon

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
