### PR TITLE
fix: Modify Fargate serverless example to wait for Fargate profiles to provision

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 # Description
 
-<!-- 
+<!--
 🛑 Please open an issue first to discuss any significant work and flesh out details/direction - we would hate for your time to be wasted.
 Consult the [CONTRIBUTING](https://github.com/aws-ia/terraform-aws-eks-blueprints/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.
 

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -2,7 +2,7 @@
 #
 # This Action will scan dependency manifest files that change as part of a Pull Request,
 # surfacing known-vulnerable versions of the packages declared or updated in the PR.
-# Once installed, if the workflow run is marked as required, 
+# Once installed, if the workflow run is marked as required,
 # PRs introducing known-vulnerable packages will be blocked from merging.
 #
 # Source repository: https://github.com/actions/dependency-review-action

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
       - id: detect-aws-credentials
         args: ['--allow-missing-credentials']
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.80.0
+    rev: v1.81.0
     hooks:
       - id: terraform_fmt
       - id: terraform_docs

--- a/examples/blue-green-upgrade/environment/versions.tf
+++ b/examples/blue-green-upgrade/environment/versions.tf
@@ -1,13 +1,14 @@
 terraform {
-  required_version = ">= 1.0.0"
+  required_version = ">= 1.0"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.72.0"
+      version = ">= 4.67"
     }
     random = {
-      version = ">= 3"
+      source  = "hashicorp/random"
+      version = ">= 3.0"
     }
   }
 }

--- a/examples/fargate-serverless/README.md
+++ b/examples/fargate-serverless/README.md
@@ -41,7 +41,7 @@ Apply complete! Resources: 63 added, 0 changed, 0 destroyed.
 
 Outputs:
 
-configure_kubectl = "aws eks --region us-west-2 update-kubeconfig --name fully-private-cluster"
+configure_kubectl = "aws eks --region us-west-2 update-kubeconfig --name fargate-serverless"
 ```
 
 2. Run `update-kubeconfig` command, using the Terraform provided Output, replace with your `$AWS_REGION` and your `$CLUSTER_NAME` variables.

--- a/examples/fargate-serverless/main.tf
+++ b/examples/fargate-serverless/main.tf
@@ -100,6 +100,9 @@ module "eks_blueprints_addons" {
   cluster_version   = module.eks.cluster_version
   oidc_provider_arn = module.eks.oidc_provider_arn
 
+  # We want to wait for the Fargate profiles to be deployed first
+  create_delay_dependencies = [for prof in module.eks.fargate_profiles : prof.fargate_profile_arn]
+
   # EKS Add-ons
   eks_addons = {
     coredns = {


### PR DESCRIPTION
# Description
The fargate sample could not be deployed correctly, so it has been partially fixed.
Using Karpenter's example, the creation of the Blueprints add-on was delayed until after the creation of the Fargate profile.

<!-- 
🛑 Please open an issue first to discuss any significant work and flesh out details/direction - we would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/aws-ia/terraform-aws-eks-blueprints/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

A brief description of the change being made with this pull request.
-->

### Motivation and Context

<!-- What inspired you to submit this pull request? -->
- Resolves #<issue-number>

### How was this change tested?

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR

### Additional Notes

<!-- Anything else we should know when reviewing? -->
