### PR TITLE
fix: Enable EventBridge rules/targets before EKS cluster

### DIFF
--- a/.github/scripts/plan-examples.py
+++ b/.github/scripts/plan-examples.py
@@ -10,6 +10,7 @@ def get_examples():
     """
     exclude = {
         'examples/appmesh-mtls',  # excluded until Rout53 is setup
+        'examples/privatelink-access',
         'examples/blue-green-upgrade/environment',
         'examples/blue-green-upgrade/modules/eks_cluster'
     }

--- a/examples/privatelink-access/README.md
+++ b/examples/privatelink-access/README.md
@@ -21,7 +21,7 @@ created so that it can respond to the ENIs created by the EKS control plane:
 
 ```sh
 terraform init
-terraform apply -target=module.create_eni_lambda -target=module.nlb
+terraform apply -target=module.eventbridge -target=module.nlb
 ```
 
 Enter `yes` at command prompt to apply

--- a/examples/privatelink-access/privatelink.tf
+++ b/examples/privatelink-access/privatelink.tf
@@ -218,7 +218,9 @@ module "delete_eni_lambda" {
 
   environment_variables = {
     TARGET_GROUP_ARN = module.nlb.target_group_arns[0]
-    EKS_CLUSTER_NAME = module.eks.cluster_name
+
+    # Passing local.name in lieu of module.eks.cluster_name to avoid dependency
+    EKS_CLUSTER_NAME = local.name
   }
 
   allowed_triggers = {


### PR DESCRIPTION
# Description

The eventbridge target for the rule `eks-api-endpoint-create` wasn't getting created with the first `terraform apply` command and it doesn't get created until after the EKS cluster is completely setup causing the initial ENI create events to be missed.

This PR ensures that the first  `terraform apply` command:
1.  Includes the target `module.eventbridge` that takes care of creating both modules `module.create_eni_lambda` and `module.delete_eni_lambda`
2. For the above to be possible, it removes the dependency of `module.delete_eni_lambda` on `module.eks`

### How was this change tested?

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I ran `pre-commit run -a` with this PR
