### PR TITLE
fix: Correct doc title to distinguish between the two Istio patterns

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
       - id: detect-aws-credentials
         args: ['--allow-missing-credentials']
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.81.0
+    rev: v1.83.0
     hooks:
       - id: terraform_fmt
       - id: terraform_docs

--- a/docs/blueprints/istio-multi-cluster.md
+++ b/docs/blueprints/istio-multi-cluster.md
@@ -1,5 +1,5 @@
 ---
-title: Istio
+title: Istio - Multi-Cluster
 ---
 
 {%

--- a/examples/istio-multi-cluster/README.md
+++ b/examples/istio-multi-cluster/README.md
@@ -1,4 +1,4 @@
-# Multiple Amazon EKS Clusters - Multi-Primary Istio installation with
+# Amazon EKS Multi-Cluster w/ Istio
 
 This example shows how to provision 2 Amazon EKS clusters with Istio setup on each of them.
 The Istio will be set-up to operate in a [Multi-Primary](https://istio.io/latest/docs/setup/install/multicluster/multi-primary/) way where services are shared across clusters.
@@ -18,37 +18,40 @@ Refer to the [documentation](https://istio.io/latest/docs/concepts/) for `Istio`
 * The process for connecting clusters is seperated from the cluster creation as it requires all cluster to be created first, and excahnge configuration between one to the other
 
 ## Folder structure
-### Folder [`0.certs-tool`](0.certs-tool/)
+
+### [`0.certs-tool`](0.certs-tool/)
 
 This folder is the [Makefiles](https://github.com/istio/istio/tree/master/tools/certs) from the Istio projects to generate 1 root CA with 2 intermediate CAs for each cluster. Please refer to the ["Certificate Management"](https://istio.io/latest/docs/tasks/security/cert-management/) section in the Istio documentation. For production setup it's [highly recommended](https://istio.io/latest/docs/tasks/security/cert-management/plugin-ca-cert/#plug-in-certificates-and-key-into-the-cluster) by the Istio project to have a production-ready CA solution.
 
 > **_NOTE:_**  The [0.certs-tool/create-certs.sh](0.certs-tool/create-certs.sh) script needs to run before the cluster creation so the code will pick up the relevant certificates
 
-### Folder [`0.vpc`](0.vpc/)
+### [`0.vpc`](0.vpc/)
+
 This folder creates the VPC for both clusters. The VPC creation is not part of the cluster provisionig and therefore lives in a seperate folder.
 To support the multi-cluster/Multi-Primary setup, this folder also creates additional security group to be used by each cluster worker nodes to allow cross-cluster communication (resources `cluster1_additional_sg` and `cluster2_additional_sg`). These security groups allow communication from one to the other and each will be added to the worker nodes of the relevant cluster
 
-### Folder [`1.cluster1`](1.cluster1/)
+### [`1.cluster1`](1.cluster1/)
 
 This folder creates an Amazon EKS Cluster, named by default `cluster-1` (see [`variables.tf`](1.cluster1/variables.tf)), with AWS Load Balancer Controller, and Istio installation.
 Configurations in this folder to be aware of:
+
 * The cluster is configured to use the security groups created in the `0.vpc` folder (`cluster1_additional_sg` in this case).
 * Kubernetes Secret named `cacerts` is created with the certificates created by the [0.certs-tool/create-certs.sh](0.certs-tool/create-certs.sh) script
 * Kubernetes Secret named `cacerts` named `istio-reader-service-account-istio-remote-secret-token` of type `Service-Account` is being created. This is to replicate the [istioctl experimental create-remote-secret](https://istio.io/latest/docs/reference/commands/istioctl/#istioctl-experimental-create-remote-secret) command. This secret will be used in folder [`3.istio-multi-primary`](3.istio-multi-primary/) to apply kubeconfig secret with tokens from the other cluster to be abble to communicate to the other cluster API Server
 
-### Folder [`2.cluster2`](2.cluster2/)
+### [`2.cluster2`](2.cluster2/)
 
 Same configuration as in `1.cluster1` except the name of the cluster which is `cluster-2`.
 
-### Folder [`3.istio-multi-primary`](3.istio-multi-primary/)
+### [`3.istio-multi-primary`](3.istio-multi-primary/)
 
 This folder deploys a reader secret on each cluster. It replicates the [`istioctl experimental create-remote-secret`](https://istio.io/latest/docs/reference/commands/istioctl/#istioctl-experimental-create-remote-secret) by applying a kubeconfig secret prefixed `istio-remote-secret-` with the cluster name at the end.
 
-### Folder [`4.test-connectivity`](4.test-connectivity/)
+### [`4.test-connectivity`](4.test-connectivity/)
 
 This folder test the installation connectivity. It follows the Istio guide [Verify the installation](https://istio.io/latest/docs/setup/install/multicluster/verify/) by deploying services on each cluster, and `curl`-ing from one to the other
 
-## Prerequisites:
+## Prerequisites
 
 Ensure that you have the following tools installed locally:
 
@@ -108,8 +111,10 @@ cd 4.test-connectivity
 ./test_connectivity.sh
 cd..
 ```
+
 This script deploy the sample application to both clusters and run curl from a pod in one cluster to a service that is deployed in both cluster. You should expect to see responses from both `V1` and `V2` of the sample application.
 The script run 4 `curl` command from cluster-1 to cluster-2 and vice versa
+
 ## Destroy
 
 To teardown and remove the resources created in this example:


### PR DESCRIPTION
# Description

- Correct doc title to distinguish between the two Istio patterns

### Motivation and Context
- This change aligns the sidebar and page titles with the blueprint name

#### Currently
![image](https://github.com/aws-ia/terraform-aws-eks-blueprints/assets/10913471/a9f9a3a0-55ac-49f7-b37f-edec02ebb14a)

### How was this change tested?

- Validated by running `mkdocs serve` locally

### Additional Notes

<!-- Anything else we should know when reviewing? -->
