### PR TITLE
fix: Add aws_iam_session_context issuer_arn as local aws_caller_identity

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -1,9 +1,6 @@
 data "aws_partition" "current" {}
 data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
-data "aws_iam_session_context" "current" {
-  arn = data.aws_caller_identity.current.arn
-}
 
 data "aws_eks_cluster" "cluster" {
   count = var.create_eks ? 1 : 0

--- a/data.tf
+++ b/data.tf
@@ -1,6 +1,9 @@
 data "aws_partition" "current" {}
 data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
+data "aws_iam_session_context" "current" {
+  arn = data.aws_caller_identity.current.arn
+}
 
 data "aws_eks_cluster" "cluster" {
   count = var.create_eks ? 1 : 0

--- a/locals.tf
+++ b/locals.tf
@@ -5,7 +5,7 @@ locals {
     aws_region_name = data.aws_region.current.name
     # aws_caller_identity
     aws_caller_identity_account_id = data.aws_caller_identity.current.account_id
-    aws_caller_identity_arn        = data.aws_caller_identity.current.arn
+    aws_caller_identity_arn        = data.aws_iam_session_context.current.issuer_arn
     # aws_partition
     aws_partition_id         = data.aws_partition.current.id
     aws_partition_dns_suffix = data.aws_partition.current.dns_suffix


### PR DESCRIPTION
### What does this PR do?
Helps to aws_caller_identity returns a consistent value when using assumed-role credentials
[Issue 1393](https://github.com/aws-ia/terraform-aws-eks-blueprints/issues/1393)

### Motivation

<!-- What inspired you to submit this pull request? -->
- Resolves #1393

### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
