### PR TITLE
fix: Add missing AddTags permission for AWS load balancer controller

### DIFF
--- a/modules/kubernetes-addons/aws-load-balancer-controller/data.tf
+++ b/modules/kubernetes-addons/aws-load-balancer-controller/data.tf
@@ -31,6 +31,7 @@ data "aws_iam_policy_document" "aws_lb" {
       "ec2:DescribeVpcPeeringConnections",
       "ec2:DescribeVpcs",
       "ec2:GetCoipPoolUsage",
+      "elasticloadbalancing:AddTags",
       "elasticloadbalancing:DescribeListenerCertificates",
       "elasticloadbalancing:DescribeListeners",
       "elasticloadbalancing:DescribeLoadBalancerAttributes",


### PR DESCRIPTION
# Description

Allow load balancer controller to create tags on ELB.

### Motivation and Context

Without the change in this pull request, we could not have load balancers created. According to a colleague, there was a recent change in the AWS APIs related to tagging and load balancers, which is the reason why we need this change.

See for example this for a discussion how it was solved there:
https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/3046

### How was this change tested?

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR

### Additional Notes

<!-- Anything else we should know when reviewing? -->
