### PR TITLE
chore: Use helm_release create_namespace option

### DIFF
--- a/modules/kubernetes-addons/argocd/README.md
+++ b/modules/kubernetes-addons/argocd/README.md
@@ -38,7 +38,6 @@ Application definitions, configurations, and environments should be declarative 
 |------|------|
 | [helm_release.argocd_application](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [kubectl_manifest.argocd_kustomize_application](https://registry.terraform.io/providers/gavinbunney/kubectl/latest/docs/resources/manifest) | resource |
-| [kubernetes_namespace_v1.this](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace_v1) | resource |
 | [kubernetes_secret.argocd_gitops](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
 | [aws_secretsmanager_secret.ssh_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret) | data source |
 | [aws_secretsmanager_secret_version.ssh_key_version](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret_version) | data source |

--- a/modules/kubernetes-addons/argocd/main.tf
+++ b/modules/kubernetes-addons/argocd/main.tf
@@ -7,23 +7,17 @@ module "helm_addon" {
   depends_on = [kubernetes_namespace_v1.this]
 }
 
-resource "kubernetes_namespace_v1" "this" {
-  count = try(local.helm_config["create_namespace"], true) && local.helm_config["namespace"] != "kube-system" ? 1 : 0
-  metadata {
-    name = local.helm_config["namespace"]
-  }
-}
-
 # ---------------------------------------------------------------------------------------------------------------------
 # ArgoCD App of Apps Bootstrapping (Helm)
 # ---------------------------------------------------------------------------------------------------------------------
 resource "helm_release" "argocd_application" {
   for_each = { for k, v in var.applications : k => merge(local.default_argocd_application, v) if merge(local.default_argocd_application, v).type == "helm" }
 
-  name      = each.key
-  chart     = "${path.module}/argocd-application/helm"
-  version   = "1.0.0"
-  namespace = local.helm_config["namespace"]
+  name             = each.key
+  chart            = "${path.module}/argocd-application/helm"
+  version          = "1.0.0"
+  namespace        = local.helm_config["namespace"]
+  create_namespace = try(local.helm_config["create_namespace"], true)
 
   # Application Meta.
   set {


### PR DESCRIPTION
### What does this PR do?

I have entrusted helm_release with the creation of the ArgoCD namespace.

### Motivation

Kubernetes namespace resources can get stuck when deleted.
For example, in the case of ArgoCD, when deleting an Application resource, if ArgoCD is deleted first, the Application resource Finalizer will stop and the ArgoCD namespace cannot be deleted forever.
Therefore, it is better to leave the creation of the ArgoCD namespace to helm_release, which is especially stable when deleting.

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [x] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
