### PR TITLE
fix: Update doc publish workflow permissions

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -3,14 +3,6 @@ on:
   push:
     branches:
       - main
-    paths:
-      - 'docs/**'
-      - mkdocs.yml
-      - README.md
-      - '.github/workflows/publish-docs.yml'
-  release:
-    types:
-      - published
 
 env:
   PYTHON_VERSION: 3.x
@@ -22,6 +14,8 @@ jobs:
   build:
     name: Deploy docs
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@v2
@@ -42,7 +36,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install mike==1.1.2 \
-            mkdocs-material==9.1.4 \
+            mkdocs-material==9.1.19 \
             mkdocs-include-markdown-plugin==4.0.4 \
             mkdocs-awesome-pages-plugin==2.9.1
 


### PR DESCRIPTION
# Description

- Update doc publish workflow permissions

### Motivation and Context

- I'm not sure what changed, but the workflow is encountering a [permissions denied](https://github.com/aws-ia/terraform-aws-eks-blueprints/actions/runs/5645948474/job/15293055425) error and I am hoping this corrects it
### How was this change tested? For now, I am run the doc deployment locally to update the docs, but I would like the workflow to do this in the future

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR

### Additional Notes

<!-- Anything else we should know when reviewing? -->
