### PR TITLE
feat: Add kubernetes-event-exporter

### DIFF
--- a/modules/kubernetes-addons/kubernetes-event-exporter/README.md
+++ b/modules/kubernetes-addons/kubernetes-event-exporter/README.md
@@ -1,0 +1,40 @@
+# Kubernetes Event Exporter
+
+This add-on provides support for the kubernetes event exporter helm chart found here: https://github.com/bitnami/charts/tree/main/bitnami/kubernetes-event-exporter
+
+This add-on allows you to print kubernetes events to stdout, which can be sent to a logging tool of your choice. 
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
+
+## Providers
+
+No providers.
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_helm_addon"></a> [helm\_addon](#module\_helm\_addon) | ../helm-addon | n/a |
+
+## Resources
+
+No resources.
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_addon_context"></a> [addon\_context](#input\_addon\_context) | Input configuration for the addon | <pre>object({<br>    aws_caller_identity_account_id = string<br>    aws_caller_identity_arn        = string<br>    aws_eks_cluster_endpoint       = string<br>    aws_partition_id               = string<br>    aws_region_name                = string<br>    eks_cluster_id                 = string<br>    eks_oidc_issuer_url            = string<br>    eks_oidc_provider_arn          = string<br>    tags                           = map(string)<br>    irsa_iam_role_path             = string<br>    irsa_iam_permissions_boundary  = string<br>  })</pre> | n/a | yes |
+| <a name="input_helm_config"></a> [helm\_config](#input\_helm\_config) | Helm Config for kubernetes-event-exporter. | `any` | `{}` | no |
+| <a name="input_manage_via_gitops"></a> [manage\_via\_gitops](#input\_manage\_via\_gitops) | Determines if the add-on should be managed via GitOps. | `bool` | `false` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_argocd_gitops_config"></a> [argocd\_gitops\_config](#output\_argocd\_gitops\_config) | Configuration used for managing the add-on with ArgoCD |
+| <a name="output_release_metadata"></a> [release\_metadata](#output\_release\_metadata) | Map of attributes of the Helm release metadata |

--- a/modules/kubernetes-addons/kubernetes-event-exporter/locals.tf
+++ b/modules/kubernetes-addons/kubernetes-event-exporter/locals.tf
@@ -1,0 +1,18 @@
+locals {
+  name = "kubernetes-event-exporter"
+
+  helm_config = merge(
+    {
+      name             = local.name
+      chart            = local.name
+      repository       = "https://charts.bitnami.com/bitnami"
+      version          = "v2.2.4"
+      namespace        = local.name
+      create_namespace = true
+      values           = [templatefile("${path.module}/values.yaml", {})]
+      description      = "kube-event-exporter"
+    },
+    var.helm_config
+  )
+
+}

--- a/modules/kubernetes-addons/kubernetes-event-exporter/main.tf
+++ b/modules/kubernetes-addons/kubernetes-event-exporter/main.tf
@@ -1,0 +1,6 @@
+module "helm_addon" {
+  source            = "../helm-addon"
+  manage_via_gitops = var.manage_via_gitops
+  helm_config       = local.helm_config
+  addon_context     = var.addon_context
+}

--- a/modules/kubernetes-addons/kubernetes-event-exporter/outputs.tf
+++ b/modules/kubernetes-addons/kubernetes-event-exporter/outputs.tf
@@ -1,0 +1,9 @@
+output "argocd_gitops_config" {
+  description = "Configuration used for managing the add-on with ArgoCD"
+  value       = var.manage_via_gitops ? { enable = true } : null
+}
+
+output "release_metadata" {
+  description = "Map of attributes of the Helm release metadata"
+  value       = module.helm_addon.release_metadata
+}

--- a/modules/kubernetes-addons/kubernetes-event-exporter/values.yaml
+++ b/modules/kubernetes-addons/kubernetes-event-exporter/values.yaml
@@ -1,0 +1,403 @@
+## @section Global parameters
+## Global Docker image parameters
+## Please, note that this will override the image parameters, including dependencies, configured to use the global value
+## Current available global Docker image parameters: imageRegistry, imagePullSecrets and storageClass
+
+## @param global.imageRegistry Global Docker image registry
+## @param global.imagePullSecrets Global Docker registry secret names as an array
+##
+global:
+  imageRegistry: ""
+  ## E.g.
+  ## imagePullSecrets:
+  ##   - myRegistryKeySecretName
+  ##
+  imagePullSecrets: []
+
+## @section Common parameters
+
+## @param kubeVersion Override Kubernetes version
+##
+kubeVersion: ""
+## @param nameOverride String to partially override kubernetes-event-exporter.fullname include (will maintain the release name)
+##
+nameOverride: ""
+## @param fullnameOverride String to fully override kubernetes-event-exporter.fullname template
+##
+fullnameOverride: ""
+## @param commonAnnotations Annotations to add to all deployed objects
+##
+commonAnnotations: {}
+## @param commonLabels Labels to add to all deployed objects
+##
+commonLabels: {}
+## Enable diagnostic mode in the deployment
+##
+diagnosticMode:
+  ## @param diagnosticMode.enabled Enable diagnostic mode (all probes will be disabled and the command will be overridden)
+  ##
+  enabled: false
+  ## @param diagnosticMode.command Command to override all containers in the deployment
+  ##
+  command:
+    - sleep
+  ## @param diagnosticMode.args Args to override all containers in the deployment
+  ##
+  args:
+    - infinity
+## @param extraDeploy Array of extra objects to deploy with the release (evaluated as a template)
+##
+extraDeploy: []
+
+## @section Kubernetes Event Exporter parameters
+
+## @param replicaCount Desired number of pod replicas
+replicaCount: 1
+## @param containerPorts.http HTTP container port
+##
+containerPorts:
+  http: 2112
+## @param extraContainerPorts Optionally specify extra list of additional port-mappings for the container
+##
+extraContainerPorts: []
+
+image:
+  ## @param image.registry Container image registry
+  ## @param image.repository Container image name
+  ## @param image.tag Container image tag
+  ## @param image.digest Container image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
+  ## @param image.pullPolicy Container image pull policy
+  ## @param image.pullSecrets Specify docker-registry secret names as an array
+  ##
+  registry: docker.io
+  repository: bitnami/kubernetes-event-exporter
+  tag: 1.1.0-debian-11-r26
+  digest: ""
+  ## Specify a imagePullPolicy
+  ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
+  ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+  ##
+  pullPolicy: IfNotPresent
+  ## Optionally specify an array of imagePullSecrets.
+  ## Secrets must be manually created in the namespace.
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  ## Example:
+  ## pullSecrets:
+  ##   - myRegistryKeySecretName
+  ##
+  pullSecrets: []
+## @param hostAliases Add deployment host aliases
+## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
+##
+hostAliases: []
+## @param config.logLevel Verbosity of the logs (options: `fatal`, `error`, `warn`, `info` or `debug`)
+## @param config.logFormat How the logs are formatted. Allowed values: `pretty` or `json`
+## @param config.receivers [array] Array containing event receivers
+## @param config.route.routes [array] Array containing event route configuration
+##
+config:
+  logLevel: debug
+  logFormat: json
+  receivers:
+    - name: "dump"
+      file:
+        path: "/dev/stdout"
+        ## Example:
+        ## layout:
+        ##   message: "{{ .Message }}"
+        ##   reason: "{{ .Reason }}"
+        ##   type: "{{ .Type }}"
+        ##   count: "{{ .Count }}"
+        ##   kind: "{{ .InvolvedObject.Kind }}"
+        ##   name: "{{ .InvolvedObject.Name }}"
+        ##   namespace: "{{ .Namespace }}"
+        ##   component: "{{ .Source.Component }}"
+        ##   host: "{{ .Source.Host }}"
+        ##
+        layout: {}
+  route:
+    routes:
+      - match:
+          - receiver: "dump"
+rbac:
+  ## @param rbac.create Create the RBAC roles for API accessibility
+  ##
+  create: true
+## Pods Service Account
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+## @param serviceAccount.create Specifies whether a ServiceAccount should be created
+## @param serviceAccount.name Name of the service account to use. If not set and create is true, a name is generated using the fullname template.
+## @param serviceAccount.automountServiceAccountToken Automount service account token for the server service account
+## @param serviceAccount.annotations Annotations for service account. Evaluated as a template. Only used if `create` is `true`.
+##
+serviceAccount:
+  create: true
+  name: ""
+  automountServiceAccountToken: true
+  annotations: {}
+## @param podAnnotations Pod annotations
+## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+##
+podAnnotations: {}
+## @param podLabels Pod labels
+## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+##
+podLabels: {}
+## SecurityContext holds pod-level security attributes and common container settings.
+## @param podSecurityContext.enabled Enable security context
+## @param podSecurityContext.fsGroup Group ID for the container
+##
+podSecurityContext:
+  enabled: true
+  fsGroup: 1001
+## @param containerSecurityContext.enabled Enable container security context
+## @param containerSecurityContext.capabilities.add [array] Add capabilities for the securityContext
+## @param containerSecurityContext.capabilities.drop [array] Drop capabilities for the securityContext
+## @param containerSecurityContext.readOnlyRootFilesystem Allows the pod to mount the RootFS as ReadOnly only
+## @param containerSecurityContext.runAsNonRoot If the pod should run as a non root container.
+## @param containerSecurityContext.runAsUser Define the uid with which the pod will run
+##
+containerSecurityContext:
+  enabled: true
+  capabilities:
+    add: []
+    drop:
+      - ALL
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  runAsUser: 1001
+## @param command Override default container command (useful when using custom images)
+##
+command: []
+## @param args Override default container args (useful when using custom images)
+##
+args: []
+## @param lifecycleHooks Lifecycle for the container to automate configuration before or after startup
+##
+lifecycleHooks: {}
+## Container resource requests and limits
+## ref: https://kubernetes.io/docs/user-guide/compute-resources/
+## We usually recommend not to specify default resources and to leave this as a conscious
+## choice for the user. This also increases chances charts run on environments with little
+## resources, such as Minikube. If you do want to specify resources, uncomment the following
+## lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+## @param resources.limits Specify resource limits which the container is not allowed to succeed.
+## @param resources.requests Specify resource requests which the container needs to spawn.
+##
+resources:
+  ## Example:
+  ## limits:
+  ##    cpu: 400m
+  ##    memory: 250Mi
+  limits: {}
+  ## Examples:
+  ## requests:
+  ##    cpu: 100m
+  ##    memory: 25Mi
+  requests: {}
+
+## Configure extra custom startup, liveness and readiness probes
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
+## @param customStartupProbe Configure startup probe for Kubernetes event exporter pod
+##
+customStartupProbe: {}
+## @param customLivenessProbe Configure liveness probe for Kubernetes event exporter pod
+##
+customLivenessProbe: {}
+## @param customReadinessProbe Configure readiness probe for Kubernetes event exporter pod
+##
+customReadinessProbe: {}
+## @param nodeSelector Node labels for pod assignment
+## Ref: https://kubernetes.io/docs/user-guide/node-selection/
+##
+nodeSelector: {}
+## @param priorityClassName Set Priority Class Name to allow priority control over other pods
+## ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
+##
+priorityClassName: ""
+## @param schedulerName Name of the k8s scheduler (other than default)
+## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
+##
+schedulerName: ""
+## @param topologySpreadConstraints Topology Spread Constraints for pod assignment
+## https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
+## The value is evaluated as a template
+##
+topologySpreadConstraints: []
+## @param tolerations Tolerations for pod assignment
+## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+##
+tolerations: []
+## @param podAffinityPreset Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
+## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+##
+podAffinityPreset: ""
+## @param podAntiAffinityPreset Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
+## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+##
+podAntiAffinityPreset: soft
+## Node affinity preset
+## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
+##
+nodeAffinityPreset:
+  ## @param nodeAffinityPreset.type Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
+  ##
+  type: ""
+  ## @param nodeAffinityPreset.key Node label key to match. Ignored if `affinity` is set.
+  ## E.g.
+  ## key: "kubernetes.io/e2e-az-name"
+  ##
+  key: ""
+  ## @param nodeAffinityPreset.values Node label values to match. Ignored if `affinity` is set.
+  ## E.g.
+  ## values:
+  ##   - e2e-az1
+  ##   - e2e-az2
+  ##
+  values: []
+## @param affinity Affinity for pod assignment
+## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+## Note: podAffinityPreset, podAntiAffinityPreset, and  nodeAffinityPreset will be ignored when it's set
+##
+affinity: {}
+## @param updateStrategy.type Deployment strategy type.
+## ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
+## e.g:
+## updateStrategy:
+##  type: RollingUpdate
+##  rollingUpdate:
+##    maxSurge: 25%
+##    maxUnavailable: 25%
+##
+updateStrategy:
+  type: RollingUpdate
+## @param extraEnvVars Array containing extra env vars to be added to all containers
+## For example:
+## extraEnvVars:
+##  - name: MY_ENV_VAR
+##    value: env_var_value
+##
+extraEnvVars: []
+## @param extraEnvVarsCM ConfigMap containing extra env vars to be added to all containers
+##
+extraEnvVarsCM: ""
+## @param extraEnvVarsSecret Secret containing extra env vars to be added to all containers
+##
+extraEnvVarsSecret: ""
+## @param extraVolumeMounts Array to add extra mounts (normally used with extraVolumes)
+##
+extraVolumeMounts: []
+## @param extraVolumes Array to add extra volumes
+##
+extraVolumes: []
+## @param initContainers Attach additional init containers to pods
+## For example:
+## initContainers:
+##   - name: your-image-name
+##     image: your-image
+##     imagePullPolicy: Always
+##
+initContainers: []
+## @param sidecars Add additional sidecar containers to pods
+## e.g:
+## sidecars:
+##   - name: your-image-name
+##     image: your-image
+##     imagePullPolicy: Always
+##     ports:
+##       - name: portname
+##         containerPort: 1234
+##
+sidecars: []
+
+## Metrics configuration
+##
+metrics:
+  ## @param metrics.enabled Enable exposing  statistics
+  ## ref: https://github.com/resmoio/kubernetes-event-exporter/blob/858089f2dc42243c0939a7f13a76fdd22e70be0f/main.go#L25
+  ##
+  enabled: false
+  ##  metrics service parameters
+  ##
+  service:
+    ## @param metrics.service.ports.http Metrics service HTTP port
+    ##
+    ports:
+      http: 2112
+    ## @param metrics.service.annotations [object] Annotations for enabling prometheus to access the metrics endpoints
+    ##
+    annotations:
+      prometheus.io/scrape: "true"
+      prometheus.io/port: "{{ .Values.metrics.service.ports.http }}"
+  ## Prometheus Operator ServiceMonitor configuration
+  ##
+  serviceMonitor:
+    ## @param metrics.serviceMonitor.enabled Create ServiceMonitor Resource for scraping metrics using PrometheusOperator
+    ##
+    enabled: false
+    ## @param metrics.serviceMonitor.port Metrics service HTTP port
+    ##
+    port: http
+    ## @param metrics.serviceMonitor.endpoints [array] The endpoint configuration of the ServiceMonitor. Path is mandatory. Interval, timeout and labellings can be overwritten.
+    ##
+    endpoints:
+      - path: /metrics
+    ## @param metrics.serviceMonitor.path Metrics service HTTP path. Deprecated: Use @param metrics.serviceMonitor.endpoints instead
+    ##
+    path: ""
+    ## @param metrics.serviceMonitor.namespace Namespace which Prometheus is running in
+    ##
+    namespace: ""
+    ## @param metrics.serviceMonitor.interval Interval at which metrics should be scraped
+    ##
+    interval: 30s
+    ## @param metrics.serviceMonitor.scrapeTimeout Specify the timeout after which the scrape is ended
+    ## e.g:
+    ##   scrapeTimeout: 30s
+    ##
+    scrapeTimeout: ""
+    ## @param metrics.serviceMonitor.labels Additional labels that can be used so ServiceMonitor will be discovered by Prometheus
+    ##
+    labels: {}
+    ## @param metrics.serviceMonitor.selector Prometheus instance selector labels
+    ## ref: https://github.com/bitnami/charts/tree/main/bitnami/prometheus-operator#prometheus-configuration
+    ##
+    selector: {}
+    ## @param metrics.serviceMonitor.relabelings RelabelConfigs to apply to samples before scraping
+    ##
+    relabelings: []
+    ## @param metrics.serviceMonitor.metricRelabelings MetricRelabelConfigs to apply to samples before ingestion
+    ##
+    metricRelabelings: []
+    ## @param metrics.serviceMonitor.honorLabels honorLabels chooses the metric's labels on collisions with target labels
+    ##
+    honorLabels: false
+    ## @param metrics.serviceMonitor.jobLabel The name of the label on the target service to use as the job name in prometheus.
+    ##
+    jobLabel: ""
+  ## Prometheus Operator alert rules configuration
+  ##
+  prometheusRule:
+    ## @param metrics.prometheusRule.enabled Create PrometheusRule Resource for scraping metrics using PrometheusOperator
+    ##
+    enabled: false
+    ## @param metrics.prometheusRule.namespace Namespace which Prometheus is running in
+    ##
+    namespace: ""
+    ## @param metrics.prometheusRule.labels Additional labels that can be used so PrometheusRule will be discovered by Prometheus
+    ##
+    labels: {}
+    ## @param metrics.prometheusRule.groups Groups, containing the alert rules.
+    ## Example:
+    ##   groups:
+    ##     - name: KubernetesEventExporter
+    ##       rules:
+    ##         - alert: KubernetesEventExporterTooManyWatchErrors
+    ##           annotations:
+    ##             message: "Kubernetes Event Exporter instance in namespace {{ `{{` }} $labels.namespace {{ `}}` }} has reported too many watch errors in 5 minutes."
+    ##           expr: |
+    ##             sum(watch_errors{namespace="{{ include "common.names.namespace" . }}"})
+    ##           for: 5m
+    ##           labels:
+    ##             severity: critical
+    groups: []

--- a/modules/kubernetes-addons/kubernetes-event-exporter/variables.tf
+++ b/modules/kubernetes-addons/kubernetes-event-exporter/variables.tf
@@ -1,0 +1,28 @@
+variable "helm_config" {
+  description = "Helm provider config for the Karpenter"
+  type        = any
+  default     = {}
+}
+
+variable "addon_context" {
+  description = "Input configuration for the addon"
+  type = object({
+    aws_caller_identity_account_id = string
+    aws_caller_identity_arn        = string
+    aws_eks_cluster_endpoint       = string
+    aws_partition_id               = string
+    aws_region_name                = string
+    eks_cluster_id                 = string
+    eks_oidc_issuer_url            = string
+    eks_oidc_provider_arn          = string
+    tags                           = map(string)
+    irsa_iam_role_path             = string
+    irsa_iam_permissions_boundary  = string
+  })
+}
+
+variable "manage_via_gitops" {
+  description = "Determines if the add-on should be managed via GitOps"
+  type        = bool
+  default     = false
+}

--- a/modules/kubernetes-addons/main.tf
+++ b/modules/kubernetes-addons/main.tf
@@ -815,3 +815,13 @@ module "consul" {
   manage_via_gitops = var.argocd_manage_add_ons
   addon_context     = local.addon_context
 }
+
+module "kubernetes_event_exporter" {
+  source = "./kubernetes-event-exporter"
+
+  count = var.enable_kubernetes_event_exporter ? 1 : 0
+
+  helm_config       = var.kubernetes_event_exporter_config
+  manage_via_gitops = var.argocd_manage_add_ons
+  addon_context     = local.addon_context
+}

--- a/modules/kubernetes-addons/variables.tf
+++ b/modules/kubernetes-addons/variables.tf
@@ -1472,3 +1472,16 @@ variable "consul_helm_config" {
   type        = any
   default     = {}
 }
+
+variable "enable_kubernetes_event_exporter" {
+  description = "kubernetes-event-exporter add-on"
+  type        = bool
+  default     = false
+}
+
+variable "kubernetes_event_exporter_config" {
+  description = "kubernetes-event-exporter Helm configuration values"
+  type        = any
+  default     = {}
+}
+


### PR DESCRIPTION
### What does this PR do?

Adds a module to install kubernetes-event-exporter helm chart. It can print kubernetes events to stdout, which can be exported a log tool.

🛑 Please open an issue first to discuss any significant work and flesh out details/direction - we would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/aws-ia/terraform-aws-eks-blueprints/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

<!-- A brief description of the change being made with this pull request. -->

### Motivation

I would like to use this module for an observability submodule in eks-workshop v2.

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

I added the module to the argocd example and deployed for testing purposes. It worked.
