### PR TITLE
feat: Upgrade modules for EKS 1.25 support

### DIFF
--- a/modules/kubernetes-addons/aws-for-fluentbit/locals.tf
+++ b/modules/kubernetes-addons/aws-for-fluentbit/locals.tf
@@ -19,7 +19,7 @@ locals {
     name        = local.name
     chart       = local.name
     repository  = "https://aws.github.io/eks-charts"
-    version     = "0.1.21"
+    version     = "0.1.24"
     namespace   = local.name
     values      = local.default_helm_values
     description = "aws-for-fluentbit Helm Chart deployment configuration"

--- a/modules/kubernetes-addons/aws-for-fluentbit/values.yaml
+++ b/modules/kubernetes-addons/aws-for-fluentbit/values.yaml
@@ -2,19 +2,7 @@ serviceAccount:
   create: false
   name: ${service_account}
 
-cloudWatch:
+cloudWatchLogs:
   enabled: true
   region: ${aws_region}
   logGroupName: ${log_group_name}
-
-firehose:
-  enabled: false
-  region: ${aws_region}
-
-kinesis:
-  enabled: false
-  region: ${aws_region}
-
-elasticsearch:
-  enabled: false
-  region: ${aws_region}

--- a/modules/kubernetes-addons/aws-node-termination-handler/locals.tf
+++ b/modules/kubernetes-addons/aws-node-termination-handler/locals.tf
@@ -8,7 +8,7 @@ locals {
     name        = local.name
     chart       = local.name
     repository  = "https://aws.github.io/eks-charts"
-    version     = "0.19.3"
+    version     = "0.21.0"
     namespace   = local.namespace
     description = "AWS Node Termination Handler Helm Chart"
     values      = local.default_helm_values


### PR DESCRIPTION
### What does this PR do?

Upgrades modules

### Motivation

<!-- What inspired you to submit this pull request? -->
- Will eventually resolve [#1456]
- Not every module is tested so there could be other modules. 

## Modules that has been updated

- [X] aws-for-fluentbit

- [X] aws-node-termination-handler

This list can be updated and I or someone else can update those modules. Do we have an example that I can run to test all modules?


### More

- [X] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [X] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes
Tested by 
1. deploying `examples/karpenter`. 
2. Upgrading it to 1.25
3. Installing above mentioned modules
![image](https://user-images.githubusercontent.com/3725386/230904689-66eef708-aee7-4943-8102-e9ac542af96d.png)
![image](https://user-images.githubusercontent.com/3725386/230904771-b00b877d-0a34-499b-95db-abc071f92cbb.png)

