### PR TITLE
fix: Update CSI Secrets Provider driver

### DIFF
--- a/modules/kubernetes-addons/csi-secrets-store-provider-aws/main.tf
+++ b/modules/kubernetes-addons/csi-secrets-store-provider-aws/main.tf
@@ -1,9 +1,17 @@
 locals {
-  name      = try(var.helm_config.name, "csi-secrets-store-provider-aws")
+  name      = try(var.helm_config.name, "secrets-store-csi-driver-provider-aws")
   namespace = try(var.helm_config.namespace, "kube-system")
 }
 
+module "secrets_store_csi_driver" {
+  source = "../secrets-store-csi-driver"
+
+  addon_context = var.addon_context
+}
+
 resource "kubernetes_namespace_v1" "csi_secrets_store_provider_aws" {
+  count = local.namespace == "kube-system" ? 0 : 1
+
   metadata {
     name = local.namespace
   }
@@ -12,19 +20,24 @@ resource "kubernetes_namespace_v1" "csi_secrets_store_provider_aws" {
 module "helm_addon" {
   source = "../helm-addon"
 
-  # https://github.com/aws/eks-charts/blob/master/stable/csi-secrets-store-provider-aws/Chart.yaml
+  # https://github.com/aws/secrets-store-csi-driver-provider-aws/blob/main/charts/secrets-store-csi-driver-provider-aws/Chart.yaml
   helm_config = merge(
     {
       name        = local.name
       chart       = local.name
-      repository  = "https://aws.github.io/eks-charts"
-      version     = "0.0.3"
-      namespace   = kubernetes_namespace_v1.csi_secrets_store_provider_aws.metadata[0].name
-      description = "A Helm chart to install the Secrets Store CSI Driver and the AWS Key Management Service Provider inside a Kubernetes cluster."
+      repository  = "https://aws.github.io/secrets-store-csi-driver-provider-aws"
+      version     = "0.3.2"
+      namespace   = local.namespace
+      description = "A Helm chart for the AWS Secrets Manager and Config Provider for Secret Store CSI Driver."
     },
     var.helm_config
   )
 
   manage_via_gitops = var.manage_via_gitops
   addon_context     = var.addon_context
+
+  depends_on = [
+    kubernetes_namespace_v1.csi_secrets_store_provider_aws,
+    module.secrets_store_csi_driver
+  ]
 }

--- a/modules/kubernetes-addons/csi-secrets-store-provider-aws/main.tf
+++ b/modules/kubernetes-addons/csi-secrets-store-provider-aws/main.tf
@@ -3,12 +3,6 @@ locals {
   namespace = try(var.helm_config.namespace, "kube-system")
 }
 
-module "secrets_store_csi_driver" {
-  source = "../secrets-store-csi-driver"
-
-  addon_context = var.addon_context
-}
-
 module "helm_addon" {
   source = "../helm-addon"
 
@@ -28,8 +22,4 @@ module "helm_addon" {
 
   manage_via_gitops = var.manage_via_gitops
   addon_context     = var.addon_context
-
-  depends_on = [
-    module.secrets_store_csi_driver
-  ]
 }

--- a/modules/kubernetes-addons/csi-secrets-store-provider-aws/main.tf
+++ b/modules/kubernetes-addons/csi-secrets-store-provider-aws/main.tf
@@ -9,26 +9,19 @@ module "secrets_store_csi_driver" {
   addon_context = var.addon_context
 }
 
-resource "kubernetes_namespace_v1" "csi_secrets_store_provider_aws" {
-  count = local.namespace == "kube-system" ? 0 : 1
-
-  metadata {
-    name = local.namespace
-  }
-}
-
 module "helm_addon" {
   source = "../helm-addon"
 
   # https://github.com/aws/secrets-store-csi-driver-provider-aws/blob/main/charts/secrets-store-csi-driver-provider-aws/Chart.yaml
   helm_config = merge(
     {
-      name        = local.name
-      chart       = local.name
-      repository  = "https://aws.github.io/secrets-store-csi-driver-provider-aws"
-      version     = "0.3.2"
-      namespace   = local.namespace
-      description = "A Helm chart for the AWS Secrets Manager and Config Provider for Secret Store CSI Driver."
+      name             = local.name
+      chart            = local.name
+      repository       = "https://aws.github.io/secrets-store-csi-driver-provider-aws"
+      version          = "0.3.2"
+      namespace        = local.namespace
+      create_namespace = local.namespace == "kube-system" ? false : true
+      description      = "A Helm chart for the AWS Secrets Manager and Config Provider for Secret Store CSI Driver."
     },
     var.helm_config
   )
@@ -37,7 +30,6 @@ module "helm_addon" {
   addon_context     = var.addon_context
 
   depends_on = [
-    kubernetes_namespace_v1.csi_secrets_store_provider_aws,
     module.secrets_store_csi_driver
   ]
 }

--- a/modules/kubernetes-addons/secrets-store-csi-driver/locals.tf
+++ b/modules/kubernetes-addons/secrets-store-csi-driver/locals.tf
@@ -3,10 +3,10 @@ locals {
 
   # https://github.com/kubernetes-sigs/secrets-store-csi-driver/blob/main/charts/secrets-store-csi-driver/Chart.yaml
   default_helm_config = {
-    name        = local.name
+    name        = "csi-secrets-store"
     chart       = local.name
     repository  = "https://kubernetes-sigs.github.io/secrets-store-csi-driver/charts"
-    version     = "1.2.4"
+    version     = "1.3.1"
     namespace   = local.name
     description = "A Helm chart to install the Secrets Store CSI Driver"
   }


### PR DESCRIPTION
### What does this PR do?

Fixes an issue with AWS CSI Secrets Provider when using the default namespace and also updates the chart because of deprecation notice on EKS charts repo

### Motivation

<!-- What inspired you to submit this pull request? -->
- Resolves #1355 

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
