### PR TITLE
chore: Add missing targets to `terraform apply` in `fully-private-cluster` example README

### DIFF
--- a/examples/fully-private-cluster/README.md
+++ b/examples/fully-private-cluster/README.md
@@ -16,7 +16,7 @@ To provision this example:
 
 ```sh
 terraform init
-terraform apply -target module.vpc
+terraform apply -target module.vpc -target module.vpc_endpoints -target module.vpc_endpoints_sg
 terraform apply -target module.eks
 terraform apply
 ```


### PR DESCRIPTION
### What does this PR do?

Add missing targets (`vpc_endpoints` and `vpc_endpoints_sg` ) to deploy in README

### Motivation

Lead readers to deploy `fully-private-cluster` example successfully

### Notes

I tried this edited command and confirmed that it is OK.

