### PR TITLE
fix: External-secrets // fix IAM permissions for SA

### DIFF
--- a/modules/kubernetes-addons/external-secrets/data.tf
+++ b/modules/kubernetes-addons/external-secrets/data.tf
@@ -6,6 +6,13 @@ data "aws_iam_policy_document" "external_secrets" {
       ["arn:${var.addon_context.aws_partition_id}:ssm:${var.addon_context.aws_region_name}:${var.addon_context.aws_caller_identity_account_id}:parameter/*"]
     )
   }
+  statement {
+    # it seems `ssm:DescribeParameters` needs wildcard on resources.
+    actions = ["ssm:DescribeParameters"]
+    resources = concat(
+      ["arn:${var.addon_context.aws_partition_id}:ssm:${var.addon_context.aws_region_name}:${var.addon_context.aws_caller_identity_account_id}:*"]
+    )
+  }
 
   statement {
     actions = [

--- a/modules/kubernetes-addons/external-secrets/data.tf
+++ b/modules/kubernetes-addons/external-secrets/data.tf
@@ -22,9 +22,7 @@ data "aws_iam_policy_document" "external_secrets" {
 
   statement {
     # it seems `ssm:DescribeParameters` needs wildcard on resources.
-    actions = ["ssm:DescribeParameters"]
-    resources = concat(
-      ["arn:${var.addon_context.aws_partition_id}:ssm:${var.addon_context.aws_region_name}:${var.addon_context.aws_caller_identity_account_id}:*"]
-    )
+    actions   = ["ssm:DescribeParameters"]
+    resources = ["arn:${var.addon_context.aws_partition_id}:ssm:${var.addon_context.aws_region_name}:${var.addon_context.aws_caller_identity_account_id}:*"]
   }
 }

--- a/modules/kubernetes-addons/external-secrets/data.tf
+++ b/modules/kubernetes-addons/external-secrets/data.tf
@@ -6,13 +6,6 @@ data "aws_iam_policy_document" "external_secrets" {
       ["arn:${var.addon_context.aws_partition_id}:ssm:${var.addon_context.aws_region_name}:${var.addon_context.aws_caller_identity_account_id}:parameter/*"]
     )
   }
-  statement {
-    # it seems `ssm:DescribeParameters` needs wildcard on resources.
-    actions = ["ssm:DescribeParameters"]
-    resources = concat(
-      ["arn:${var.addon_context.aws_partition_id}:ssm:${var.addon_context.aws_region_name}:${var.addon_context.aws_caller_identity_account_id}:*"]
-    )
-  }
 
   statement {
     actions = [
@@ -24,6 +17,14 @@ data "aws_iam_policy_document" "external_secrets" {
     resources = concat(
       var.external_secrets_secrets_manager_arns,
       ["arn:${var.addon_context.aws_partition_id}:secretsmanager:${var.addon_context.aws_region_name}:${var.addon_context.aws_caller_identity_account_id}:secret:*"]
+    )
+  }
+
+  statement {
+    # it seems `ssm:DescribeParameters` needs wildcard on resources.
+    actions = ["ssm:DescribeParameters"]
+    resources = concat(
+      ["arn:${var.addon_context.aws_partition_id}:ssm:${var.addon_context.aws_region_name}:${var.addon_context.aws_caller_identity_account_id}:*"]
     )
   }
 }


### PR DESCRIPTION
`ssm:DescribeParameters` seems to need a resource wildcard

### What does this PR do?

Adds IAM permission for external-secrets SA to allow use of `ssm:DescribeParameters` on wildcard resource.

### Motivation

- Resolves aws-ia/terraform-aws-eks-blueprints-addons#75 

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [x] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
    - not needed
- [x] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

TF plan run
```
  # module.eks_blueprints_kubernetes_addons.module.external_secrets[0].aws_iam_policy.external_secrets will be updated in-place
  ~ resource "aws_iam_policy" "external_secrets" {
        id          = "arn:aws:iam::<account>:policy/eks-external-secrets-irsa"
        name        = "eks-external-secrets-irsa"
      ~ policy      = jsonencode(
          ~ {
              ~ Statement = [
                  ~ {
                      ~ Resource = "arn:aws:ssm:*:*:parameter/*" -> [
                          + "arn:aws:ssm:eu-central-1:<account>:parameter/*",
                          + "arn:aws:ssm:*:*:parameter/*",
                        ]
                        # (3 unchanged elements hidden)
                    },
                  ~ {
                      ~ Resource = "arn:aws:secretsmanager:*:*:secret:*" -> [
                          + "arn:aws:secretsmanager:eu-central-1:<account>:secret:*",
                          + "arn:aws:secretsmanager:*:*:secret:*",
                        ]
                        # (3 unchanged elements hidden)
                    },
                  + {
                      + Action   = "ssm:DescribeParameters"
                      + Effect   = "Allow"
                      + Resource = "arn:aws:ssm:eu-central-1:<account>:*"
                      + Sid      = ""
                    },
                ]
                # (1 unchanged element hidden)
            }
        )
        tags        = {}
        # (5 unchanged attributes hidden)
    }
```
