### PR TITLE
fix: Kubecost Container Version health with EKS 1.25+

### DIFF
--- a/docs/add-ons/kubecost.md
+++ b/docs/add-ons/kubecost.md
@@ -24,7 +24,7 @@ Deploy Kubecost with custom `values.yaml`
     name       = "kubecost"                                             # (Required) Release name.
     repository = "oci://public.ecr.aws/kubecost"                        # (Optional) Repository URL where to locate the requested chart.
     chart      = "cost-analyzer"                                        # (Required) Chart name to be installed.
-    version    = "1.96.0"                                               # (Optional) Specify the exact chart version to install. If this is not specified, it defaults to the version set within default_helm_config: https://github.com/aws-ia/terraform-aws-eks-blueprints/blob/main/modules/kubernetes-addons/kubecost/locals.tf
+    version    = "1.103.3"                                              # (Optional) Specify the exact chart version to install. If this is not specified, it defaults to the version set within default_helm_config: https://github.com/aws-ia/terraform-aws-eks-blueprints/blob/main/modules/kubernetes-addons/kubecost/locals.tf
     namespace  = "kubecost"                                             # (Optional) The namespace to install the release into.
     values = [templatefile("${path.module}/kubecost-values.yaml", {})]
   }

--- a/modules/kubernetes-addons/kubecost/main.tf
+++ b/modules/kubernetes-addons/kubecost/main.tf
@@ -7,7 +7,7 @@ module "helm_addon" {
       name             = "kubecost"
       chart            = "cost-analyzer"
       repository       = "oci://public.ecr.aws/kubecost"
-      version          = "1.97.0"
+      version          = "1.103.3"
       namespace        = "kubecost"
       values           = [file("${path.module}/values.yaml")]
       create_namespace = true

--- a/modules/kubernetes-addons/kubecost/values.yaml
+++ b/modules/kubernetes-addons/kubecost/values.yaml
@@ -4,7 +4,7 @@ global:
     enabled: false
     proxy: false
 
-imageVersion: prod-1.97.0
+imageVersion: prod-1.103.3
 kubecostFrontend:
   image: public.ecr.aws/kubecost/frontend
 


### PR DESCRIPTION
EKS version 1.25+ breaks cost-model container
issue makes pod unhealthy because of error:
```
HorizontalPodAutoscaler v2beta1 is deprecated
```
ref: https://github.com/tektoncd/pipeline/issues/5128


### What does this PR do?

Bumps container tag for cost-model that has the new HPA ApiVersion support with EKS version 1.25+. Without it, container is never in healthy state by kubelet.

### Motivation

related to this: https://github.com/tektoncd/pipeline/issues/5128

### More

- [X ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [X] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?
