### PR TITLE
fix: Token password causing terraform change when no change

### DIFF
--- a/examples/karpenter/main.tf
+++ b/examples/karpenter/main.tf
@@ -171,6 +171,10 @@ module "eks_blueprints_kubernetes_addons" {
   data_plane_wait_arn = join(",", [for prof in module.eks.fargate_profiles : prof.fargate_profile_arn])
 
   enable_karpenter = true
+    karpenter_helm_config = {
+    repository_username = "placeholder-user"
+    repository_password = "placeholder-pass"
+  }
   karpenter_node_iam_instance_profile        = module.karpenter.instance_profile_name
   karpenter_enable_spot_termination_handling = true
 

--- a/examples/karpenter/main.tf
+++ b/examples/karpenter/main.tf
@@ -15,6 +15,12 @@ provider "kubernetes" {
 }
 
 provider "helm" {
+  registry {
+    url      = "oci://public.ecr.aws"
+    username = data.aws_ecrpublic_authorization_token.token.user_name
+    password = data.aws_ecrpublic_authorization_token.token.password
+  }
+  
   kubernetes {
     host                   = module.eks.cluster_endpoint
     cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
@@ -165,10 +171,6 @@ module "eks_blueprints_kubernetes_addons" {
   data_plane_wait_arn = join(",", [for prof in module.eks.fargate_profiles : prof.fargate_profile_arn])
 
   enable_karpenter = true
-  karpenter_helm_config = {
-    repository_username = data.aws_ecrpublic_authorization_token.token.user_name
-    repository_password = data.aws_ecrpublic_authorization_token.token.password
-  }
   karpenter_node_iam_instance_profile        = module.karpenter.instance_profile_name
   karpenter_enable_spot_termination_handling = true
 

--- a/examples/karpenter/main.tf
+++ b/examples/karpenter/main.tf
@@ -171,7 +171,7 @@ module "eks_blueprints_kubernetes_addons" {
   data_plane_wait_arn = join(",", [for prof in module.eks.fargate_profiles : prof.fargate_profile_arn])
 
   enable_karpenter = true
-    karpenter_helm_config = {
+  karpenter_helm_config = {
     repository_username = "placeholder-user"
     repository_password = "placeholder-pass"
   }


### PR DESCRIPTION
## :bangbang: PLEASE READ THIS FIRST :bangbang:

The direction for EKS Blueprints will soon shift from providing an all-encompassing, monolithic "framework" and instead focus more on how users can organize a set of modular components to create the desired solution on Amazon EKS. We have updated the [examples](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples) to show how we use the https://github.com/terraform-aws-modules/terraform-aws-eks for EKS cluster and node group creation. We will not be accepting any PRs that apply to EKS cluster or node group creation process. Any such PR may be closed by the maintainers.

We are hitting also the pause button on new add-on creations at this time until a future roadmap for add-ons is finalized. Please do not submit new add-on PRs. Any such PR may be closed by the maintainers.

Please track progress, learn what's new and how the migration path would look like to upgrade your current Terraform deployments. We welcome the EKS Blueprints community to continue the discussion in issue https://github.com/aws-ia/terraform-aws-eks-blueprints/issues/1421

### What does this PR do?

🛑 Please open an issue first to discuss any significant work and flesh out details/direction - we would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/aws-ia/terraform-aws-eks-blueprints/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

<!-- A brief description of the change being made with this pull request. -->

### Motivation

The current example will cause a new helm release to be created, everytime `terraform apply` is called. This is because a new token is retrieved from the public ECR and thus causing the `data.aws_ecrpublic_authorization_token.token.password` to be different every time. Which will then "trick" the helm release into deploying a new version when a new version is not needed.

This change will add the public registry to the helm provider itself, rather than as a helm config of the karpenter module.

### More

- [Y] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
