### PR TITLE
fix: Use `most_recent = true` when using VPC CNI custom configuration

### DIFF
--- a/examples/ipv4-prefix-delegation/main.tf
+++ b/examples/ipv4-prefix-delegation/main.tf
@@ -59,6 +59,7 @@ module "eks" {
       # the addon is configured before data plane compute resources are created
       # See README for further details
       before_compute = true
+      most_recent    = true # To ensure access to the latest settings provided
       configuration_values = jsonencode({
         env = {
           # Reference docs https://docs.aws.amazon.com/eks/latest/userguide/cni-increase-ip-addresses.html

--- a/examples/vpc-cni-custom-networking/main.tf
+++ b/examples/vpc-cni-custom-networking/main.tf
@@ -67,6 +67,7 @@ module "eks" {
       # the addon is configured before data plane compute resources are created
       # See README for further details
       before_compute = true
+      most_recent    = true # To ensure access to the latest settings provided
       configuration_values = jsonencode({
         env = {
           # Reference https://aws.github.io/aws-eks-best-practices/reliability/docs/networkmanagement/#cni-custom-networking


### PR DESCRIPTION
### What does this PR do?

- Use `most_recent = true` when using VPC CNI custom configuration

### Motivation

- Without using the most recent, the default version of the VPC CNI pulled may or may not have support for the environment variable versions used. This ensures that the latest addon version is used which has access to all of the environment variables used in the examples

### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
