### PR TITLE
fix: Remove cluster security group from EniConfig for Custom Networking example

### DIFF
--- a/examples/vpc-cni-custom-networking/main.tf
+++ b/examples/vpc-cni-custom-networking/main.tf
@@ -127,7 +127,6 @@ resource "kubectl_manifest" "eni_config" {
     }
     spec = {
       securityGroups = [
-        module.eks.cluster_primary_security_group_id,
         module.eks.node_security_group_id,
       ]
       subnet = each.value


### PR DESCRIPTION
# Description

<!-- 
🛑 Please open an issue first to discuss any significant work and flesh out details/direction - we would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/aws-ia/terraform-aws-eks-blueprints/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

A brief description of the change being made with this pull request.
-->
When using custom networking, whatever security groups you specify in the ENIConfigs will be attached to your EKS Nodes (or at least Managed Node Groups in my experience). This example does _not_ use the EKS-created cluster security group in the node's launch template, but _does_ specify it in the ENI Config. The result is that EKS will attach the EKS Cluster SG to the node which is likely not the desired outcome. 

This issue can be seen previously here in this issue: https://github.com/aws-ia/terraform-aws-eks-blueprints/issues/1390
The [FAQ](https://github.com/terraform-aws-modules/terraform-aws-eks/blob/master/docs/faq.md#i-received-an-error-expect-exactly-one-securitygroup-tagged-with-kubernetesioclustername-) referenced also has some inaccuracies in it:
1) By having the tag in place at all in multiple security groups, the AWS load balancer controller will not work, making the tag not "owned" does not seem to work (at least in my experience)
2) Even in a configuration where you _don't_ specify to attach the cluster security group to your nodes, using this example will add it in and send you down a very [wild goose chase](https://github.com/terraform-aws-modules/terraform-aws-eks/issues/2687) with AWS Support.  

### Motivation and Context

<!-- What inspired you to submit this pull request? -->
- Resolves #1390
- Resolves terraform-aws-eks#2687
- Clarifies undocumented/unexpected behavior

### How was this change tested?

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR

### Additional Notes

<!-- Anything else we should know when reviewing? -->
