### PR TITLE
fix: argocd_gitops_config does not always exists

### DIFF
--- a/modules/kubernetes-addons/locals.tf
+++ b/modules/kubernetes-addons/locals.tf
@@ -6,53 +6,53 @@ locals {
 
   # Configuration for managing add-ons via ArgoCD.
   argocd_addon_config = {
-    agones                    = var.enable_agones ? module.agones[0].argocd_gitops_config : null
-    awsEfsCsiDriver           = var.enable_aws_efs_csi_driver ? module.aws_efs_csi_driver[0].argocd_gitops_config : null
-    awsFSxCsiDriver           = var.enable_aws_fsx_csi_driver ? module.aws_fsx_csi_driver[0].argocd_gitops_config : null
-    awsForFluentBit           = var.enable_aws_for_fluentbit ? module.aws_for_fluent_bit[0].argocd_gitops_config : null
-    awsLoadBalancerController = var.enable_aws_load_balancer_controller ? module.aws_load_balancer_controller[0].argocd_gitops_config : null
-    awsNodeTerminationHandler = var.enable_aws_node_termination_handler ? module.aws_node_termination_handler[0].argocd_gitops_config : null
-    certManager               = var.enable_cert_manager ? module.cert_manager[0].argocd_gitops_config : null
-    clusterAutoscaler         = var.enable_cluster_autoscaler ? module.cluster_autoscaler[0].argocd_gitops_config : null
-    corednsAutoscaler         = var.enable_amazon_eks_coredns && var.enable_coredns_autoscaler && length(var.coredns_autoscaler_helm_config) > 0 ? module.coredns_autoscaler[0].argocd_gitops_config : null
-    datadogOperator           = var.enable_datadog_operator ? module.datadog_operator[0].argocd_gitops_config : null
-    grafana                   = var.enable_grafana ? module.grafana[0].argocd_gitops_config : null
-    ingressNginx              = var.enable_ingress_nginx ? module.ingress_nginx[0].argocd_gitops_config : null
-    keda                      = var.enable_keda ? module.keda[0].argocd_gitops_config : null
-    metricsServer             = var.enable_metrics_server ? module.metrics_server[0].argocd_gitops_config : null
-    ondat                     = var.enable_ondat ? module.ondat[0].argocd_gitops_config : null
-    prometheus                = var.enable_prometheus ? module.prometheus[0].argocd_gitops_config : null
-    sparkHistoryServer        = var.enable_spark_history_server ? module.spark_history_server[0].argocd_gitops_config : null
-    sparkOperator             = var.enable_spark_k8s_operator ? module.spark_k8s_operator[0].argocd_gitops_config : null
-    tetrateIstio              = var.enable_tetrate_istio ? module.tetrate_istio[0].argocd_gitops_config : null
-    traefik                   = var.enable_traefik ? module.traefik[0].argocd_gitops_config : null
-    vault                     = var.enable_vault ? module.vault[0].argocd_gitops_config : null
-    vpa                       = var.enable_vpa ? module.vpa[0].argocd_gitops_config : null
-    yunikorn                  = var.enable_yunikorn ? module.yunikorn[0].argocd_gitops_config : null
-    argoRollouts              = var.enable_argo_rollouts ? module.argo_rollouts[0].argocd_gitops_config : null
-    argoWorkflows             = var.enable_argo_workflows ? module.argo_workflows[0].argocd_gitops_config : null
-    karpenter                 = var.enable_karpenter ? module.karpenter[0].argocd_gitops_config : null
-    kubernetesDashboard       = var.enable_kubernetes_dashboard ? module.kubernetes_dashboard[0].argocd_gitops_config : null
-    kubePrometheusStack       = var.enable_kube_prometheus_stack ? module.kube_prometheus_stack[0].argocd_gitops_config : null
-    awsCloudWatchMetrics      = var.enable_aws_cloudwatch_metrics ? module.aws_cloudwatch_metrics[0].argocd_gitops_config : null
-    externalDns               = var.enable_external_dns ? module.external_dns[0].argocd_gitops_config : null
-    externalSecrets           = var.enable_external_secrets ? module.external_secrets[0].argocd_gitops_config : null
-    velero                    = var.enable_velero ? module.velero[0].argocd_gitops_config : null
-    promtail                  = var.enable_promtail ? module.promtail[0].argocd_gitops_config : null
-    calico                    = var.enable_calico ? module.calico[0].argocd_gitops_config : null
-    kubecost                  = var.enable_kubecost ? module.kubecost[0].argocd_gitops_config : null
-    strimziKafkaOperator      = var.enable_strimzi_kafka_operator ? module.strimzi_kafka_operator[0].argocd_gitops_config : null
-    smb_csi_driver            = var.enable_smb_csi_driver ? module.smb_csi_driver[0].argocd_gitops_config : null
-    chaos_mesh                = var.enable_chaos_mesh ? module.chaos_mesh[0].argocd_gitops_config : null
-    cilium                    = var.enable_cilium ? module.cilium[0].argocd_gitops_config : null
-    gatekeeper                = var.enable_gatekeeper ? module.gatekeeper[0].argocd_gitops_config : null
-    kyverno                   = var.enable_kyverno ? { enable = true } : null
-    kyverno_policies          = var.enable_kyverno ? { enable = true } : null
-    kyverno_policy_reporter   = var.enable_kyverno ? { enable = true } : null
-    nvidiaDevicePlugin        = var.enable_nvidia_device_plugin ? module.nvidia_device_plugin[0].argocd_gitops_config : null
-    consul                    = var.enable_consul ? module.consul[0].argocd_gitops_config : null
-    thanos                    = var.enable_thanos ? module.thanos[0].argocd_gitops_config : null
-    kubeStateMetrics          = var.enable_kube_state_metrics ? module.kube_state_metrics[0].argocd_gitops_config : null
+    agones                    = var.enable_agones ? try(module.agones[0].argocd_gitops_config, null) : null
+    awsEfsCsiDriver           = var.enable_aws_efs_csi_driver ? try(module.aws_efs_csi_driver[0].argocd_gitops_config, null) : null
+    awsFSxCsiDriver           = var.enable_aws_fsx_csi_driver ? try(module.aws_fsx_csi_driver[0].argocd_gitops_config, null) : null
+    awsForFluentBit           = var.enable_aws_for_fluentbit ? try(module.aws_for_fluent_bit[0].argocd_gitops_config, null) : null
+    awsLoadBalancerController = var.enable_aws_load_balancer_controller ? try(module.aws_load_balancer_controller[0].argocd_gitops_config, null) : null
+    awsNodeTerminationHandler = var.enable_aws_node_termination_handler ? try(module.aws_node_termination_handler[0].argocd_gitops_config, null) : null
+    certManager               = var.enable_cert_manager ? try(module.cert_manager[0].argocd_gitops_config, null) : null
+    clusterAutoscaler         = var.enable_cluster_autoscaler ? try(module.cluster_autoscaler[0].argocd_gitops_config, null) : null
+    corednsAutoscaler         = var.enable_amazon_eks_coredns && var.enable_coredns_autoscaler && length(var.coredns_autoscaler_helm_config) > 0 ? try(module.coredns_autoscaler[0].argocd_gitops_config, null) : null
+    datadogOperator           = var.enable_datadog_operator ? try(module.datadog_operator[0].argocd_gitops_config, null) : null
+    grafana                   = var.enable_grafana ? try(module.grafana[0].argocd_gitops_config, null) : null
+    ingressNginx              = var.enable_ingress_nginx ? try(try(module.ingress_nginx[0].argocd_gitops_config, null), null) : null
+    keda                      = var.enable_keda ? try(try(module.keda[0].argocd_gitops_config, null), null) : null
+    metricsServer             = var.enable_metrics_server ? try(try(module.metrics_server[0].argocd_gitops_config, null), null) : null
+    ondat                     = var.enable_ondat ? try(try(module.ondat[0].argocd_gitops_config, null), null) : null
+    prometheus                = var.enable_prometheus ? try(try(module.prometheus[0].argocd_gitops_config, null), null) : null
+    sparkHistoryServer        = var.enable_spark_history_server ? try(try(module.spark_history_server[0].argocd_gitops_config, null), null) : null
+    sparkOperator             = var.enable_spark_k8s_operator ? try(module.spark_k8s_operator[0].argocd_gitops_config, null) : null
+    tetrateIstio              = var.enable_tetrate_istio ? try(module.tetrate_istio[0].argocd_gitops_config, null) : null
+    traefik                   = var.enable_traefik ? try(module.traefik[0].argocd_gitops_config, null) : null
+    vault                     = var.enable_vault ? try(module.vault[0].argocd_gitops_config, null) : null
+    vpa                       = var.enable_vpa ? try(module.vpa[0].argocd_gitops_config, null) : null
+    yunikorn                  = var.enable_yunikorn ? try(module.yunikorn[0].argocd_gitops_config, null) : null
+    argoRollouts              = var.enable_argo_rollouts ? try(module.argo_rollouts[0].argocd_gitops_config, null) : null
+    argoWorkflows             = var.enable_argo_workflows ? try(module.argo_workflows[0].argocd_gitops_config, null) : null
+    karpenter                 = var.enable_karpenter ? try(module.karpenter[0].argocd_gitops_config, null) : null
+    kubernetesDashboard       = var.enable_kubernetes_dashboard ? try(module.kubernetes_dashboard[0].argocd_gitops_config, null) : null
+    kubePrometheusStack       = var.enable_kube_prometheus_stack ? try(module.kube_prometheus_stack[0].argocd_gitops_config, null) : null
+    awsCloudWatchMetrics      = var.enable_aws_cloudwatch_metrics ? try(module.aws_cloudwatch_metrics[0].argocd_gitops_config, null) : null
+    externalDns               = var.enable_external_dns ? try(module.external_dns[0].argocd_gitops_config, null) : null
+    externalSecrets           = var.enable_external_secrets ? try(module.external_secrets[0].argocd_gitops_config, null) : null
+    velero                    = var.enable_velero ? try(module.velero[0].argocd_gitops_config, null) : null
+    promtail                  = var.enable_promtail ? try(module.promtail[0].argocd_gitops_config, null) : null
+    calico                    = var.enable_calico ? try(module.calico[0].argocd_gitops_config, null) : null
+    kubecost                  = var.enable_kubecost ? try(module.kubecost[0].argocd_gitops_config, null) : null
+    strimziKafkaOperator      = var.enable_strimzi_kafka_operator ? try(module.strimzi_kafka_operator[0].argocd_gitops_config, null) : null
+    smb_csi_driver            = var.enable_smb_csi_driver ? try(module.smb_csi_driver[0].argocd_gitops_config, null) : null
+    chaos_mesh                = var.enable_chaos_mesh ? try(module.chaos_mesh[0].argocd_gitops_config, null) : null
+    cilium                    = var.enable_cilium ? try(module.cilium[0].argocd_gitops_config, null) : null
+    gatekeeper                = var.enable_gatekeeper ? try(module.gatekeeper[0].argocd_gitops_config, null) : null
+    kyverno                   = var.enable_kyverno ? try({ enable = true }, null) : null
+    kyverno_policies          = var.enable_kyverno ? try({ enable = true }, null) : null
+    kyverno_policy_reporter   = var.enable_kyverno ? try({ enable = true }, null) : null
+    nvidiaDevicePlugin        = var.enable_nvidia_device_plugin ? try(module.nvidia_device_plugin[0].argocd_gitops_config, null) : null
+    consul                    = var.enable_consul ? try(module.consul[0].argocd_gitops_config, null) : null
+    thanos                    = var.enable_thanos ? try(module.thanos[0].argocd_gitops_config, null) : null
+    kubeStateMetrics          = var.enable_kube_state_metrics ? try(module.kube_state_metrics[0].argocd_gitops_config, null) : null
   }
 
   addon_context = {


### PR DESCRIPTION
This PR fixes a bug in destroys where the module addon is not created with argocd_gitops_config option.

### What does this PR do?

🛑 Please open an issue first to discuss any significant work and flesh out details/direction - we would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/aws-ia/terraform-aws-eks-blueprints/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

<!-- A brief description of the change being made with this pull request. -->

### Motivation

<!-- What inspired you to submit this pull request? -->
- Resolves #<issue-number>

### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
