### PR TITLE
fix: Escape regex validation backslash

### DIFF
--- a/modules/kubernetes-addons/argocd/variables.tf
+++ b/modules/kubernetes-addons/argocd/variables.tf
@@ -10,7 +10,7 @@ variable "applications" {
   default     = {}
 
   validation {
-    condition     = alltrue([for k, v in var.applications : length(regexall("^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$", k)) > 0])
+    condition     = alltrue([for k, v in var.applications : length(regexall("^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$", k)) > 0])
     error_message = "All ArgoCD application config keys must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character"
   }
 }


### PR DESCRIPTION

### What does this PR do?
This fixes a recent change that broke the argocd addon variables file -- i escaped the backslash before the dot so that it's a valid regex.
