### PR TITLE
chore: Update mkdocs CD deploy to use standard mkdocs without versioning

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -35,23 +35,13 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install mike==1.1.2 \
-            mkdocs-material==9.1.19 \
-            mkdocs-include-markdown-plugin==4.0.4 \
-            mkdocs-awesome-pages-plugin==2.9.1
+          python -m pip install mkdocs-material==9.3.1 \
+            mkdocs-include-markdown-plugin==6.0.1 \
+            mkdocs-awesome-pages-plugin==2.9.2
 
       - name: git config
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
 
-      - name: mike deploy main
-        if: contains(github.ref, 'refs/heads/main')
-        run: |
-          mike deploy --push main
-
-      - name: mike deploy new version
-        if: contains(github.ref, 'refs/tags/v') && !github.event.release.prerelease
-        run: |
-          VERSION=${GITHUB_REF/refs\/tags\//}
-          mike deploy --rebase --push --update-aliases "${VERSION}" latest
+      - run: mkdocs gh-deploy --force

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,6 @@ repos:
           - '--args=--only=terraform_naming_convention'
           - '--args=--only=terraform_required_version'
           - '--args=--only=terraform_required_providers'
-          - '--args=--only=terraform_standard_module_structure'
           - '--args=--only=terraform_workspace_remote'
       - id: terraform_validate
         exclude: (docs|modules)

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ order to avoid confusion around the consumption model.
 However, we do have a number of Terraform modules that were created to support
 EKS Blueprints in addition to the community hosted modules. Please see the respective projects for more
 details on the modules constructed to support EKS Blueprints for Terraform; those projects are listed
-[below](https://aws-ia.github.io/terraform-aws-eks-blueprints/main/#related-projects).
+[below](https://aws-ia.github.io/terraform-aws-eks-blueprints/#related-projects).
 
 - [`terraform-aws-eks-blueprint-addon`](https://github.com/aws-ia/terraform-aws-eks-blueprints-addon) -
 (Note the singular form) Terraform module which can provision an addon using the Terraform
@@ -108,7 +108,7 @@ EKS Blueprints for Terraform does not have an opinion in this matter and will de
 Therefore, we do not provide variables and outputs to expose various levels of configuration for the examples.
 Users can modify the pattern locally after cloning to suite their requirements.
 
-4. Please see the [FAQ section](https://aws-ia.github.io/terraform-aws-eks-blueprints/main/faq/#provider-authentication)
+4. Please see the [FAQ section](https://aws-ia.github.io/terraform-aws-eks-blueprints/faq/#provider-authentication)
 on authenticating Kubernetes based providers (`kubernetes`, `helm`, `kubectl`) to Amazon EKS clusters
 regarding the use of static tokens versus dynamic tokens using the `awscli`.
 

--- a/docs/_partials/destroy.md
+++ b/docs/_partials/destroy.md
@@ -4,4 +4,4 @@ terraform destroy -target="module.eks" -auto-approve
 terraform destroy -auto-approve
 ```
 
-See [here](https://aws-ia.github.io/terraform-aws-eks-blueprints/main/getting-started/#destroy) for more details on cleaning up the resources created.
+See [here](https://aws-ia.github.io/terraform-aws-eks-blueprints/getting-started/#destroy) for more details on cleaning up the resources created.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -12,7 +12,7 @@ Ensure that you have installed the following tools locally:
 
 ## Deploy
 
-1. For consuming EKS Blueprints, please see the [Consumption](https://aws-ia.github.io/terraform-aws-eks-blueprints/main/#consumption) section. For exploring and trying out the patterns provided, please
+1. For consuming EKS Blueprints, please see the [Consumption](https://aws-ia.github.io/terraform-aws-eks-blueprints/#consumption) section. For exploring and trying out the patterns provided, please
 clone the project locally to quickly get up and running with a pattern. After cloning the project locally, `cd` into the pattern
 directory of your choice.
 
@@ -28,7 +28,7 @@ directory of your choice.
     For patterns that deviate from this general flow, see the pattern's respective `REAMDE.md` for more details.
 
     !!! info "Terraform targetted apply"
-        Please see the [Terraform Caveats](https://aws-ia.github.io/terraform-aws-eks-blueprints/main/#terraform-caveats) section for details on the use of targeted Terraform apply's
+        Please see the [Terraform Caveats](https://aws-ia.github.io/terraform-aws-eks-blueprints/#terraform-caveats) section for details on the use of targeted Terraform apply's
 
 3. Once all of the resources have successfully been provisioned, the following command can be used to update the `kubeconfig`
 on your local machine and allow you to interact with your EKS Cluster using `kubectl`.

--- a/patterns/agones-game-controller/README.md
+++ b/patterns/agones-game-controller/README.md
@@ -21,7 +21,7 @@ through the details of deploying EKS Cluster using eksctl and deploy Agones with
 
 ## Deploy
 
-See [here](https://aws-ia.github.io/terraform-aws-eks-blueprints/main/getting-started/#prerequisites) for the prerequisites and steps to deploy this pattern.
+See [here](https://aws-ia.github.io/terraform-aws-eks-blueprints/getting-started/#prerequisites) for the prerequisites and steps to deploy this pattern.
 
 ## Validate
 

--- a/patterns/appmesh-mtls/README.md
+++ b/patterns/appmesh-mtls/README.md
@@ -4,7 +4,7 @@ This pattern demonstrates how to deploy and configure AppMesh mTLS on an Amazon 
 
 ## Deploy
 
-See [here](https://aws-ia.github.io/terraform-aws-eks-blueprints/main/getting-started/#prerequisites) for the prerequisites and steps to deploy this pattern.
+See [here](https://aws-ia.github.io/terraform-aws-eks-blueprints/getting-started/#prerequisites) for the prerequisites and steps to deploy this pattern.
 
 ## Validate
 

--- a/patterns/argocd/README.md
+++ b/patterns/argocd/README.md
@@ -8,7 +8,7 @@ This pattern demonstrates an EKS cluster that uses ArgoCD for application deploy
 
 ## Deploy
 
-See [here](https://aws-ia.github.io/terraform-aws-eks-blueprints/main/getting-started/#prerequisites) for the prerequisites and steps to deploy this pattern.
+See [here](https://aws-ia.github.io/terraform-aws-eks-blueprints/getting-started/#prerequisites) for the prerequisites and steps to deploy this pattern.
 
 ## Validate
 

--- a/patterns/blue-green-upgrade/modules/eks_cluster/README.md
+++ b/patterns/blue-green-upgrade/modules/eks_cluster/README.md
@@ -32,25 +32,25 @@ The AWS resources created by the script are detailed bellow:
     - ecsdemo-nodejs
     - ecsdemo-crystal
   - Kubernetes addon deployed with Terraform
-    - [ArgoCD](https://aws-ia.github.io/terraform-aws-eks-blueprints/main/add-ons/argocd/)
+    - ArgoCD
       - to deploy additional addons
       - to deploy our demo workloads
       - configured to be exposed through a service loadbalancer (for testing)
-  - [EKS Managed Add-ons](https://aws-ia.github.io/terraform-aws-eks-blueprints/add-ons/managed-add-ons/)
+  - EKS Managed Add-ons
     - CoreDNS
     - Kube Proxy
     - VPC CNI
     - EBS CSI Driver
   - Kubernetes addon deployed half with terraform and half with dedicated [ArgoCD addon repo](https://github.com/aws-samples/eks-blueprints-add-ons)
-    - [Metrics server](https://aws-ia.github.io/terraform-aws-eks-blueprints/main/add-ons/metrics-server/)
-    - [Vertical Pod Autoscaler](https://aws-ia.github.io/terraform-aws-eks-blueprints/main/add-ons/vpa/)
-    - [Aws Load Balancer Controller](https://aws-ia.github.io/terraform-aws-eks-blueprints/main/add-ons/aws-load-balancer-controller/)
-    - [Karpenter](https://aws-ia.github.io/terraform-aws-eks-blueprints/main/add-ons/karpenter/)
-    - [External DNS](https://aws-ia.github.io/terraform-aws-eks-blueprints/main/add-ons/external-dns/)
+    - Metrics server
+    - Vertical Pod Autoscaler
+    - Aws Load Balancer Controller
+    - Karpenter
+    - External DNS
       - configured to target the environment infrastructure Hosted Zone
-    - [AWS for FluentBit](https://aws-ia.github.io/terraform-aws-eks-blueprints/main/add-ons/aws-for-fluent-bit/) to centralized logs in Amazon CloudWatch
-    - [AWS CloudWatch Metrics](https://aws-ia.github.io/terraform-aws-eks-blueprints/main/add-ons/aws-cloudwatch-metrics/) to enable [Container Insight](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/ContainerInsights.html)
-    - [Kubecost](https://aws-ia.github.io/terraform-aws-eks-blueprints/main/add-ons/kubecost/)
+    - AWS for FluentBit
+    - AWS CloudWatch Metrics
+    - Kubecost
   - Kubernetes workloads (defined in a dedicated github repository repository)
     - team-burnham
       - burnham-ingress configured with weighted target groups

--- a/patterns/elastic-fabric-adapter/README.md
+++ b/patterns/elastic-fabric-adapter/README.md
@@ -4,7 +4,7 @@ This pattern demonstrates an Amazon EKS Cluster with an EFA-enabled nodegroup.
 
 ## Deploy
 
-See [here](https://aws-ia.github.io/terraform-aws-eks-blueprints/main/getting-started/#prerequisites) for the prerequisites and steps to deploy this pattern.
+See [here](https://aws-ia.github.io/terraform-aws-eks-blueprints/getting-started/#prerequisites) for the prerequisites and steps to deploy this pattern.
 
 ## Validate
 

--- a/patterns/external-secrets/README.md
+++ b/patterns/external-secrets/README.md
@@ -7,7 +7,7 @@ store is also created. Both stores use IRSA to retrieve the secret values from A
 
 ## Deploy
 
-See [here](https://aws-ia.github.io/terraform-aws-eks-blueprints/main/getting-started/#prerequisites) for the prerequisites and steps to deploy this pattern.
+See [here](https://aws-ia.github.io/terraform-aws-eks-blueprints/getting-started/#prerequisites) for the prerequisites and steps to deploy this pattern.
 
 ## Validate
 

--- a/patterns/fargate-serverless/README.md
+++ b/patterns/fargate-serverless/README.md
@@ -4,7 +4,7 @@ This pattern demonstrates an Amazon EKS Cluster that utilizes Fargate profiles f
 
 ## Deploy
 
-See [here](https://aws-ia.github.io/terraform-aws-eks-blueprints/main/getting-started/#prerequisites) for the prerequisites and steps to deploy this pattern.
+See [here](https://aws-ia.github.io/terraform-aws-eks-blueprints/getting-started/#prerequisites) for the prerequisites and steps to deploy this pattern.
 
 ## Validate
 

--- a/patterns/fully-private-cluster/README.md
+++ b/patterns/fully-private-cluster/README.md
@@ -24,7 +24,7 @@ If you are using an existing VPC then you may need to ensure these endpoints are
 
 ## Deploy
 
-See [here](https://aws-ia.github.io/terraform-aws-eks-blueprints/main/getting-started/#prerequisites) for the prerequisites and steps to deploy this pattern.
+See [here](https://aws-ia.github.io/terraform-aws-eks-blueprints/getting-started/#prerequisites) for the prerequisites and steps to deploy this pattern.
 
 ## Validate
 

--- a/patterns/ipv6-eks-cluster/README.md
+++ b/patterns/ipv6-eks-cluster/README.md
@@ -4,7 +4,7 @@ This pattern demonstrates an EKS cluster that utilizes IPv6 networking.
 
 ## Deploy
 
-See [here](https://aws-ia.github.io/terraform-aws-eks-blueprints/main/getting-started/#prerequisites) for the prerequisites and steps to deploy this pattern.
+See [here](https://aws-ia.github.io/terraform-aws-eks-blueprints/getting-started/#prerequisites) for the prerequisites and steps to deploy this pattern.
 
 ## Validate
 

--- a/patterns/istio/README.md
+++ b/patterns/istio/README.md
@@ -14,7 +14,7 @@ concepts.
 
 ## Deploy
 
-See [here](https://aws-ia.github.io/terraform-aws-eks-blueprints/main/getting-started/#prerequisites) for the prerequisites and steps to deploy this pattern.
+See [here](https://aws-ia.github.io/terraform-aws-eks-blueprints/getting-started/#prerequisites) for the prerequisites and steps to deploy this pattern.
 
 ### Observability Add-ons
 

--- a/patterns/karpenter/README.md
+++ b/patterns/karpenter/README.md
@@ -4,7 +4,7 @@ This pattern demonstrates how to provision Karpenter on a serverless cluster (se
 
 ## Deploy
 
-See [here](https://aws-ia.github.io/terraform-aws-eks-blueprints/main/getting-started/#prerequisites) for the prerequisites and steps to deploy this pattern.
+See [here](https://aws-ia.github.io/terraform-aws-eks-blueprints/getting-started/#prerequisites) for the prerequisites and steps to deploy this pattern.
 
 ## Validate
 

--- a/patterns/multi-tenancy-with-teams/README.md
+++ b/patterns/multi-tenancy-with-teams/README.md
@@ -9,7 +9,7 @@ This example solution provides:
 
 ## Deploy
 
-See [here](https://aws-ia.github.io/terraform-aws-eks-blueprints/main/getting-started/#prerequisites) for the prerequisites and steps to deploy this pattern.
+See [here](https://aws-ia.github.io/terraform-aws-eks-blueprints/getting-started/#prerequisites) for the prerequisites and steps to deploy this pattern.
 
 ## Validate
 

--- a/patterns/private-public-ingress/README.md
+++ b/patterns/private-public-ingress/README.md
@@ -13,7 +13,7 @@ Refer to the [documentation](https://kubernetes-sigs.github.io/aws-load-balancer
 
 ## Deploy
 
-See [here](https://aws-ia.github.io/terraform-aws-eks-blueprints/main/getting-started/#prerequisites) for the prerequisites and steps to deploy this pattern.
+See [here](https://aws-ia.github.io/terraform-aws-eks-blueprints/getting-started/#prerequisites) for the prerequisites and steps to deploy this pattern.
 
 ## Validate
 

--- a/patterns/privatelink-access/README.md
+++ b/patterns/privatelink-access/README.md
@@ -7,7 +7,7 @@ for further details on  `AWS PrivateLink`.
 
 ## Deploy
 
-See [here](https://aws-ia.github.io/terraform-aws-eks-blueprints/main/getting-started/#prerequisites) for the prerequisites and steps to deploy this pattern.
+See [here](https://aws-ia.github.io/terraform-aws-eks-blueprints/getting-started/#prerequisites) for the prerequisites and steps to deploy this pattern.
 
 ## Validate
 

--- a/patterns/sso-iam-identity-center/README.md
+++ b/patterns/sso-iam-identity-center/README.md
@@ -4,7 +4,7 @@ This example demonstrates how to deploy an Amazon EKS cluster that is deployed o
 
 ## Deploy
 
-See [here](https://aws-ia.github.io/terraform-aws-eks-blueprints/main/getting-started/#prerequisites) for the prerequisites and steps to deploy this pattern.
+See [here](https://aws-ia.github.io/terraform-aws-eks-blueprints/getting-started/#prerequisites) for the prerequisites and steps to deploy this pattern.
 
 ## Validate
 

--- a/patterns/sso-okta/README.md
+++ b/patterns/sso-okta/README.md
@@ -4,7 +4,7 @@ This example demonstrates how to deploy an Amazon EKS cluster that is deployed o
 
 ## Deploy
 
-See [here](https://aws-ia.github.io/terraform-aws-eks-blueprints/main/getting-started/#prerequisites) for the prerequisites and steps to deploy this pattern.
+See [here](https://aws-ia.github.io/terraform-aws-eks-blueprints/getting-started/#prerequisites) for the prerequisites and steps to deploy this pattern.
 
 ## Validate
 

--- a/patterns/stateful/README.md
+++ b/patterns/stateful/README.md
@@ -38,7 +38,7 @@ In addition, the following properties are configured on the nodegroup volumes:
 
 ## Deploy
 
-See [here](https://aws-ia.github.io/terraform-aws-eks-blueprints/main/getting-started/#prerequisites) for the prerequisites and steps to deploy this pattern.
+See [here](https://aws-ia.github.io/terraform-aws-eks-blueprints/getting-started/#prerequisites) for the prerequisites and steps to deploy this pattern.
 
 ## Validate
 

--- a/patterns/tls-with-aws-pca-issuer/README.md
+++ b/patterns/tls-with-aws-pca-issuer/README.md
@@ -4,7 +4,7 @@ This pattern demonstrates how to enable TLS with AWS PCA issuer on an Amazon EKS
 
 ## Deploy
 
-See [here](https://aws-ia.github.io/terraform-aws-eks-blueprints/main/getting-started/#prerequisites) for the prerequisites and steps to deploy this pattern.
+See [here](https://aws-ia.github.io/terraform-aws-eks-blueprints/getting-started/#prerequisites) for the prerequisites and steps to deploy this pattern.
 
 ## Validate
 

--- a/patterns/wireguard-with-cilium/README.md
+++ b/patterns/wireguard-with-cilium/README.md
@@ -7,7 +7,7 @@ This pattern demonstrates Cilium configured in CNI chaining mode with VPC CNI an
 
 ## Deploy
 
-See [here](https://aws-ia.github.io/terraform-aws-eks-blueprints/main/getting-started/#prerequisites) for the prerequisites and steps to deploy this pattern.
+See [here](https://aws-ia.github.io/terraform-aws-eks-blueprints/getting-started/#prerequisites) for the prerequisites and steps to deploy this pattern.
 
 ## Validate
 


### PR DESCRIPTION
# Description

- Update mkdocs CD deploy to use standard mkdocs without versioning
- Correct links with change to drop versioned docs

### Motivation and Context

- Only v5 documentation will be shown to avoid confusion. If users need to view v4.x configurations, that is captured in git history and accessible through the repository using the tag version

### How was this change tested?

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR

### Additional Notes

<!-- Anything else we should know when reviewing? -->
