### PR TITLE
fix: Correct doc name for privatelink example

### DIFF
--- a/docs/blueprints/aws-eks-privatelink.md
+++ b/docs/blueprints/aws-eks-privatelink.md
@@ -1,7 +1,0 @@
----
-title: AWS EKS PrivateLink
----
-
-{%
-   include-markdown "../../examples/aws-eks-privatelink/README.md"
-%}

--- a/docs/blueprints/privatelink-access.md
+++ b/docs/blueprints/privatelink-access.md
@@ -1,0 +1,7 @@
+---
+title: PrivateLink Access
+---
+
+{%
+   include-markdown "../../examples/privatelink-access/README.md"
+%}


### PR DESCRIPTION
# Description

- Correct doc name for privatelink example

### Motivation and Context

- The pattern name changed during the recent PR review, but the documentation page/link was not updated to match

### How was this change tested?

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR

### Additional Notes

<!-- Anything else we should know when reviewing? -->
