### PR TITLE
feat: Add optional path variable for the aws_load_balancer_controller aws_iam_policy

### DIFF
--- a/modules/kubernetes-addons/README.md
+++ b/modules/kubernetes-addons/README.md
@@ -172,7 +172,6 @@
 | <a name="input_custom_image_registry_uri"></a> [custom\_image\_registry\_uri](#input\_custom\_image\_registry\_uri) | Custom image registry URI map of `{region = dkr.endpoint }` | `map(string)` | `{}` | no |
 | <a name="input_data_plane_wait_arn"></a> [data\_plane\_wait\_arn](#input\_data\_plane\_wait\_arn) | Addon deployment will not proceed until this value is known. Set to node group/Fargate profile ARN to wait for data plane to be ready before provisioning addons | `string` | `""` | no |
 | <a name="input_datadog_operator_helm_config"></a> [datadog\_operator\_helm\_config](#input\_datadog\_operator\_helm\_config) | Datadog Operator Helm Chart config | `any` | `{}` | no |
-| <a name="input_eks_cluster_domain"></a> [eks\_cluster\_domain](#input\_eks\_cluster\_domain) | The domain for the EKS cluster | `string` | `""` | no |
 | <a name="input_eks_cluster_endpoint"></a> [eks\_cluster\_endpoint](#input\_eks\_cluster\_endpoint) | Endpoint for your Kubernetes API server | `string` | `null` | no |
 | <a name="input_eks_cluster_id"></a> [eks\_cluster\_id](#input\_eks\_cluster\_id) | EKS Cluster Id | `string` | n/a | yes |
 | <a name="input_eks_cluster_version"></a> [eks\_cluster\_version](#input\_eks\_cluster\_version) | The Kubernetes version for the cluster | `string` | `null` | no |
@@ -261,7 +260,6 @@
 | <a name="input_enable_yunikorn"></a> [enable\_yunikorn](#input\_enable\_yunikorn) | Enable Apache YuniKorn K8s scheduler add-on | `bool` | `false` | no |
 | <a name="input_external_dns_helm_config"></a> [external\_dns\_helm\_config](#input\_external\_dns\_helm\_config) | External DNS Helm Chart config | `any` | `{}` | no |
 | <a name="input_external_dns_irsa_policies"></a> [external\_dns\_irsa\_policies](#input\_external\_dns\_irsa\_policies) | Additional IAM policies for a IAM role for service accounts | `list(string)` | `[]` | no |
-| <a name="input_external_dns_private_zone"></a> [external\_dns\_private\_zone](#input\_external\_dns\_private\_zone) | Determines if referenced Route53 zone is private. | `bool` | `false` | no |
 | <a name="input_external_dns_route53_zone_arns"></a> [external\_dns\_route53\_zone\_arns](#input\_external\_dns\_route53\_zone\_arns) | List of Route53 zones ARNs which external-dns will have access to create/manage records | `list(string)` | `[]` | no |
 | <a name="input_external_secrets_helm_config"></a> [external\_secrets\_helm\_config](#input\_external\_secrets\_helm\_config) | External Secrets operator Helm Chart config | `any` | `{}` | no |
 | <a name="input_external_secrets_irsa_policies"></a> [external\_secrets\_irsa\_policies](#input\_external\_secrets\_irsa\_policies) | Additional IAM policies for a IAM role for service accounts | `list(string)` | `[]` | no |

--- a/modules/kubernetes-addons/README.md
+++ b/modules/kubernetes-addons/README.md
@@ -140,6 +140,7 @@
 | <a name="input_aws_fsx_csi_driver_helm_config"></a> [aws\_fsx\_csi\_driver\_helm\_config](#input\_aws\_fsx\_csi\_driver\_helm\_config) | AWS FSx CSI driver Helm Chart config | `any` | `{}` | no |
 | <a name="input_aws_fsx_csi_driver_irsa_policies"></a> [aws\_fsx\_csi\_driver\_irsa\_policies](#input\_aws\_fsx\_csi\_driver\_irsa\_policies) | Additional IAM policies for a IAM role for service accounts | `list(string)` | `[]` | no |
 | <a name="input_aws_load_balancer_controller_helm_config"></a> [aws\_load\_balancer\_controller\_helm\_config](#input\_aws\_load\_balancer\_controller\_helm\_config) | AWS Load Balancer Controller Helm Chart config | `any` | `{}` | no |
+| <a name="input_aws_load_balancer_controller_path"></a> [aws\_load\_balancer\_controller\_path](#input\_aws\_load\_balancer\_controller\_path) | Path in which to create the LB IRSA policy | `string` | `"/"` | no |
 | <a name="input_aws_node_termination_handler_helm_config"></a> [aws\_node\_termination\_handler\_helm\_config](#input\_aws\_node\_termination\_handler\_helm\_config) | AWS Node Termination Handler Helm Chart config | `any` | `{}` | no |
 | <a name="input_aws_node_termination_handler_irsa_policies"></a> [aws\_node\_termination\_handler\_irsa\_policies](#input\_aws\_node\_termination\_handler\_irsa\_policies) | Additional IAM policies for a IAM role for service accounts | `list(string)` | `[]` | no |
 | <a name="input_aws_privateca_acmca_arn"></a> [aws\_privateca\_acmca\_arn](#input\_aws\_privateca\_acmca\_arn) | ARN of AWS ACM PCA | `string` | `""` | no |
@@ -277,6 +278,7 @@
 | <a name="input_karpenter_helm_config"></a> [karpenter\_helm\_config](#input\_karpenter\_helm\_config) | Karpenter autoscaler add-on config | `any` | `{}` | no |
 | <a name="input_karpenter_irsa_policies"></a> [karpenter\_irsa\_policies](#input\_karpenter\_irsa\_policies) | Additional IAM policies for a IAM role for service accounts | `list(string)` | `[]` | no |
 | <a name="input_karpenter_node_iam_instance_profile"></a> [karpenter\_node\_iam\_instance\_profile](#input\_karpenter\_node\_iam\_instance\_profile) | Karpenter Node IAM Instance profile id | `string` | `""` | no |
+| <a name="input_karpenter_path"></a> [karpenter\_path](#input\_karpenter\_path) | Path in which to create the Karpenter policy | `string` | `"/"` | no |
 | <a name="input_keda_helm_config"></a> [keda\_helm\_config](#input\_keda\_helm\_config) | KEDA Event-based autoscaler add-on config | `any` | `{}` | no |
 | <a name="input_keda_irsa_policies"></a> [keda\_irsa\_policies](#input\_keda\_irsa\_policies) | Additional IAM policies for a IAM role for service accounts | `list(string)` | `[]` | no |
 | <a name="input_kube_prometheus_stack_helm_config"></a> [kube\_prometheus\_stack\_helm\_config](#input\_kube\_prometheus\_stack\_helm\_config) | Community kube-prometheus-stack Helm Chart config | `any` | `{}` | no |

--- a/modules/kubernetes-addons/aws-load-balancer-controller/README.md
+++ b/modules/kubernetes-addons/aws-load-balancer-controller/README.md
@@ -100,6 +100,7 @@ If the IAM role is too long, override the service account name in the `helm_conf
 | <a name="input_addon_context"></a> [addon\_context](#input\_addon\_context) | Input configuration for the addon. | <pre>object({<br>    aws_caller_identity_account_id = string<br>    aws_caller_identity_arn        = string<br>    aws_eks_cluster_endpoint       = string<br>    aws_partition_id               = string<br>    aws_region_name                = string<br>    eks_cluster_id                 = string<br>    eks_oidc_issuer_url            = string<br>    eks_oidc_provider_arn          = string<br>    tags                           = map(string)<br>    irsa_iam_role_path             = string<br>    irsa_iam_permissions_boundary  = string<br>    default_repository             = string<br>  })</pre> | n/a | yes |
 | <a name="input_helm_config"></a> [helm\_config](#input\_helm\_config) | Helm provider config for the aws\_load\_balancer\_controller. | `any` | `{}` | no |
 | <a name="input_manage_via_gitops"></a> [manage\_via\_gitops](#input\_manage\_via\_gitops) | Determines if the add-on should be managed via GitOps. | `bool` | `false` | no |
+| <a name="input_path"></a> [path](#input\_path) | Path in which to create the LB IRSA policy | `string` | `"/"` | no |
 
 ## Outputs
 

--- a/modules/kubernetes-addons/aws-load-balancer-controller/main.tf
+++ b/modules/kubernetes-addons/aws-load-balancer-controller/main.tf
@@ -11,5 +11,6 @@ resource "aws_iam_policy" "aws_load_balancer_controller" {
   name        = "${var.addon_context.eks_cluster_id}-lb-irsa"
   description = "Allows lb controller to manage ALB and NLB"
   policy      = data.aws_iam_policy_document.aws_lb.json
+  path        = var.path
   tags        = var.addon_context.tags
 }

--- a/modules/kubernetes-addons/aws-load-balancer-controller/variables.tf
+++ b/modules/kubernetes-addons/aws-load-balancer-controller/variables.tf
@@ -27,3 +27,9 @@ variable "addon_context" {
     default_repository             = string
   })
 }
+
+variable "path" {
+  description = "Path in which to create the LB IRSA policy"
+  type        = string
+  default     = "/"
+}

--- a/modules/kubernetes-addons/external-dns/README.md
+++ b/modules/kubernetes-addons/external-dns/README.md
@@ -32,18 +32,15 @@ For complete project documentation, please visit the [ExternalDNS Github reposit
 |------|------|
 | [aws_iam_policy.external_dns](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy_document.external_dns_iam_policy_document](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [aws_route53_zone.selected](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route53_zone) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_addon_context"></a> [addon\_context](#input\_addon\_context) | Input configuration for the addon | <pre>object({<br>    aws_caller_identity_account_id = string<br>    aws_caller_identity_arn        = string<br>    aws_eks_cluster_endpoint       = string<br>    aws_partition_id               = string<br>    aws_region_name                = string<br>    eks_cluster_id                 = string<br>    eks_oidc_issuer_url            = string<br>    eks_oidc_provider_arn          = string<br>    tags                           = map(string)<br>    irsa_iam_role_path             = string<br>    irsa_iam_permissions_boundary  = string<br>  })</pre> | n/a | yes |
-| <a name="input_domain_name"></a> [domain\_name](#input\_domain\_name) | [Deprecated - use `route53_zone_arns`] Domain name of the Route53 hosted zone to use with External DNS. | `string` | n/a | yes |
 | <a name="input_helm_config"></a> [helm\_config](#input\_helm\_config) | External DNS Helm Configuration | `any` | `{}` | no |
 | <a name="input_irsa_policies"></a> [irsa\_policies](#input\_irsa\_policies) | Additional IAM policies used for the add-on service account. | `list(string)` | `[]` | no |
 | <a name="input_manage_via_gitops"></a> [manage\_via\_gitops](#input\_manage\_via\_gitops) | Determines if the add-on should be managed via GitOps. | `bool` | `false` | no |
-| <a name="input_private_zone"></a> [private\_zone](#input\_private\_zone) | [Deprecated - use `route53_zone_arns`] Determines if referenced Route53 hosted zone is private. | `bool` | `false` | no |
 | <a name="input_route53_zone_arns"></a> [route53\_zone\_arns](#input\_route53\_zone\_arns) | List of Route53 zones ARNs which external-dns will have access to create/manage records | `list(string)` | `[]` | no |
 
 ## Outputs

--- a/modules/kubernetes-addons/external-dns/data.tf
+++ b/modules/kubernetes-addons/external-dns/data.tf
@@ -1,10 +1,9 @@
 data "aws_iam_policy_document" "external_dns_iam_policy_document" {
   statement {
     effect = "Allow"
-    resources = distinct(concat(
-      [data.aws_route53_zone.selected.arn],
+    resources = distinct(
       var.route53_zone_arns
-    ))
+    )
     actions = [
       "route53:ChangeResourceRecordSets",
       "route53:ListResourceRecordSets",

--- a/modules/kubernetes-addons/external-dns/main.tf
+++ b/modules/kubernetes-addons/external-dns/main.tf
@@ -72,9 +72,3 @@ resource "aws_iam_policy" "external_dns" {
   policy      = data.aws_iam_policy_document.external_dns_iam_policy_document.json
   tags        = var.addon_context.tags
 }
-
-# TODO - remove at next breaking change
-data "aws_route53_zone" "selected" {
-  name         = var.domain_name
-  private_zone = var.private_zone
-}

--- a/modules/kubernetes-addons/external-dns/variables.tf
+++ b/modules/kubernetes-addons/external-dns/variables.tf
@@ -16,17 +16,6 @@ variable "irsa_policies" {
   default     = []
 }
 
-variable "domain_name" {
-  description = "[Deprecated - use `route53_zone_arns`] Domain name of the Route53 hosted zone to use with External DNS."
-  type        = string
-}
-
-variable "private_zone" {
-  description = "[Deprecated - use `route53_zone_arns`] Determines if referenced Route53 hosted zone is private."
-  type        = bool
-  default     = false
-}
-
 variable "route53_zone_arns" {
   description = "List of Route53 zones ARNs which external-dns will have access to create/manage records"
   type        = list(string)

--- a/modules/kubernetes-addons/main.tf
+++ b/modules/kubernetes-addons/main.tf
@@ -286,8 +286,6 @@ module "external_dns" {
   irsa_policies     = var.external_dns_irsa_policies
   addon_context     = local.addon_context
 
-  domain_name       = var.eks_cluster_domain
-  private_zone      = var.external_dns_private_zone
   route53_zone_arns = var.external_dns_route53_zone_arns
 }
 

--- a/modules/kubernetes-addons/main.tf
+++ b/modules/kubernetes-addons/main.tf
@@ -182,7 +182,10 @@ module "aws_load_balancer_controller" {
   source            = "./aws-load-balancer-controller"
   helm_config       = var.aws_load_balancer_controller_helm_config
   manage_via_gitops = var.argocd_manage_add_ons
-  addon_context     = merge(local.addon_context, { default_repository = local.amazon_container_image_registry_uris[data.aws_region.current.name] })
+  path              = var.aws_load_balancer_controller_path
+  addon_context = merge(local.addon_context, {
+    default_repository = local.amazon_container_image_registry_uris[data.aws_region.current.name]
+  })
 }
 
 module "aws_node_termination_handler" {
@@ -322,6 +325,7 @@ module "karpenter" {
   node_iam_instance_profile                   = var.karpenter_node_iam_instance_profile
   enable_spot_termination                     = var.karpenter_enable_spot_termination_handling
   manage_via_gitops                           = var.argocd_manage_add_ons
+  path                                        = var.karpenter_path
   addon_context                               = local.addon_context
   sqs_queue_managed_sse_enabled               = var.sqs_queue_managed_sse_enabled
   sqs_queue_kms_master_key_id                 = var.sqs_queue_kms_master_key_id
@@ -803,7 +807,8 @@ module "emr_on_eks" {
 
   # EMR Virtual Cluster
   name           = try(each.value.name, each.key)
-  eks_cluster_id = data.aws_eks_cluster.eks_cluster.id # Data source is tied to `sleep` to ensure data plane is ready first
+  eks_cluster_id = data.aws_eks_cluster.eks_cluster.id
+  # Data source is tied to `sleep` to ensure data plane is ready first
 
   tags = merge(var.tags, try(each.value.tags, {}))
 }

--- a/modules/kubernetes-addons/variables.tf
+++ b/modules/kubernetes-addons/variables.tf
@@ -3,12 +3,6 @@ variable "eks_cluster_id" {
   type        = string
 }
 
-variable "eks_cluster_domain" {
-  description = "The domain for the EKS cluster"
-  type        = string
-  default     = ""
-}
-
 variable "eks_worker_security_group_id" {
   description = "EKS Worker Security group Id created by EKS module"
   type        = string
@@ -357,12 +351,6 @@ variable "external_dns_irsa_policies" {
   description = "Additional IAM policies for a IAM role for service accounts"
   type        = list(string)
   default     = []
-}
-
-variable "external_dns_private_zone" {
-  type        = bool
-  description = "Determines if referenced Route53 zone is private."
-  default     = false
 }
 
 variable "external_dns_route53_zone_arns" {

--- a/modules/kubernetes-addons/variables.tf
+++ b/modules/kubernetes-addons/variables.tf
@@ -617,6 +617,12 @@ variable "aws_load_balancer_controller_helm_config" {
   default     = {}
 }
 
+variable "aws_load_balancer_controller_path" {
+  description = "Path in which to create the LB IRSA policy"
+  type        = string
+  default     = "/"
+}
+
 #-----------NGINX-------------
 variable "enable_ingress_nginx" {
   description = "Enable Ingress Nginx add-on"
@@ -909,6 +915,12 @@ variable "karpenter_enable_spot_termination_handling" {
   description = "Determines whether to enable native spot termination handling"
   type        = bool
   default     = false
+}
+
+variable "karpenter_path" {
+  description = "Path in which to create the Karpenter policy"
+  type        = string
+  default     = "/"
 }
 
 variable "sqs_queue_managed_sse_enabled" {


### PR DESCRIPTION
### What does this PR do?

### Motivation

Needed a custom path for the resource aws_iam_policy.aws_load_balancer_controller, since the roles used to deploy the resources have strict permissions on certain policy paths.
In addition, fixes issue with not being able to provide the path variable for the Karpenter add-on and the issue with having deprecated variables tied to external DNS.

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
