### PR TITLE
fix: Remove broken link in fargate-serverless README

### DIFF
--- a/examples/fargate-serverless/README.md
+++ b/examples/fargate-serverless/README.md
@@ -8,7 +8,7 @@ This example solution provides:
 - AWS EKS Fargate Profiles for the `kube-system` namespace which is used by the `coredns`, `vpc-cni`, and `kube-proxy` addons, as well as profile that will match on `app-*` namespaces using a wildcard pattern.
 - AWS EKS managed addons `coredns`, `vpc-cni` and `kube-proxy`
 - AWS Load Balancer Controller add-on deployed through a Helm chart. The default AWS Load Balancer Controller add-on configuration is overridden so that it can be deployed on Fargate compute.
-- A [sample-app](./sample-app) is provided to demonstrates how to configure the Ingress so that application can be accessed over the internet.
+- A sample-app is provided (in-line) to demonstrate how to configure the Ingress so that application can be accessed over the internet.
 
 ## Prerequisites:
 


### PR DESCRIPTION
# Description

<!-- 
🛑 Please open an issue first to discuss any significant work and flesh out details/direction - we would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/aws-ia/terraform-aws-eks-blueprints/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

A brief description of the change being made with this pull request.
-->

Removes the link as the sample-app is provided inline.

### Motivation and Context

<!-- What inspired you to submit this pull request? -->
- Resolves #1678 

### How was this change tested?

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR

### Additional Notes

<!-- Anything else we should know when reviewing? -->
