### PR TITLE
feat: Update `stateful` example to show multi-volume, instance store, gp3, encryption, and containerd dedicated volume

### DIFF
--- a/examples/stateful/README.md
+++ b/examples/stateful/README.md
@@ -1,13 +1,42 @@
-# Stateful EKS Cluster
+# EKS Cluster for Stateful Workloads
 
 ## Features
 
-- [velero](https://github.com/vmware-tanzu/velero) for cluster backup and restore
+Please note: not all of the features listed below are required for stateful workloads on EKS. We are simply grouping together a set of features that are commonly encountered when managing stateful workloads. Users are encouraged to only enable the features that are required for their workload(s) and use case(s).
 
-## TODO
+### [velero](https://github.com/vmware-tanzu/velero)
 
-- Persistent volumes
-- Datastores (RDBMs, cache, queue, etc.)
+(From the project documentation)
+`velero` (formerly Heptio Ark) gives you tools to back up and restore your Kubernetes cluster resources and persistent volumes. You can run Velero with a public cloud platform or on-premises. Velero lets you:
+
+- Take backups of your cluster and restore in case of loss.
+- Migrate cluster resources to other clusters.
+- Replicate your production cluster to development and testing clusters.
+
+### EBS & EFS CSI Drivers
+
+- A second storage class for `gp3` backed volumes has been added and made the default over the EKS default `gp2` storage class (`gp2` storage class remains in the cluster for use, but it is no longer the default storage class)
+- A standard implementation of the EFS CSI driver
+
+### EKS Managed Nodegroup w/ Multiple Volumes
+
+An EKS managed nodegroup that utilizes multiple EBS volumes. The primary use case demonstrated in this example is a second volume that is dedicated to the `containerd` runtime to ensure the root volume is not filled up nor has its I/O exhausted to ensure the instance does not reach a degraded state. The `containerd` directories are mapped to this volume. You can read more about this recommendation in our [EKS best practices guide](https://aws.github.io/aws-eks-best-practices/scalability/docs/data-plane/#use-multiple-ebs-volumes-for-containers) and refer to the `containerd` [documentation](https://github.com/containerd/containerd/blob/main/docs/ops.md#base-configuration) for more information. The update for `containerd` to use the second volume is managed through the provided user data.
+
+In addition, the following properties are configured on the nodegroup volumes:
+
+- EBS encryption using a customer managed key (CMK)
+- Configuring the volumes to use GP3 storage
+
+### EKS Managed Nodegroup w/ Instance Store Volume(s)
+
+An EKS managed nodegroup that utilizes EC2 instances with ephemeral instance store(s). Instance stores are ideal for temporary storage of information that changes frequently, such as buffers, caches, scratch data, and other temporary content, or for data that is replicated across a fleet of instances. You can read more about instance stores in the [AWS documentation](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/InstanceStorage.html); and be sure to check out the [`Block device mapping instance store caveats`](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/block-device-mapping-concepts.html#instance-block-device-mapping) section as well which covers why the example has provided user data for mounting the instance store(s). The size and number of instance stores will vary based on the EC2 instance type and class.
+
+In addition, the following properties are configured on the nodegroup volumes:
+
+- EBS encryption using a customer managed key (CMK)
+- Configuring the volumes to use GP3 storage
+
+## Prerequisites:
 
 Ensure that you have the following tools installed locally:
 
@@ -19,16 +48,94 @@ Ensure that you have the following tools installed locally:
 
 To provision this example:
 
-```bash
+```sh
 terraform init
 terraform apply
 ```
 
+Enter `yes` at command prompt to apply
+
 ## Validate
 
-- For validating `velero` see [here](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/modules/kubernetes-addons/velero#validate)
+For validating `velero` see [here](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/modules/kubernetes-addons/velero#validate)
 
-Enter `yes` at command prompt to apply
+The following command will update the `kubeconfig` on your local machine and allow you to interact with your EKS Cluster using `kubectl` to validate the deployment.
+
+1. Run `update-kubeconfig` command:
+
+```sh
+aws eks --region <REGION> update-kubeconfig --name <CLUSTER_NAME>
+```
+
+2. List the storage classes to view that `efs`, `gp2`, and `gp3` classes are present and `gp3` is the default storage class
+
+```sh
+kubectl get storageclasses
+NAME            PROVISIONER             RECLAIMPOLICY   VOLUMEBINDINGMODE      ALLOWVOLUMEEXPANSION   AGE
+efs             efs.csi.aws.com         Delete          Immediate              true                   2m19s
+gp2             kubernetes.io/aws-ebs   Delete          WaitForFirstConsumer   false                  15m
+gp3 (default)   ebs.csi.aws.com         Delete          WaitForFirstConsumer   true                   2m19s
+```
+
+3. From an instance launched with instance store(s), check that the instance store has been mounted correctly. To verify, first install the `nvme-cli` tool and then use it to verify. To verify, you can access the instance using SSM Session Manager:
+
+```sh
+# Install the nvme-cli tool
+sudo yum install nvme-cli -y
+
+# Show NVMe volumes attached
+sudo nvme list
+
+# Output should look like below - notice the model is `EC2 NVMe Instance Storage` for the instance store
+Node             SN                   Model                                    Namespace Usage                      Format           FW Rev
+---------------- -------------------- ---------------------------------------- --------- -------------------------- ---------------- --------
+/dev/nvme0n1     vol0546d3c3b0af0bf6d Amazon Elastic Block Store               1          25.77  GB /  25.77  GB    512   B +  0 B   1.0
+/dev/nvme1n1     AWS24BBF51AF55097008 Amazon EC2 NVMe Instance Storage         1          75.00  GB /  75.00  GB    512   B +  0 B   0
+
+# Show disks, their partitions and mounts
+sudo lsblk
+
+# Output should look like below
+NAME          MAJ:MIN RM  SIZE RO TYPE MOUNTPOINT
+nvme0n1       259:0    0   24G  0 disk
+├─nvme0n1p1   259:2    0   24G  0 part /
+└─nvme0n1p128 259:3    0    1M  0 part
+nvme1n1       259:1    0 69.9G  0 disk /local1 # <--- this is the instance store
+```
+
+4. From an instance launched with multiple volume(s), check that the instance store has been mounted correctly. To verify, first install the `nvme-cli` tool and then use it to verify. To verify, you can access the instance using SSM Session Manager:
+
+```sh
+# Install the nvme-cli tool
+sudo yum install nvme-cli -y
+
+# Show NVMe volumes attached
+sudo nvme list
+
+# Output should look like below, where /dev/nvme0n1 is the root volume and /dev/nvme1n1 is the second, additional volume
+Node             SN                   Model                                    Namespace Usage                      Format           FW Rev
+---------------- -------------------- ---------------------------------------- --------- -------------------------- ---------------- --------
+/dev/nvme0n1     vol0cd37dab9e4a5c184 Amazon Elastic Block Store               1          68.72  GB /  68.72  GB    512   B +  0 B   1.0
+/dev/nvme1n1     vol0ad3629c159ee869c Amazon Elastic Block Store               1          25.77  GB /  25.77  GB    512   B +  0 B   1.0
+```
+
+5. From the same instance used in step 4, check that the containerd directories are using the second `/dev/nvme1n1` volume:
+
+```sh
+df /var/lib/containerd/
+
+# Output should look like below, which shows the directory on the /dev/nvme1n1 volume and NOT on /dev/nvme0n1 (root volume)
+Filesystem     1K-blocks    Used Available Use% Mounted on
+/dev/nvme1n1    24594768 2886716  20433380  13% /var/lib/containerd
+```
+
+```sh
+df /run/containerd/
+
+# Output should look like below, which shows the directory on the /dev/nvme1n1 volume and NOT on /dev/nvme0n1 (root volume)
+Filesystem     1K-blocks    Used Available Use% Mounted on
+/dev/nvme1n1    24594768 2886716  20433380  13% /run/containerd
+```
 
 ## Destroy
 

--- a/examples/stateful/main.tf
+++ b/examples/stateful/main.tf
@@ -20,6 +20,7 @@ data "aws_eks_cluster_auth" "this" {
   name = module.eks.cluster_name
 }
 
+data "aws_caller_identity" "current" {}
 data "aws_availability_zones" "available" {}
 
 locals {
@@ -28,6 +29,9 @@ locals {
 
   vpc_cidr = "10.0.0.0/16"
   azs      = slice(data.aws_availability_zones.available.names, 0, 3)
+
+  # To ensure name is consistent between whats created and the user data script
+  second_volume_name = "/dev/xvdb"
 
   tags = {
     Blueprint  = local.name
@@ -58,13 +62,123 @@ module "eks" {
   vpc_id     = module.vpc.vpc_id
   subnet_ids = module.vpc.private_subnets
 
+  eks_managed_node_group_defaults = {
+    iam_role_additional_policies = {
+      # Not required, but used in the example to access the nodes to inspect mounted volumes
+      AmazonSSMManagedInstanceCore = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+    }
+  }
+
   eks_managed_node_groups = {
-    initial = {
-      instance_types = ["m5.large"]
+    multi-volume = {
+      instance_types = ["c5.large"]
 
       min_size     = 1
       max_size     = 3
       desired_size = 1
+
+      block_device_mappings = {
+        # Root volume
+        xvda = {
+          device_name = "/dev/xvda"
+          ebs = {
+            volume_type           = "gp3"
+            encrypted             = true
+            kms_key_id            = module.ebs_kms_key.key_arn
+            delete_on_termination = true
+          }
+        }
+        xvdb = {
+          # This will be used for containerd's data directory
+          device_name = local.second_volume_name
+          ebs = {
+            volume_size           = 24
+            volume_type           = "gp3"
+            iops                  = 3000
+            encrypted             = true
+            kms_key_id            = module.ebs_kms_key.key_arn
+            delete_on_termination = true
+          }
+        }
+      }
+
+      # This user data mounts the containerd directories to the second EBS volume which
+      # is dedicated to just contianerd. You can read more about the practice and why
+      # here https://aws.github.io/aws-eks-best-practices/scalability/docs/data-plane/#use-multiple-ebs-volumes-for-containers
+      # and https://github.com/containerd/containerd/blob/main/docs/ops.md#base-configuration
+      pre_bootstrap_user_data = <<-EOT
+        # Wait for second volume to attach before trying to mount paths
+        TOKEN=$(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
+        EC2_INSTANCE_ID=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" -v http://169.254.169.254/latest/meta-data/instance-id)
+        DATA_STATE="unknown"
+        until [ "$${DATA_STATE}" == "attached" ]; do
+          DATA_STATE=$(aws ec2 describe-volumes \
+            --region ${local.region} \
+            --filters \
+                Name=attachment.instance-id,Values=$${EC2_INSTANCE_ID} \
+                Name=attachment.device,Values=${local.second_volume_name} \
+            --query Volumes[].Attachments[].State \
+            --output text)
+
+          sleep 5
+        done
+
+        # Mount the containerd directories to the 2nd volume
+        SECOND_VOL=$(lsblk -o NAME,TYPE -d | awk '/disk/ {print $1}' | sed -n '2 p')
+        systemctl stop containerd
+        mkfs -t ext4 /dev/$${SECOND_VOL}
+        rm -rf /var/lib/containerd/*
+        rm -rf /run/containerd/*
+
+        mount /dev/$${SECOND_VOL} /var/lib/containerd/
+        mount /dev/$${SECOND_VOL} /run/containerd/
+        systemctl start containerd
+      EOT
+    }
+
+    instance-store = {
+      instance_types = ["m5ad.large"]
+
+      min_size     = 1
+      max_size     = 3
+      desired_size = 1
+
+      block_device_mappings = {
+        # Root volume
+        xvda = {
+          device_name = "/dev/xvda"
+          ebs = {
+            volume_size           = 24
+            volume_type           = "gp3"
+            iops                  = 3000
+            encrypted             = true
+            kms_key_id            = module.ebs_kms_key.key_arn
+            delete_on_termination = true
+          }
+        }
+      }
+
+      # The virtual device name (ephemeralN). Instance store volumes are numbered
+      # starting from 0. An instance type with 2 available instance store volumes
+      # can specify mappings for ephemeral0 and ephemeral1. The number of available
+      # instance store volumes depends on the instance type. After you connect to
+      # the instance, you must mount the volume - here, we are using user data to automatically
+      # mount the volume(s) during instance creation.
+      #
+      # NVMe instance store volumes are automatically enumerated and assigned a device
+      # name. Including them in your block device mapping has no effect.
+      pre_bootstrap_user_data = <<-EOT
+        IDX=1
+        DEVICES=$(lsblk -o NAME,TYPE -dsn | awk '/disk/ {print $1}')
+        for DEV in $DEVICES
+        do
+          mkfs.xfs /dev/$${DEV}
+          mkdir -p /local$${IDX}
+          echo /dev/$${DEV} /local$${IDX} xfs defaults,noatime 1 2 >> /etc/fstab
+          IDX=$(($${IDX} + 1))
+        done
+        mount -a
+      EOT
     }
   }
 
@@ -89,18 +203,80 @@ module "eks_blueprints_kubernetes_addons" {
   enable_velero           = true
   velero_backup_s3_bucket = module.velero_backup_s3_bucket.s3_bucket_id
 
-  enable_aws_efs_csi_driver = true
-
-  enable_self_managed_aws_ebs_csi_driver = true
-  self_managed_aws_ebs_csi_driver_helm_config = {
-    set_values = [
-      {
-        name  = "node.tolerateAllTaints"
-        value = "true"
-    }]
-  }
+  enable_amazon_eks_aws_ebs_csi_driver = true
+  enable_aws_efs_csi_driver            = true
 
   tags = local.tags
+}
+
+################################################################################
+# Storage Classes
+################################################################################
+
+resource "kubernetes_annotations" "gp2" {
+  api_version = "storage.k8s.io/v1"
+  kind        = "StorageClass"
+  force       = "true"
+
+  metadata {
+    name = "gp2"
+  }
+
+  annotations = {
+    # Modify annotations to remove gp2 as default storage class still reatain the class
+    "storageclass.kubernetes.io/is-default-class" = "false"
+  }
+
+  depends_on = [
+    module.eks_blueprints_kubernetes_addons
+  ]
+}
+
+resource "kubernetes_storage_class_v1" "gp3" {
+  metadata {
+    name = "gp3"
+
+    annotations = {
+      # Annotation to set gp3 as default storage class
+      "storageclass.kubernetes.io/is-default-class" = "true"
+    }
+  }
+
+  storage_provisioner    = "ebs.csi.aws.com"
+  allow_volume_expansion = true
+  reclaim_policy         = "Delete"
+  volume_binding_mode    = "WaitForFirstConsumer"
+
+  parameters = {
+    encrypted = true
+    fsType    = "ext4"
+    type      = "gp3"
+  }
+
+  depends_on = [
+    module.eks_blueprints_kubernetes_addons
+  ]
+}
+
+resource "kubernetes_storage_class_v1" "efs" {
+  metadata {
+    name = "efs"
+  }
+
+  storage_provisioner = "efs.csi.aws.com"
+  parameters = {
+    provisioningMode = "efs-ap" # Dynamic provisioning
+    fileSystemId     = module.efs.id
+    directoryPerms   = "700"
+  }
+
+  mount_options = [
+    "iam"
+  ]
+
+  depends_on = [
+    module.eks_blueprints_kubernetes_addons
+  ]
 }
 
 ################################################################################
@@ -141,18 +317,12 @@ module "vpc" {
   tags = local.tags
 }
 
-resource "random_string" "random" {
-  length  = 16
-  special = false
-  upper   = false
-}
-
 #tfsec:ignore:*
 module "velero_backup_s3_bucket" {
   source  = "terraform-aws-modules/s3-bucket/aws"
   version = "~> 3.0"
 
-  bucket = "${local.name}-${random_string.random.result}"
+  bucket_prefix = "${local.name}-"
 
   # Allow deletion of non-empty bucket
   # NOTE: This is enabled for example usage only, you should not enable this for production workloads
@@ -211,43 +381,23 @@ module "efs" {
   tags = local.tags
 }
 
-resource "kubernetes_storage_class_v1" "gp3" {
-  metadata {
-    name = "gp3"
-  }
+module "ebs_kms_key" {
+  source  = "terraform-aws-modules/kms/aws"
+  version = "~> 1.5"
 
-  storage_provisioner    = "ebs.csi.aws.com"
-  allow_volume_expansion = true
-  reclaim_policy         = "Delete"
-  volume_binding_mode    = "WaitForFirstConsumer"
-  parameters = {
-    encrypted = true
-    fsType    = "ext4"
-    type      = "gp3"
-  }
+  description = "Customer managed key to encrypt EKS managed node group volumes"
 
-  depends_on = [
-    module.eks_blueprints_kubernetes_addons
-  ]
-}
-
-resource "kubernetes_storage_class_v1" "efs" {
-  metadata {
-    name = "efs"
-  }
-
-  storage_provisioner = "efs.csi.aws.com"
-  parameters = {
-    provisioningMode = "efs-ap" # Dynamic provisioning
-    fileSystemId     = module.efs.id
-    directoryPerms   = "700"
-  }
-
-  mount_options = [
-    "iam"
+  # Policy
+  key_administrators = [data.aws_caller_identity.current.arn]
+  key_service_roles_for_autoscaling = [
+    # required for the ASG to manage encrypted volumes for nodes
+    "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling",
+    # required for the cluster / persistentvolume-controller to create encrypted PVCs
+    module.eks.cluster_iam_role_arn,
   ]
 
-  depends_on = [
-    module.eks_blueprints_kubernetes_addons
-  ]
+  # Aliases
+  aliases = ["eks/${local.name}/ebs"]
+
+  tags = local.tags
 }


### PR DESCRIPTION
### What does this PR do?

- Update `stateful` example to demonstrate: 
  - Multiple volumes; second volume to be dedicated to the `containerd` runtime
  - Instance store with mountaing via user data
  - Setting EBS volume storage type `gp3`
  - EBS volume encryption using CMK (customer managed KMS key)
  - Add `gp3` storage class and setting as the default storage class provider

### Motivation

<!-- What inspired you to submit this pull request? -->
- Resolves #1261

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [x] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
