### PR TITLE
fix: Align creation of k8s namespaces and service account in addons

### DIFF
--- a/modules/kubernetes-addons/adot-collector-haproxy/main.tf
+++ b/modules/kubernetes-addons/adot-collector-haproxy/main.tf
@@ -53,7 +53,7 @@ module "helm_addon" {
   irsa_config = {
     create_kubernetes_namespace         = try(var.helm_config["create_namespace"], true)
     kubernetes_namespace                = local.namespace
-    create_kubernetes_service_account   = true
+    create_kubernetes_service_account   = try(var.helm_config["create_service_account"], true)
     create_service_account_secret_token = try(var.helm_config["create_service_account_secret_token"], false)
     kubernetes_service_account          = try(var.helm_config.service_account, local.name)
     irsa_iam_policies                   = ["arn:${data.aws_partition.current.partition}:iam::aws:policy/AmazonPrometheusRemoteWriteAccess"]

--- a/modules/kubernetes-addons/adot-collector-java/main.tf
+++ b/modules/kubernetes-addons/adot-collector-java/main.tf
@@ -53,7 +53,7 @@ module "helm_addon" {
   irsa_config = {
     create_kubernetes_namespace         = try(var.helm_config["create_namespace"], true)
     kubernetes_namespace                = local.namespace
-    create_kubernetes_service_account   = true
+    create_kubernetes_service_account   = try(var.helm_config["create_service_account"], true)
     create_service_account_secret_token = try(var.helm_config["create_service_account_secret_token"], false)
     kubernetes_service_account          = try(var.helm_config.service_account, local.name)
     irsa_iam_policies                   = ["arn:${data.aws_partition.current.partition}:iam::aws:policy/AmazonPrometheusRemoteWriteAccess"]

--- a/modules/kubernetes-addons/adot-collector-memcached/main.tf
+++ b/modules/kubernetes-addons/adot-collector-memcached/main.tf
@@ -53,7 +53,7 @@ module "helm_addon" {
   irsa_config = {
     create_kubernetes_namespace         = try(var.helm_config["create_namespace"], true)
     kubernetes_namespace                = local.namespace
-    create_kubernetes_service_account   = true
+    create_kubernetes_service_account   = try(var.helm_config["create_service_account"], true)
     create_service_account_secret_token = try(var.helm_config["create_service_account_secret_token"], false)
     kubernetes_service_account          = try(var.helm_config.service_account, local.name)
     irsa_iam_policies                   = ["arn:${data.aws_partition.current.partition}:iam::aws:policy/AmazonPrometheusRemoteWriteAccess"]

--- a/modules/kubernetes-addons/adot-collector-nginx/main.tf
+++ b/modules/kubernetes-addons/adot-collector-nginx/main.tf
@@ -53,7 +53,7 @@ module "helm_addon" {
   irsa_config = {
     create_kubernetes_namespace         = try(var.helm_config["create_namespace"], true)
     kubernetes_namespace                = local.namespace
-    create_kubernetes_service_account   = true
+    create_kubernetes_service_account   = try(var.helm_config["create_service_account"], true)
     create_service_account_secret_token = try(var.helm_config["create_service_account_secret_token"], false)
     kubernetes_service_account          = try(var.helm_config.service_account, local.name)
     irsa_iam_policies                   = ["arn:${data.aws_partition.current.partition}:iam::aws:policy/AmazonPrometheusRemoteWriteAccess"]

--- a/modules/kubernetes-addons/appmesh-controller/main.tf
+++ b/modules/kubernetes-addons/appmesh-controller/main.tf
@@ -34,9 +34,9 @@ module "helm_addon" {
   ]
 
   irsa_config = {
-    create_kubernetes_namespace         = true
+    create_kubernetes_namespace         = try(var.helm_config["create_namespace"], true)
     kubernetes_namespace                = local.namespace
-    create_kubernetes_service_account   = true
+    create_kubernetes_service_account   = try(var.helm_config["create_service_account"], true)
     create_service_account_secret_token = try(var.helm_config["create_service_account_secret_token"], false)
     kubernetes_service_account          = try(var.helm_config.service_account, local.name)
     irsa_iam_policies                   = concat([aws_iam_policy.this.arn], var.irsa_policies)

--- a/modules/kubernetes-addons/aws-cloudwatch-metrics/locals.tf
+++ b/modules/kubernetes-addons/aws-cloudwatch-metrics/locals.tf
@@ -39,7 +39,7 @@ locals {
     kubernetes_service_account          = local.service_account
     create_service_account_secret_token = try(local.helm_config["create_service_account_secret_token"], false)
     create_kubernetes_namespace         = try(local.helm_config["create_namespace"], true)
-    create_kubernetes_service_account   = true
+    create_kubernetes_service_account   = try(var.helm_config["create_service_account"], true)
     irsa_iam_policies                   = concat(["arn:${var.addon_context.aws_partition_id}:iam::aws:policy/CloudWatchAgentServerPolicy"], var.irsa_policies)
   }
 

--- a/modules/kubernetes-addons/aws-ebs-csi-driver/main.tf
+++ b/modules/kubernetes-addons/aws-ebs-csi-driver/main.tf
@@ -64,7 +64,7 @@ module "helm_addon" {
   irsa_config = {
     create_kubernetes_namespace         = try(var.helm_config.create_namespace, false)
     kubernetes_namespace                = local.namespace
-    create_kubernetes_service_account   = true
+    create_kubernetes_service_account   = try(var.helm_config["create_service_account"], true)
     create_service_account_secret_token = try(var.helm_config["create_service_account_secret_token"], false)
     kubernetes_service_account          = local.service_account
     irsa_iam_policies                   = concat([aws_iam_policy.aws_ebs_csi_driver[0].arn], lookup(var.helm_config, "additional_iam_policies", []))

--- a/modules/kubernetes-addons/aws-efs-csi-driver/main.tf
+++ b/modules/kubernetes-addons/aws-efs-csi-driver/main.tf
@@ -25,7 +25,7 @@ module "helm_addon" {
     kubernetes_namespace                = local.namespace
     kubernetes_service_account          = local.service_account
     create_kubernetes_namespace         = try(var.helm_config.create_namespace, false)
-    create_kubernetes_service_account   = true
+    create_kubernetes_service_account   = try(var.helm_config["create_service_account"], true)
     create_service_account_secret_token = try(var.helm_config["create_service_account_secret_token"], false)
     irsa_iam_policies                   = concat([aws_iam_policy.aws_efs_csi_driver.arn], var.irsa_policies)
   }

--- a/modules/kubernetes-addons/aws-for-fluentbit/locals.tf
+++ b/modules/kubernetes-addons/aws-for-fluentbit/locals.tf
@@ -46,7 +46,7 @@ locals {
     kubernetes_namespace                = local.helm_config["namespace"]
     kubernetes_service_account          = local.service_account
     create_kubernetes_namespace         = try(local.helm_config["create_namespace"], true)
-    create_kubernetes_service_account   = true
+    create_kubernetes_service_account   = try(var.helm_config["create_service_account"], true)
     create_service_account_secret_token = try(local.helm_config["create_service_account_secret_token"], false)
     irsa_iam_policies                   = concat([aws_iam_policy.aws_for_fluent_bit.arn], var.irsa_policies)
   }

--- a/modules/kubernetes-addons/aws-fsx-csi-driver/locals.tf
+++ b/modules/kubernetes-addons/aws-fsx-csi-driver/locals.tf
@@ -38,7 +38,7 @@ locals {
     kubernetes_namespace                = local.helm_config["namespace"]
     kubernetes_service_account          = local.service_account
     create_kubernetes_namespace         = try(local.helm_config["create_namespace"], true)
-    create_kubernetes_service_account   = true
+    create_kubernetes_service_account   = try(var.helm_config["create_service_account"], true)
     create_service_account_secret_token = try(local.helm_config["create_service_account_secret_token"], false)
     irsa_iam_policies                   = concat([aws_iam_policy.aws_fsx_csi_driver.arn], var.irsa_policies)
     tags                                = var.addon_context.tags

--- a/modules/kubernetes-addons/aws-load-balancer-controller/locals.tf
+++ b/modules/kubernetes-addons/aws-load-balancer-controller/locals.tf
@@ -47,7 +47,7 @@ locals {
     kubernetes_namespace                = local.helm_config["namespace"]
     kubernetes_service_account          = local.service_account
     create_kubernetes_namespace         = try(local.helm_config["create_namespace"], true)
-    create_kubernetes_service_account   = true
+    create_kubernetes_service_account   = try(var.helm_config["create_service_account"], true)
     create_service_account_secret_token = try(local.helm_config["create_service_account_secret_token"], false)
     irsa_iam_policies                   = [aws_iam_policy.aws_load_balancer_controller.arn]
   }

--- a/modules/kubernetes-addons/aws-node-termination-handler/locals.tf
+++ b/modules/kubernetes-addons/aws-node-termination-handler/locals.tf
@@ -46,8 +46,8 @@ locals {
   irsa_config = {
     kubernetes_namespace                = local.namespace
     kubernetes_service_account          = local.service_account
-    create_kubernetes_namespace         = false
-    create_kubernetes_service_account   = true
+    create_kubernetes_namespace         = try(var.helm_config["create_namespace"], false)
+    create_kubernetes_service_account   = try(var.helm_config["create_service_account"], true)
     create_service_account_secret_token = try(local.helm_config["create_service_account_secret_token"], false)
     irsa_iam_policies                   = concat([aws_iam_policy.aws_node_termination_handler_irsa.arn], var.irsa_policies)
   }

--- a/modules/kubernetes-addons/aws-privateca-issuer/locals.tf
+++ b/modules/kubernetes-addons/aws-privateca-issuer/locals.tf
@@ -31,7 +31,7 @@ locals {
   irsa_config = {
     create_kubernetes_namespace         = try(local.helm_config["create_namespace"], true)
     kubernetes_namespace                = local.helm_config["namespace"]
-    create_kubernetes_service_account   = true
+    create_kubernetes_service_account   = try(var.helm_config["create_service_account"], true)
     create_service_account_secret_token = try(local.helm_config["create_service_account_secret_token"], false)
     kubernetes_service_account          = local.service_account
     irsa_iam_policies                   = concat([aws_iam_policy.aws_privateca_issuer.arn], var.irsa_policies)

--- a/modules/kubernetes-addons/cert-manager/locals.tf
+++ b/modules/kubernetes-addons/cert-manager/locals.tf
@@ -38,7 +38,7 @@ locals {
     kubernetes_namespace                = local.helm_config["namespace"]
     kubernetes_service_account          = local.service_account
     create_kubernetes_namespace         = try(local.helm_config["create_namespace"], true)
-    create_kubernetes_service_account   = true
+    create_kubernetes_service_account   = try(var.helm_config["create_service_account"], true)
     create_service_account_secret_token = try(local.helm_config["create_service_account_secret_token"], false)
     kubernetes_svc_image_pull_secrets   = var.kubernetes_svc_image_pull_secrets
     irsa_iam_policies                   = concat([aws_iam_policy.cert_manager.arn], var.irsa_policies)

--- a/modules/kubernetes-addons/cluster-autoscaler/main.tf
+++ b/modules/kubernetes-addons/cluster-autoscaler/main.tf
@@ -40,7 +40,7 @@ module "helm_addon" {
   irsa_config = {
     create_kubernetes_namespace         = try(var.helm_config.create_namespace, false)
     kubernetes_namespace                = local.namespace
-    create_kubernetes_service_account   = true
+    create_kubernetes_service_account   = try(var.helm_config["create_service_account"], true)
     create_service_account_secret_token = try(var.helm_config["create_service_account_secret_token"], false)
     kubernetes_service_account          = local.service_account
     irsa_iam_policies                   = [aws_iam_policy.cluster_autoscaler.arn]

--- a/modules/kubernetes-addons/external-dns/main.tf
+++ b/modules/kubernetes-addons/external-dns/main.tf
@@ -51,7 +51,7 @@ module "helm_addon" {
   irsa_config = {
     create_kubernetes_namespace         = try(var.helm_config.create_namespace, true)
     kubernetes_namespace                = try(var.helm_config.namespace, local.name)
-    create_kubernetes_service_account   = true
+    create_kubernetes_service_account   = try(var.helm_config["create_service_account"], true)
     create_service_account_secret_token = try(var.helm_config["create_service_account_secret_token"], false)
     kubernetes_service_account          = local.service_account
     irsa_iam_policies                   = concat([aws_iam_policy.external_dns.arn], var.irsa_policies)

--- a/modules/kubernetes-addons/external-secrets/locals.tf
+++ b/modules/kubernetes-addons/external-secrets/locals.tf
@@ -46,7 +46,7 @@ locals {
     kubernetes_namespace                = local.helm_config["namespace"]
     kubernetes_service_account          = local.service_account
     create_kubernetes_namespace         = try(local.helm_config["create_namespace"], true)
-    create_kubernetes_service_account   = true
+    create_kubernetes_service_account   = try(var.helm_config["create_service_account"], true)
     create_service_account_secret_token = try(local.helm_config["create_service_account_secret_token"], false)
     irsa_iam_policies                   = concat([aws_iam_policy.external_secrets.arn], var.irsa_policies)
   }

--- a/modules/kubernetes-addons/grafana/locals.tf
+++ b/modules/kubernetes-addons/grafana/locals.tf
@@ -37,7 +37,7 @@ locals {
     kubernetes_namespace                = local.helm_config["namespace"]
     kubernetes_service_account          = try(var.helm_config.service_account, local.name)
     create_kubernetes_namespace         = try(local.helm_config.create_namespace, true)
-    create_kubernetes_service_account   = true
+    create_kubernetes_service_account   = try(var.helm_config["create_service_account"], true)
     create_service_account_secret_token = try(local.helm_config["create_service_account_secret_token"], false)
     irsa_iam_policies                   = concat([aws_iam_policy.grafana.arn], var.irsa_policies)
   }

--- a/modules/kubernetes-addons/karpenter/locals.tf
+++ b/modules/kubernetes-addons/karpenter/locals.tf
@@ -38,7 +38,7 @@ locals {
     kubernetes_namespace                = local.helm_config["namespace"]
     kubernetes_service_account          = local.service_account
     create_kubernetes_namespace         = try(local.helm_config["create_namespace"], true)
-    create_kubernetes_service_account   = true
+    create_kubernetes_service_account   = try(var.helm_config["create_service_account"], true)
     create_service_account_secret_token = try(local.helm_config["create_service_account_secret_token"], false)
     irsa_iam_policies                   = concat([aws_iam_policy.karpenter.arn], var.irsa_policies)
   }

--- a/modules/kubernetes-addons/keda/locals.tf
+++ b/modules/kubernetes-addons/keda/locals.tf
@@ -30,7 +30,7 @@ locals {
     kubernetes_namespace                = local.helm_config["namespace"]
     kubernetes_service_account          = local.service_account
     create_kubernetes_namespace         = try(local.helm_config["create_namespace"], true)
-    create_kubernetes_service_account   = true
+    create_kubernetes_service_account   = try(var.helm_config["create_service_account"], true)
     create_service_account_secret_token = try(local.helm_config["create_service_account_secret_token"], false)
     irsa_iam_policies                   = concat([aws_iam_policy.keda_irsa.arn], var.irsa_policies)
   }

--- a/modules/kubernetes-addons/spark-history-server/locals.tf
+++ b/modules/kubernetes-addons/spark-history-server/locals.tf
@@ -30,7 +30,7 @@ locals {
     kubernetes_namespace                = local.helm_config["namespace"]
     kubernetes_service_account          = try(var.helm_config.service_account, local.name)
     create_kubernetes_namespace         = try(local.helm_config["create_namespace"], true)
-    create_kubernetes_service_account   = true
+    create_kubernetes_service_account   = try(var.helm_config["create_service_account"], true)
     create_service_account_secret_token = try(local.helm_config["create_service_account_secret_token"], false)
     irsa_iam_policies                   = length(var.irsa_policies) > 0 ? var.irsa_policies : ["arn:${var.addon_context.aws_partition_id}:iam::aws:policy/AmazonS3ReadOnlyAccess"]
   }

--- a/modules/kubernetes-addons/thanos/locals.tf
+++ b/modules/kubernetes-addons/thanos/locals.tf
@@ -27,8 +27,8 @@ locals {
   irsa_config = {
     kubernetes_namespace                = local.namespace
     kubernetes_service_account          = local.service_account
-    create_kubernetes_namespace         = false
-    create_kubernetes_service_account   = true
+    create_kubernetes_namespace         = try(var.helm_config["create_namespace"], false)
+    create_kubernetes_service_account   = try(var.helm_config["create_service_account"], true)
     create_service_account_secret_token = try(local.helm_config["create_service_account_secret_token"], false)
     irsa_iam_policies                   = var.irsa_policies
   }

--- a/modules/kubernetes-addons/velero/main.tf
+++ b/modules/kubernetes-addons/velero/main.tf
@@ -44,7 +44,7 @@ module "helm_addon" {
     create_kubernetes_namespace = try(var.helm_config["create_namespace"], true)
     kubernetes_namespace        = local.namespace
 
-    create_kubernetes_service_account   = true
+    create_kubernetes_service_account   = try(var.helm_config["create_service_account"], true)
     create_service_account_secret_token = try(var.helm_config["create_service_account_secret_token"], false)
     kubernetes_service_account          = try(var.helm_config.service_account, local.name)
 


### PR DESCRIPTION
### What does this PR do?

Some addons support setting `helm_config.create_namespace`, but don't support setting `helm_config.create_service_account`. This makes disabling `create_namespace` useless when the creation of the service account is enabled since **the service account can't be created into a non-existent namespace**.

On the other hand, since Blueprints v5 will have different repositories per addon, I would prefer to manage all Kubernetes resources through a custom ArgoCD app. And then, I want **blueprints to only create the IAM roles for IRSA**.

For both reasons, this PR will allow conditionally creating namespaces (already supported) and service accounts per addon.

### Motivation

- Related to #1421

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
