### PR TITLE
docs: Remove "Node Groups" section and mention `terraform-aws-modules`

### DIFF
--- a/docs/.pages
+++ b/docs/.pages
@@ -2,7 +2,6 @@ nav:
     - Overview: index.md
     - Getting Started: getting-started.md
     - Core Concepts: core-concepts.md
-    - Node Groups: node-groups.md
     - IAM: iam
     - Teams: teams.md
     - Modules: modules

--- a/docs/core-concepts.md
+++ b/docs/core-concepts.md
@@ -12,7 +12,9 @@ This document provides a high level overview of the Core Concepts that are embed
 
 ## Cluster
 
-A `cluster` is simply an EKS cluster. EKS Blueprints provides for customizing the compute options you leverage with your `clusters`. The framework currently supports `EC2`, `Fargate` and `BottleRocket` instances. It also supports managed and self-managed node groups. To specify the type of compute you want to use for your `cluster`, you use the `managed_node_groups`, `self_managed_nodegroups`, or `fargate_profiles` variables.
+A `cluster` is simply an EKS cluster. EKS Blueprints provides for customizing the compute options you leverage with your `clusters`. The framework currently supports `EC2`, `Fargate` and `BottleRocket` instances. It also supports managed and self-managed node groups.
+
+We rely on [`terraform-aws-modules/eks/aws`](https://registry.terraform.io/modules/terraform-aws-modules/eks/aws/latest) to configure `clusters`. See our [examples](getting-started.md) to see how `terraform-aws-modules/eks/aws` is configured for EKS Blueprints.
 
 ## Add-on
 


### PR DESCRIPTION
### What does this PR do?

As part of v5 migration, https://github.com/aws-ia/terraform-aws-eks-blueprints/pull/1428 removes "Node Groups" page, but forgot to remove the page button.

This PR removes the "Node Groups" button in the documentation page.

Also, new users likely lost what to do when configuring a cluster.

We at least need to mention that we use `terraform-aws-modules/eks/aws` to avoid confusion.

### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [x] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
