### PR TITLE
fix: Update ArgoCD to latest version

### DIFF
--- a/modules/kubernetes-addons/argocd/locals.tf
+++ b/modules/kubernetes-addons/argocd/locals.tf
@@ -9,7 +9,7 @@ locals {
     name             = local.name
     chart            = local.name
     repository       = "https://argoproj.github.io/argo-helm"
-    version          = "5.13.8"
+    version          = "5.34.6"
     namespace        = local.namespace
     create_namespace = true
     values           = local.default_helm_values


### PR DESCRIPTION
### What does this PR do?
Bumps the Argocd version to latest to fix `containerport`

### Motivation

This fixes a Containerport issue:
When the default port is `8080` and you change it in the values to something else eg `8090` causes the argocd server to go into `crashloopbackoff` 

Overwriting the version of agrocd in our implementation of EKS blueprint resolves the issue.
Hence we are making this PR.

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature 
- [x] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

This can be tested using the following values in `values.yaml` :

``` yaml
server:
  containerPort: 8090
```
