### PR TITLE
fix: Change EKS addons to use EKS Blueprint addons module

### DIFF
--- a/examples/istio/main.tf
+++ b/examples/istio/main.tf
@@ -59,13 +59,6 @@ module "eks" {
   cluster_version                = "1.27"
   cluster_endpoint_public_access = true
 
-  # EKS Addons
-  cluster_addons = {
-    coredns    = {}
-    kube-proxy = {}
-    vpc-cni    = {}
-  }
-
   vpc_id     = module.vpc.vpc_id
   subnet_ids = module.vpc.private_subnets
 
@@ -120,6 +113,13 @@ module "eks_blueprints_addons" {
   enable_aws_load_balancer_controller = true
 
   tags = local.tags
+
+  eks_addons = {
+    coredns =    {}
+    vpc-cni    = {}
+    kube-proxy = {}
+  }
+
 }
 
 ################################################################################


### PR DESCRIPTION
Changed addons to blueprint

# Description
Changing the addons from EKS to EKS Blueprints Addons fixed error messagens on vpc-cni.

<!--
🛑 Please open an issue first to discuss any significant work and flesh out details/direction - we would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/aws-ia/terraform-aws-eks-blueprints/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

A brief description of the change being made with this pull request.
-->

### Motivation and Context

<!-- What inspired you to submit this pull request? -->
- Resolves #<issue-number>

### How was this change tested?

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [x] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR

### Additional Notes

<!-- Anything else we should know when reviewing? -->
