### PR TITLE
feat: Make kube-prometheus-stack namespace configurable

### DIFF
--- a/modules/kubernetes-addons/kube-prometheus-stack/main.tf
+++ b/modules/kubernetes-addons/kube-prometheus-stack/main.tf
@@ -8,6 +8,8 @@ locals {
 }
 
 resource "kubernetes_namespace_v1" "prometheus" {
+  count = try(var.helm_config.create_namespace, true) ? 1 : 0
+
   metadata {
     name = local.namespace
   }
@@ -23,7 +25,7 @@ module "helm_addon" {
       chart      = local.name
       repository = "https://prometheus-community.github.io/helm-charts"
       version    = "41.6.1"
-      namespace  = kubernetes_namespace_v1.prometheus.metadata[0].name
+      namespace  = try(kubernetes_namespace_v1.prometheus[0].metadata[0].name, local.namespace)
       values = [templatefile("${path.module}/values.yaml", {
         aws_region = var.addon_context.aws_region_name
       })]


### PR DESCRIPTION
### What does this PR do?

Building namespaces should be optional in kubernetes-addons. kube-prometheus-stack creates a namespace as part of it's deployment.

### Motivation

- Resolves #1056

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [x] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
