### PR TITLE
fix: Update `ExternalDNS` policy to support multiple Route 53 zones

### DIFF
--- a/modules/kubernetes-addons/external-dns/data.tf
+++ b/modules/kubernetes-addons/external-dns/data.tf
@@ -5,15 +5,15 @@ data "aws_iam_policy_document" "external_dns_iam_policy_document" {
       [data.aws_route53_zone.selected.arn],
       var.route53_zone_arns
     ))
-    actions = [
-      "route53:ChangeResourceRecordSets",
-      "route53:ListResourceRecordSets",
-    ]
+    actions = ["route53:ChangeResourceRecordSets"]
   }
 
   statement {
     effect    = "Allow"
     resources = ["*"]
-    actions   = ["route53:ListHostedZones"]
+    actions = [
+      "route53:ListHostedZones",
+      "route53:ListResourceRecordSets",
+    ]
   }
 }


### PR DESCRIPTION
### What does this PR do?

If you have multiple Route 53 zones on the AWS account, then externalDNS will fail trying to list the resource record sets for other hosted zones (not the one used by your cluster) and won't be able to update even the entry for the zone it has access to.
The issue has appeared after this commit by @rodrigobersa : https://github.com/aws-ia/terraform-aws-eks-blueprints/commit/8421a3b9600b734e600039ec2e8cddf6d03afe83#diff-3972dd5c24a63dda22823ec8ba870f9c566791eeffef91eaa6d6c382fd3fd9d3L97 
So this pull request basically reverts the policy body to the earlier version.

### Motivation

- Ref aws-ia/terraform-aws-eks-blueprints-addons#17

### More

- [x] Yes, I have tested the PR using my local account setup
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

I've created a new EKS cluster using my fork and the policy was created correctly:
```
{
    "Statement": [
        {
            "Action": "route53:ChangeResourceRecordSets",
            "Effect": "Allow",
            "Resource": "arn:aws:route53:::hostedzone/xxxxxxx",
            "Sid": ""
        },
        {
            "Action": [
                "route53:ListResourceRecordSets",
                "route53:ListHostedZones"
            ],
            "Effect": "Allow",
            "Resource": "*",
            "Sid": ""
        }
    ],
    "Version": "2012-10-17"
}
```