### PR TITLE
feat: Add FSx for NetApp ONTAP CSI add-on

### DIFF
--- a/docs/add-ons/aws-fsxn-csi-driver.md
+++ b/docs/add-ons/aws-fsxn-csi-driver.md
@@ -6,7 +6,7 @@ This add-on deploys the [Amazon FSx for NetApp ONTAP CSI Driver](https://aws.ama
 
 ## Usage
 
-The [Amazon FSx for NetApp ONTAP CSI Driver](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/modules/kubernetes-addons/aws-fsxn-csi-driver) can be deployed by enabling the add-on via the following.
+The [Amazon FSx for NetApp ONTAP CSI Driver](https://github.com/mickeysh/terraform-aws-eks-blueprints/tree/main/modules/kubernetes-addons/aws-fsxn-csi-driver) can be deployed by enabling the add-on via the following.
 
 ```hcl
   enable_aws_fsxn_csi_driver = true

--- a/docs/add-ons/aws-fsxn-csi-driver.md
+++ b/docs/add-ons/aws-fsxn-csi-driver.md
@@ -1,0 +1,44 @@
+# Amazon FSx for NetApp ONTAP
+ CSI Driver
+
+Amazon FSx for NetApp ONTAP is a fully managed service that provides highly reliable, scalable, high-performing, and feature-rich file storage built on NetApp's popular ONTAP file system.
+This add-on deploys the [Amazon FSx for NetApp ONTAP CSI Driver](https://aws.amazon.com/fsx/netapp-ontap/) into an EKS cluster.
+
+## Usage
+
+The [Amazon FSx for NetApp ONTAP CSI Driver](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/modules/kubernetes-addons/aws-fsxn-csi-driver) can be deployed by enabling the add-on via the following.
+
+```hcl
+  enable_aws_fsxn_csi_driver = true
+```
+
+You can optionally customize the Helm chart that deploys `enable_aws_fsxn_csi_driver` via the following configuration.
+
+```hcl
+  enable_aws_fsxn_csi_driver = true
+  aws_fsx_csi_driver_helm_config = {
+    name                       = "trident-operator"
+    chart                      = "trident-operator"
+    repository                 = "https://netapp.github.io/trident-helm-chart"
+    version                    = "23.01.0"
+    namespace                  = "trident"
+    values = [templatefile("${path.module}/values.yaml", {})] # Create this `values.yaml` file with your own custom values
+  }
+```
+
+Once deployed, you will be able to see a number of supporting resources in the `trident` namespace.
+
+```sh
+$ kubectl get deployment fsx-csi-controller -n kube-system
+
+NAME                 READY   UP-TO-DATE   AVAILABLE   AGE
+fsx-csi-controller   2/2     2            2           4m29s
+```
+
+```sh
+$ kubectl get daemonset fsx-csi-node -n kube-system
+
+NAME           DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR                 AGE
+fsx-csi-node   3         3         3       3            3           kubernetes.io/os=linux   4m32s
+```
+

--- a/docs/add-ons/aws-fsxn-csi-driver.md
+++ b/docs/add-ons/aws-fsxn-csi-driver.md
@@ -29,16 +29,16 @@ You can optionally customize the Helm chart that deploys `enable_aws_fsxn_csi_dr
 Once deployed, you will be able to see a number of supporting resources in the `trident` namespace.
 
 ```sh
-$ kubectl get deployment fsx-csi-controller -n kube-system
+$ kubectl get deployment trident-controller -n trident
 
 NAME                 READY   UP-TO-DATE   AVAILABLE   AGE
-fsx-csi-controller   2/2     2            2           4m29s
+trident-controller   1/1     1            1           41m
 ```
 
 ```sh
-$ kubectl get daemonset fsx-csi-node -n kube-system
+$ kubectl get daemonset trident-node-linux -n trident
 
-NAME           DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR                 AGE
-fsx-csi-node   3         3         3       3            3           kubernetes.io/os=linux   4m32s
+NAME                 DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR                                     AGE
+trident-node-linux   6         6         6       6            6           kubernetes.io/arch=amd64,kubernetes.io/os=linux   42m
 ```
 

--- a/modules/kubernetes-addons/aws-fsxn-csi-driver/locals.tf
+++ b/modules/kubernetes-addons/aws-fsxn-csi-driver/locals.tf
@@ -1,5 +1,5 @@
 locals {
-  name = "trident-operator"
+  name      = "trident-operator"
   namespace = "trident"
 
   default_helm_config = {
@@ -17,6 +17,6 @@ locals {
 
   default_helm_values = [templatefile("${path.module}/values.yaml", {})]
 
-  helm_config = merge(local.default_helm_config,var.helm_config)
+  helm_config = merge(local.default_helm_config, var.helm_config)
   irsa_config = {}
 }

--- a/modules/kubernetes-addons/aws-fsxn-csi-driver/locals.tf
+++ b/modules/kubernetes-addons/aws-fsxn-csi-driver/locals.tf
@@ -1,0 +1,22 @@
+locals {
+  name = "trident-operator"
+  namespace = "trident"
+
+  default_helm_config = {
+    name             = local.name
+    chart            = local.name
+    repository       = "https://netapp.github.io/trident-helm-chart"
+    version          = "23.01.0"
+    namespace        = local.namespace
+    create_namespace = true
+    values           = local.default_helm_values
+    set              = []
+    description      = "Amazon FSx for NetApp ONTAP CSI storage provisioner using the Trident Operator."
+    wait             = false
+  }
+
+  default_helm_values = [templatefile("${path.module}/values.yaml", {})]
+
+  helm_config = merge(local.default_helm_config,var.helm_config)
+  irsa_config = {}
+}

--- a/modules/kubernetes-addons/aws-fsxn-csi-driver/main.tf
+++ b/modules/kubernetes-addons/aws-fsxn-csi-driver/main.tf
@@ -4,7 +4,6 @@
 module "helm_addon" {
   source            = "../helm-addon"
   manage_via_gitops = var.manage_via_gitops
-  set_values        = local.set_values
   helm_config       = local.helm_config
   irsa_config       = local.irsa_config
   addon_context     = var.addon_context

--- a/modules/kubernetes-addons/aws-fsxn-csi-driver/main.tf
+++ b/modules/kubernetes-addons/aws-fsxn-csi-driver/main.tf
@@ -1,0 +1,11 @@
+#-------------------------------------------------
+# FSx for NetApp ONTAP Helm Add-on
+#-------------------------------------------------
+module "helm_addon" {
+  source            = "../helm-addon"
+  manage_via_gitops = var.manage_via_gitops
+  set_values        = local.set_values
+  helm_config       = local.helm_config
+  irsa_config       = local.irsa_config
+  addon_context     = var.addon_context
+}

--- a/modules/kubernetes-addons/aws-fsxn-csi-driver/outputs.tf
+++ b/modules/kubernetes-addons/aws-fsxn-csi-driver/outputs.tf
@@ -1,8 +1,3 @@
-output "argocd_gitops_config" {
-  description = "Configuration used for managing the add-on with ArgoCD"
-  value       = var.manage_via_gitops ? local.argocd_gitops_config : null
-}
-
 output "release_metadata" {
   description = "Map of attributes of the Helm release metadata"
   value       = module.helm_addon.release_metadata

--- a/modules/kubernetes-addons/aws-fsxn-csi-driver/outputs.tf
+++ b/modules/kubernetes-addons/aws-fsxn-csi-driver/outputs.tf
@@ -1,0 +1,10 @@
+output "argocd_gitops_config" {
+  description = "Configuration used for managing the add-on with ArgoCD"
+  value       = var.manage_via_gitops ? local.argocd_gitops_config : null
+}
+
+output "release_metadata" {
+  description = "Map of attributes of the Helm release metadata"
+  value       = module.helm_addon.release_metadata
+}
+

--- a/modules/kubernetes-addons/aws-fsxn-csi-driver/values.yaml
+++ b/modules/kubernetes-addons/aws-fsxn-csi-driver/values.yaml
@@ -1,0 +1,125 @@
+# Default values for standalone.
+# This is a YAML-formatted file.
+
+## Node labels for pod assignment
+## ref: https://kubernetes.io/docs/user-guide/node-selection/
+nodeSelector: {}
+
+## Pod Annotations
+podAnnotations: {}
+
+## Deployment Annotations
+deploymentAnnotations: {}
+
+## Tolerations for pod assignment
+## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+tolerations: []
+
+## Affinity for pod assignment
+## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+affinity: {}
+
+# tridentControllerPluginNodeSelector additional nodeSelectors for the Pod running the Trident Controller CSI Plugin.
+# tridentControllerPluginNodeSelector : {}
+
+# tridentControllerPluginTolerations overrides tolerations for the Pod running the Trident Controler CSI Plugin.
+# tridentControllerPluginTolerations: []
+
+# tridentNodePluginNodeSelector additional nodeSelectors for Pods running the Trident Node CSI Plugin.
+# tridentNodePluginNodeSelector : {}
+
+# tridentNodePluginTolerations overrides tolerations for Pods running the Trident Node CSI Plugin. 
+# tridentNodePluginTolerations: []
+
+
+
+# imageRegistry identifies the registry for the trident-operator, trident, and other images.  Leave empty to accept the default.
+imageRegistry: ""
+
+# imagePullPolicy sets the image pull policy for the trident-operator.
+imagePullPolicy: IfNotPresent
+
+# imagePullSecrets sets the image pull secrets for the trident-operator, trident, and other images.
+imagePullSecrets: []
+
+# kubeletDir allows overriding the host location of kubelet's internal state. (default "/var/lib/kubelet").
+kubeletDir: ""
+
+
+# operatorLogLevel allows the log level of the Trident operator to be set to one of these: 
+# trace, debug, info, warn, error, fatal.
+# operatorLogLevel: "info"
+
+# operatorDebug allows the log level of the Trident operator to be set to debug
+operatorDebug: true
+
+# operatorImage allows the complete override of the image for trident-operator.
+operatorImage: ""
+
+# operatorImageTag allows overriding the tag of the trident-operator image.
+operatorImageTag: ""
+
+
+# tridentIPv6 allows enabling Trident to work in IPv6 clusters.
+tridentIPv6: false
+
+# tridentK8sTimeout overrides the default 30-second timeout for most Kubernetes API operations (if non-zero, in seconds).
+tridentK8sTimeout: 0
+
+# tridentHttpRequestTimeout (duration) overrides the default 90-second timeout for the HTTP requests, with 0s being an
+# infinite duration for the timeout. Negative values are not allowed.
+tridentHttpRequestTimeout: "90s"
+
+# tridentSilenceAutosupport allows disabling Trident's periodic Autosupport reporting.
+tridentSilenceAutosupport: false
+
+# tridentAutosupportImage allows the complete override of the image for Trident's Autosupport container.
+tridentAutosupportImage: ""
+
+# tridentAutosupportImageTag allows overriding the tag of the image for Trident's Autosupport container.
+tridentAutosupportImageTag: "23.01"
+
+# tridentAutosupportProxy allows Trident's autosupport container to phone home via an HTTP proxy.
+tridentAutosupportProxy: ""
+
+# tridentLogFormat sets the Trident logging format (text or json).
+tridentLogFormat: "text"
+
+# tridentDisableAuditLog disables Trident's audit logger.
+tridentDisableAuditLog: true
+
+# tridentLogLevel allows the log level of Trident to be set to one of these: trace, debug, info, warn, error, fatal.
+#tridentLogLevel: "info"
+
+# tridentDebug allows the log level of Trident to be set to debug
+tridentDebug: false
+
+# tridentLogWorkflows allows specific Trident workflows to be enabled for trace logging or log suppression.
+tridentLogWorkflows: ""
+
+# tridentLogLayers allows specific Trident layers to be enabled for trace logging or log suppression.
+tridentLogLayers: ""
+
+# tridentImage allows the complete override of the image for Trident.
+tridentImage: ""
+
+# tridentImageTag allows overriding the tag of the image for Trident.
+tridentImageTag: ""
+
+# (Deprecated) tridentEnableNodePrep attempts to automatically install required packages on nodes.
+tridentEnableNodePrep: false
+
+# (Deprecated) tridentSkipK8sVersionCheck allows overriding the k8s version limit for Trident.
+tridentSkipK8sVersionCheck: false
+
+# tridentProbePort allows overriding the default port used for k8s liveness/readiness probes.
+tridentProbePort: ""
+
+# windows allows Trident to be installed on Windows worker node.
+windows: false
+
+# enableForceDetach allows enabling the force detach feature.
+enableForceDetach: false
+
+# excludePodSecurityPolicy excludes the operator pod security policy from creation.
+excludePodSecurityPolicy: false

--- a/modules/kubernetes-addons/aws-fsxn-csi-driver/variables.tf
+++ b/modules/kubernetes-addons/aws-fsxn-csi-driver/variables.tf
@@ -1,0 +1,33 @@
+variable "helm_config" {
+  description = "Helm provider config for the aws_fsxn_csi_driver."
+  type        = any
+  default     = {}
+}
+
+variable "manage_via_gitops" {
+  description = "Determines if the add-on should be managed via GitOps."
+  type        = bool
+  default     = false
+}
+
+variable "irsa_policies" {
+  description = "Additional IAM policies for a IAM role for service accounts"
+  type        = list(string)
+  default     = []
+}
+
+variable "addon_context" {
+  description = "Input configuration for the addon"
+  type = object({
+    aws_caller_identity_account_id = string
+    aws_caller_identity_arn        = string
+    aws_eks_cluster_endpoint       = string
+    aws_partition_id               = string
+    aws_region_name                = string
+    eks_cluster_id                 = string
+    eks_oidc_issuer_url            = string
+    eks_oidc_provider_arn          = string
+    tags                           = map(string)
+  })
+}
+

--- a/modules/kubernetes-addons/aws-fsxn-csi-driver/versions.tf
+++ b/modules/kubernetes-addons/aws-fsxn-csi-driver/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.0.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.72"
+    }
+  }
+}

--- a/modules/kubernetes-addons/main.tf
+++ b/modules/kubernetes-addons/main.tf
@@ -155,6 +155,15 @@ module "aws_fsx_csi_driver" {
   addon_context     = local.addon_context
 }
 
+module "aws_fsxn_csi_driver" {
+  count             = var.enable_aws_fsxn_csi_driver ? 1 : 0
+  source            = "./aws-fsxn-csi-driver"
+  helm_config       = var.aws_fsxn_csi_driver_helm_config
+  irsa_policies     = var.aws_fsxn_csi_driver_irsa_policies
+  manage_via_gitops = var.argocd_manage_add_ons
+  addon_context     = local.addon_context
+}
+
 module "aws_for_fluent_bit" {
   count                    = var.enable_aws_for_fluentbit ? 1 : 0
   source                   = "./aws-for-fluentbit"

--- a/modules/kubernetes-addons/variables.tf
+++ b/modules/kubernetes-addons/variables.tf
@@ -604,6 +604,25 @@ variable "aws_fsx_csi_driver_irsa_policies" {
   type        = list(string)
   default     = []
 }
+
+#-----------AWS FSX ONTAP CSI DRIVER ADDON-------------
+variable "enable_aws_fsxn_csi_driver" {
+  description = "Enable AWS FSxN CSI driver add-on"
+  type        = bool
+  default     = false
+}
+
+variable "aws_fsxn_csi_driver_helm_config" {
+  description = "AWS FSxN CSI driver Helm Chart config"
+  type        = any
+  default     = {}
+}
+
+variable "aws_fsxn_csi_driver_irsa_policies" {
+  description = "Additional IAM policies for a IAM role for service accounts"
+  type        = list(string)
+  default     = []
+}
 #-----------AWS LB Ingress Controller-------------
 variable "enable_aws_load_balancer_controller" {
   description = "Enable AWS Load Balancer Controller add-on"


### PR DESCRIPTION
### What does this PR do?
This PR adds support for FSx for NetApp ONTAP CSI driver

<!-- A brief description of the change being made with this pull request. -->

### Motivation
Customers that are working on EKS with Terraform and blueprints/EKS add-ons and implementing FSxN as storage would like to see an integrated way to deploy the CSI driver, same as EBS, EFS and FSx Lustre

<!-- What inspired you to submit this pull request? -->


### More

- [X ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [X ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
