### PR TITLE
feat: Update datadog-operator chart to 1.0.2

### DIFF
--- a/modules/kubernetes-addons/datadog-operator/main.tf
+++ b/modules/kubernetes-addons/datadog-operator/main.tf
@@ -11,7 +11,7 @@ module "helm_addon" {
       name             = local.name
       chart            = local.name
       repository       = "https://helm.datadoghq.com"
-      version          = "0.8.8"
+      version          = "1.0.2"
       namespace        = local.name
       create_namespace = true
       description      = "Datadog Operator"


### PR DESCRIPTION
### What does this PR do?

Update the datadog-operator Helm chart version to 1.0.2.

### Motivation

The latest version of the datadog-operator Helm chart is [1.0.2](https://github.com/DataDog/helm-charts/releases/tag/datadog-operator-1.0.2).

The version of the datadog-operator Helm chart referenced in the add-on is currently 0.8.8. This version relies on policy/v1beta1 `PodDisruptionBudget` which was deprecated in Kubernetes v1.21 and removed from Kubernetes v1.25. In addition to new features, version 1.0.0 of the chart [resolves this issue](https://github.com/DataDog/helm-charts/issues/941).

### More

- [X] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [X] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [X] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
