### PR TITLE
make efs attachable for stateful example

### DIFF
--- a/examples/stateful/main.tf
+++ b/examples/stateful/main.tf
@@ -370,6 +370,7 @@ module "efs" {
   name           = local.name
 
   # Mount targets / security group
+  attach_policy = false
   mount_targets = {
     for k, v in zipmap(local.azs, module.vpc.private_subnets) : k => { subnet_id = v }
   }


### PR DESCRIPTION
# Description
shared efs storage in stateful example doesn't work without that workaround described in https://github.com/aws-ia/terraform-aws-eks-blueprints/issues/1197#issuecomment-1321182807
it looks wise for me to fix the example in any way

### Motivation and Context

- Resolves #1197

### How was this change tested?

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR

### Additional Notes

literally nothing to add