### PR TITLE
fix: The typo in userdata-amazonlinux2eks.tpl

### DIFF
--- a/modules/aws-eks-managed-node-groups/templates/userdata-amazonlinux2eks.tpl
+++ b/modules/aws-eks-managed-node-groups/templates/userdata-amazonlinux2eks.tpl
@@ -29,7 +29,7 @@ mount -a
 %{ if length(service_ipv4_cidr) > 0 ~}
 export SERVICE_IPV4_CIDR=${service_ipv4_cidr}
 %{ endif ~}
-%{ if length(service_ipv4_cidr) > 0 ~}
+%{ if length(service_ipv6_cidr) > 0 ~}
 export SERVICE_IPV6_CIDR=${service_ipv6_cidr}
 %{ endif ~}
 %{ if length(custom_ami_id) > 0 ~}


### PR DESCRIPTION
fix: the typo in userdata-amazonlinux2eks.tpl.

Within the code, the content '%{if length(service_ipv4_cidr) > 0 ~ }' should be changed to '%{if length(service_ipv6_cidr) > 0 ~ }'. Currently, when service_ipv4_cidr is defined in the userdata, the condition 'export SERVICE_IPV6_CIDR=${service_ipv6_cidr}' is executed.