### PR TITLE
feat(cert-manager): GitOps: Add support for installing issuers

### DIFF
--- a/docs/add-ons/cert-manager.md
+++ b/docs/add-ons/cert-manager.md
@@ -46,5 +46,14 @@ The following properties are made available for use when managing the add-on via
 
 certManager = {
   enable = true
+  serviceAccountName = local.service_account
+  certManagerCa = {
+    enabled = true
+  }
+  certManagerLetsencrypt = {
+    enabled  = var.install_letsencrypt_issuers
+    email    = var.letsencrypt_email
+    dnsZones = var.domain_names
+  }
 }
 ```

--- a/modules/kubernetes-addons/argocd/main.tf
+++ b/modules/kubernetes-addons/argocd/main.tf
@@ -69,7 +69,7 @@ resource "helm_release" "argocd_application" {
       { repoUrl = each.value.repo_url },
       each.value.values,
       local.global_application_values,
-      each.value.add_on_application ? var.addon_config : {}
+      yamldecode(each.value.add_on_application ? yamlencode(var.addon_config) : yamlencode({}))
     ))
     type = "auto"
   }

--- a/modules/kubernetes-addons/cert-manager/locals.tf
+++ b/modules/kubernetes-addons/cert-manager/locals.tf
@@ -47,5 +47,13 @@ locals {
   argocd_gitops_config = {
     enable             = true
     serviceAccountName = local.service_account
+    certManagerCa = {
+      enabled = true
+    }
+    certManagerLetsencrypt = {
+      enabled  = var.install_letsencrypt_issuers
+      email    = var.letsencrypt_email
+      dnsZones = var.domain_names
+    }
   }
 }


### PR DESCRIPTION
### What does this PR do?

Two descriptions for each commits:

----

[feat(cert-manager): GitOps: Add support for installing issuers](https://github.com/aws-ia/terraform-aws-eks-blueprints/commit/b974a0396510b0f1734fdc267cbda44f0975d26a)

Currently cert-manager with GitOps config has the two issues:

1. It does not install CA, whereas it is installed by default without GitOps
2. It does not support `cert_manager_install_letsencrypt_issuers` option.

To resolve the issue, I did the following:

1. Copy the [helm charts](1) to [eks-blueprints-add-ons](2) as-is. See: https://github.com/aws-samples/eks-blueprints-add-ons/pull/147
2. Add additional configuration to support those two helm charts.

[1]: https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/modules/kubernetes-addons/cert-manager
[2]: https://github.com/aws-samples/eks-blueprints-add-ons

----

[feat(argocd): handle complex object type for addon_config](https://github.com/aws-ia/terraform-aws-eks-blueprints/commit/70a110a1ea54c214903354455be88aef54dfe223)

The previous commit uses a complext object type to specify values for
a helm chart with multiple subcharts.

However this triggers Inconsistent conditional result types error like
following:

> Error: Inconsistent conditional result types
>   on .terraform/modules/eks.blueprints_kubernetes_addons/modules/kubernetes-addons/argocd/main.tf line 72, in resource "helm_release" "argocd_application":
>   72:       each.value.add_on_application ? var.addon_config : {}
>     ├────────────────
>     │ each.value.add_on_application is true
>     │ var.addon_config is object with 10 attributes
>
> The true and false result expressions must have consistent types. The
> 'true' value includes object attribute "awsEfsCsiDriver", which is absent
> in the 'false' value.

To workaround the issue I had to encode & decode the line causing the issue.
It doesn't look pretty but I don't come up a better solution.

----

### Motivation


<!-- What inspired you to submit this pull request? -->
- Resolves https://github.com/aws-samples/eks-blueprints-add-ons/issues/127
- Related: https://github.com/aws-samples/eks-blueprints-add-ons/pull/147

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [x] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
