### PR TITLE
fix: Correct metadata for self-managed CoreDNS

### DIFF
--- a/modules/kubernetes-addons/aws-coredns/README.md
+++ b/modules/kubernetes-addons/aws-coredns/README.md
@@ -22,9 +22,18 @@ To enable and modify the EKS managed addon for CoreDNS, you can reference the fo
 
 ```sh
 kubectl --namespace kube-system delete deployment coredns
+
 kubectl --namespace kube-system annotate --overwrite service kube-dns meta.helm.sh/release-name=coredns
 kubectl --namespace kube-system annotate --overwrite service kube-dns meta.helm.sh/release-namespace=kube-system
 kubectl --namespace kube-system label --overwrite service kube-dns app.kubernetes.io/managed-by=Helm
+
+kubectl --namespace kube-system annotate --overwrite configmap coredns meta.helm.sh/release-name=coredns
+kubectl --namespace kube-system annotate --overwrite configmap coredns meta.helm.sh/release-namespace=kube-system
+kubectl --namespace kube-system label --overwrite configmap coredns app.kubernetes.io/managed-by=Helm eks.amazonaws.com/component-
+
+kubectl --namespace kube-system annotate --overwrite serviceaccount coredns meta.helm.sh/release-name=coredns
+kubectl --namespace kube-system annotate --overwrite serviceaccount coredns meta.helm.sh/release-namespace=kube-system
+kubectl --namespace kube-system label --overwrite serviceaccount coredns app.kubernetes.io/managed-by=Helm eks.amazonaws.com/component-
 ```
 
 See the [`fargate-serverless`](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples/fargate-serverless) example where the self-managed CoreDNS addon is used to provision CoreDNS on a serverless cluster (data plane).
@@ -86,6 +95,7 @@ By default, EKS provisions CoreDNS with a replica count of 2. As the cluster siz
 | Name | Type |
 |------|------|
 | [aws_eks_addon.coredns](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_addon) | resource |
+| [null_resource.modify_coredns_metadata](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [null_resource.modify_kube_dns](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [null_resource.remove_default_coredns_deployment](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [time_sleep.this](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |


### PR DESCRIPTION
### What does this PR do?

Correct the CoreDNS metadata such that the following works as expected:

```terraform
module "eks_blueprints_kubernetes_addons" {
  enable_amazon_eks_coredns         = false
  enable_self_managed_coredns       = true
  remove_default_coredns_deployment = true
}
```

### Motivation

As of v4.24.0, Helm complains about mismatched metadata, requiring manual action to be able to switch to self-managed CoreDNs.

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
