### PR TITLE
feat: Nodegroup `update_default_version` config should be parameterized

### DIFF
--- a/modules/aws-eks-managed-node-groups/locals.tf
+++ b/modules/aws-eks-managed-node-groups/locals.tf
@@ -26,7 +26,7 @@ locals {
 
     release_version      = ""
     force_update_version = null
-    
+
     update_default_version = true
 
     k8s_labels           = {}

--- a/modules/aws-eks-managed-node-groups/locals.tf
+++ b/modules/aws-eks-managed-node-groups/locals.tf
@@ -26,6 +26,8 @@ locals {
 
     release_version      = ""
     force_update_version = null
+    
+    update_default_version = true
 
     k8s_labels           = {}
     k8s_taints           = []

--- a/modules/aws-eks-managed-node-groups/managed-launch-templates.tf
+++ b/modules/aws-eks-managed-node-groups/managed-launch-templates.tf
@@ -3,7 +3,7 @@ resource "aws_launch_template" "managed_node_groups" {
 
   name                   = "${var.context.eks_cluster_id}-${local.managed_node_group["node_group_name"]}"
   description            = "Launch Template for EKS Managed Node Groups"
-  update_default_version = true
+  update_default_version = var.update_default_version
 
   user_data = local.userdata_base64
 

--- a/modules/aws-eks-managed-node-groups/managed-launch-templates.tf
+++ b/modules/aws-eks-managed-node-groups/managed-launch-templates.tf
@@ -3,7 +3,7 @@ resource "aws_launch_template" "managed_node_groups" {
 
   name                   = "${var.context.eks_cluster_id}-${local.managed_node_group["node_group_name"]}"
   description            = "Launch Template for EKS Managed Node Groups"
-  update_default_version = var.update_default_version
+  update_default_version = local.managed_node_group["update_default_version"]
 
   user_data = local.userdata_base64
 


### PR DESCRIPTION
### What does this PR do?

Parameterize `update_default_version` launch template config so nodegroups are not automatically updated on a version change
https://github.com/aws-ia/terraform-aws-eks-blueprints/issues/1589

<!-- A brief description of the change being made with this pull request. -->

### Motivation
Allow more control over Prod maintenance activities
- Resolves #<issue-number>

### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
