### PR TITLE
fix: Allow more restrictive policies on external-secrets

### DIFF
--- a/modules/kubernetes-addons/external-secrets/data.tf
+++ b/modules/kubernetes-addons/external-secrets/data.tf
@@ -1,10 +1,7 @@
 data "aws_iam_policy_document" "external_secrets" {
   statement {
-    actions = ["ssm:GetParameter"]
-    resources = concat(
-      var.external_secrets_ssm_parameter_arns,
-      ["arn:${var.addon_context.aws_partition_id}:ssm:${var.addon_context.aws_region_name}:${var.addon_context.aws_caller_identity_account_id}:parameter/*"]
-    )
+    actions   = ["ssm:GetParameter"]
+    resources = length(var.external_secrets_ssm_parameter_arns) > 0 ? var.external_secrets_ssm_parameter_arns : ["arn:${var.addon_context.aws_partition_id}:ssm:${var.addon_context.aws_region_name}:${var.addon_context.aws_caller_identity_account_id}:parameter/*"]
   }
 
   statement {
@@ -14,9 +11,6 @@ data "aws_iam_policy_document" "external_secrets" {
       "secretsmanager:DescribeSecret",
       "secretsmanager:ListSecretVersionIds",
     ]
-    resources = concat(
-      var.external_secrets_secrets_manager_arns,
-      ["arn:${var.addon_context.aws_partition_id}:secretsmanager:${var.addon_context.aws_region_name}:${var.addon_context.aws_caller_identity_account_id}:secret:*"]
-    )
+    resources = length(var.external_secrets_secrets_manager_arns) > 0 ? var.external_secrets_secrets_manager_arns : ["arn:${var.addon_context.aws_partition_id}:secretsmanager:${var.addon_context.aws_region_name}:${var.addon_context.aws_caller_identity_account_id}:secret:*"]
   }
 }


### PR DESCRIPTION
### What does this PR do?

Allows more restrictive account-wise secrets and parameters if needed.

<!-- A brief description of the change being made with this pull request. -->

If the user passes ARNs allow those ARNs to be used, otherwise use the default account-wide secrets/param usage.

### Motivation

<!-- What inspired you to submit this pull request? -->

I am allowing secrets based by a path-name strategy in each cluster:
(e.g `arn:aws:secretsmanager:<reg_id>:<acc_id>:secret:<cluster_name>/*"`)

With the bump to 2.47.0, I noticed that applying would in fact allow any cluster to access any secret via the IRSA.
`arn:aws:secretsmanager:<reg_id>:<acc_id>:secret:*` is added alongside the previous one.

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR
##### Precommit
```
$ gc -m 'allow more restrictive policies'
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check for merge conflicts................................................Passed
detect private key.......................................................Passed
detect aws credentials...................................................Passed
Terraform fmt............................................................Passed
Terraform docs...........................................................Passed
Terraform validate with tflint...........................................Passed
Terraform validate.......................................................Passed
Terraform validate with tfsec........................(no files to check)Skipped
[fix/default-all-account-secrets 876dad3] allow more restrictive policies
 1 file changed, 3 insertions(+), 9 deletions(-)
```

##### Tfsec
```
$ tfsec modules/kubernetes-addons/external-secrets
  timings
  ──────────────────────────────────────────
  disk i/o             448.768µs
  parsing              30.786129ms
  adaptation           270.476µs
  checks               3.500227ms
  total                35.0056ms

  counts
  ──────────────────────────────────────────
  modules downloaded   0
  modules processed    3
  blocks processed     55
  files read           14

  results
  ──────────────────────────────────────────
  passed               9
  ignored              0
  critical             0
  high                 0
  medium               0
  low                  0


No problems detected!
```

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
I did not open an issue as it's not technically a bug  🤔

##### [Test] When changing the array of ARNs to empty array
```
  ~ resource "aws_iam_policy" "external_secrets" {
        id          = "arn:aws:iam::REDACTED:policy/REDACTED-external-secrets-irsa"
        name        = "REDACTED-external-secrets-irsa"
      ~ policy      = jsonencode(
          ~ {
              ~ Statement = [
                    {
                        Action   = "ssm:GetParameter"
                        Effect   = "Allow"
                        Resource = "arn:aws:ssm:*:*:parameter/*"
                        Sid      = ""
                    },
                  ~ {
                      ~ Resource = "arn:aws:secretsmanager:REDACTED:REDACTED:secret:REDACTED/*" -> "arn:aws:secretsmanager:REDACTED:secret:*"
                        # (3 unchanged elements hidden)
                    },
                ]
                # (1 unchanged element hidden)
            }
        )
        tags        = {}
        # (5 unchanged attributes hidden)
    }
```
 Otherwise, it stays the same.