### PR TITLE
fix: Correct `teams` patterns use of multi-team namespace creation

### DIFF
--- a/examples/multi-tenancy-with-teams/main.tf
+++ b/examples/multi-tenancy-with-teams/main.tf
@@ -126,10 +126,10 @@ module "eks_blueprints_dev_teams" {
   }
 
   namespaces = {
-    "blue-${each.key}" = {
+    "team-${each.key}" = {
       labels = {
-        appName     = "blue-team-app",
-        projectName = "project-blue",
+        appName     = "${each.key}-team-app",
+        projectName = "project-${each.key}",
       }
 
       resource_quota = {


### PR DESCRIPTION
The readme says 2 namespaces team-blue and team-red will be created, but the code has some hardcoded values instead of using the key from the iterator