### PR TITLE
recurse for directory support added to kubectl argocd app

### DIFF
--- a/docs/add-ons/argocd.md
+++ b/docs/add-ons/argocd.md
@@ -130,10 +130,12 @@ argocd_applications = {
       This points to a single application with no overlays, but it could easily
       point to a a specific overlay for an environment like "dev", and/or utilize
       the ArgoCD app of apps model to install many additional ArgoCD apps.
+      Directory recursion is enabled: https://argo-cd.readthedocs.io/en/stable/user-guide/directory/#enabling-recursive-resource-detection
     */
     path                = "argocd-example-apps/kustomize-guestbook/"
     repo_url            = "https://github.com/argoproj/argocd-example-apps.git"
     type                = "kustomize"
+    recurse             = true
   }
   addons = {
     path                = "chart"

--- a/modules/kubernetes-addons/argocd/argocd-application/kubectl/application.yaml.tftpl
+++ b/modules/kubernetes-addons/argocd/argocd-application/kubectl/application.yaml.tftpl
@@ -11,6 +11,10 @@ spec:
     repoURL: ${sourceRepoUrl}
     targetRevision: ${sourceTargetRevision}
     path: ${sourcePath}
+    %{ if useRecurse }
+    directory:
+      recurse: true
+    %{ endif }
   destination:
     server: ${destinationServer}
     namespace: ${namespace}

--- a/modules/kubernetes-addons/argocd/locals.tf
+++ b/modules/kubernetes-addons/argocd/locals.tf
@@ -30,6 +30,7 @@ locals {
     values             = {}
     type               = "helm"
     add_on_application = false
+    use_recurse        = false
   }
 
   global_application_values = {

--- a/modules/kubernetes-addons/argocd/main.tf
+++ b/modules/kubernetes-addons/argocd/main.tf
@@ -107,6 +107,7 @@ resource "kubectl_manifest" "argocd_kustomize_application" {
       sourcePath           = each.value.path
       destinationServer    = each.value.destination
       ignoreDifferences    = lookup(each.value, "ignoreDifferences", [])
+      useRecurse           = each.value.use_recurse
     }
   )
 


### PR DESCRIPTION
### What does this PR do?

🛑 Please open an issue first to discuss any significant work and flesh out details/direction - we would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/aws-ia/terraform-aws-eks-blueprints/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

This PR adds support for ArgoCD app recursion: https://argo-cd.readthedocs.io/en/stable/user-guide/directory/#enabling-recursive-resource-detection

### Motivation

- Resolves #1505

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [x] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR - and it's giving an error in external-secrets (unrelated to my pr)

### For Moderators

- [ ] E2E Test successfully complete before merge?

