### PR TITLE
docs: Fix wrong variable name

### DIFF
--- a/docs/add-ons/index.md
+++ b/docs/add-ons/index.md
@@ -69,7 +69,7 @@ If you would like to use private repositories, you can download Docker images fo
 
 To indicate that you would like to manage add-ons via ArgoCD, you must do the following:
 
-1. Enable the ArgoCD add-on by setting `argocd_enable` to `true`.
+1. Enable the ArgoCD add-on by setting `enable_argocd` to `true`.
 2. Specify you would like ArgoCD to be responsible for deploying your add-ons by setting `argocd_manage_add_ons` to `true`. This will prevent the individual Terraform add-on modules from deploying Helm charts.
 3. Pass Application configuration for your add-ons repository via the `argocd_applications` property.
 


### PR DESCRIPTION
### Motivation

<!-- What inspired you to submit this pull request? -->
A simple correction on documentation. The [documentation](https://aws-ia.github.io/terraform-aws-eks-blueprints/main/add-ons/) says:
> Enable the ArgoCD add-on by setting `argocd_enable` to `true`.

but the actual variable is `enable_argocd`

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [x] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR

### Additional Notes

<!-- Anything else we should know when reviewing? -->
