### PR TITLE
feat: Update Karpenter version to `0.27.3`

### DIFF
--- a/modules/kubernetes-addons/karpenter/locals.tf
+++ b/modules/kubernetes-addons/karpenter/locals.tf
@@ -17,7 +17,7 @@ locals {
       name       = local.name
       chart      = local.name
       repository = "oci://public.ecr.aws/karpenter"
-      version    = "v0.23.0"
+      version    = "v0.27.3"
       namespace  = local.name
       values = [
         <<-EOT


### PR DESCRIPTION
### What does this PR do?

Updates the default karpenter version fixing connectivity issues for Bottlerocket nodes on IPv6 clusters 

### Motivation

- [Resolves #<issue-number>](https://github.com/aws/karpenter/issues/3623)

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
