### PR TITLE
fix(aws-for-fluentbit): Add missing action in CW policy

### DIFF
--- a/modules/kubernetes-addons/aws-for-fluentbit/data.tf
+++ b/modules/kubernetes-addons/aws-for-fluentbit/data.tf
@@ -20,6 +20,7 @@ data "aws_iam_policy_document" "irsa" {
       "logs:CreateLogStream",
       "logs:DescribeLogGroups",
       "logs:DescribeLogStreams",
+      "logs:PutRetentionPolicy",
     ]
   }
 }


### PR DESCRIPTION
### What does this PR do?
Update [aws-for-fluentbit](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/modules/kubernetes-addons/aws-for-fluentbit) policy, the service account does not have enough permissions to set a log retention policy, this generates errors when fluentbit wants to create a log group.

```
time="2023-03-04T18:45:59Z" level=error msg="AccessDeniedException: User: arn:aws:sts::00000:assumed-role/CLUSTER-aws-for-fluent-bit-sa-irsa/1111111111 is not authorized to perform: logs:PutRetentionPolicy on resource: arn:aws:logs:us-east-1:00000:log-group:/cluster/fluentbit-logs/namespace/app:log-stream: because no identity-based policy allows the logs:PutRetentionPolicy action\n\tstatus code: 400, request id: 0000000" 
```

### Motivation
Configure fluentbit to create a resource group for each application in kubernetes

<!-- What inspired you to submit this pull request? -->
- Resolves #<issue-number>
https://github.com/aws-ia/terraform-aws-eks-blueprints/issues/1454

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [x] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
