### PR TITLE
fix: Use namespace resource to share across `istio` charts to avoid conflicts

### DIFF
--- a/patterns/istio/README.md
+++ b/patterns/istio/README.md
@@ -16,6 +16,12 @@ concepts.
 
 See [here](https://aws-ia.github.io/terraform-aws-eks-blueprints/getting-started/#prerequisites) for the prerequisites and steps to deploy this pattern.
 
+Once the resources have been provisioned, you will need to replace the `istio-ingress` pods due to a [`istiod` dependency issue](https://github.com/istio/istio/issues/35789). Use the following command to perform a rolling restart of the `istio-ingress` pods:
+
+```sh
+kubectl rollout restart deployment istio-ingress -n istio-ingress
+```
+
 ### Observability Add-ons
 
 Use the following code snippet to add the Istio Observability Add-ons on the EKS

--- a/patterns/istio/main.tf
+++ b/patterns/istio/main.tf
@@ -71,11 +71,11 @@ module "eks" {
 
   eks_managed_node_groups = {
     initial = {
-      instance_types = ["m5.xlarge"]
+      instance_types = ["m5.large"]
 
       min_size     = 1
       max_size     = 5
-      desired_size = 3 # When < 3, the coredns add-on ends up in a degraded state
+      desired_size = 2
     }
   }
 


### PR DESCRIPTION
# Description

- Both the `istio-base` and `istiod` rely on the `istio-system` namespace, but if we try to create it in the `helm_release` resource then the chart that is not creating the namespace fails since the namespace does not exist. Instead, changing to use a standalone namespace resource that is passed into the charts resolves this conflict
- The `istio-ingress` automatically pulls the necessary image but only after it has been updated by `istiod` to know which image it should pull. This creates a hard dependency where `istio-ingress` requires `istiod` to be running before its pods are created, otherwise an image value must be specified in the `instio-ingress` chart values. There are numerous issues for this unfortunate situation, see below a couple of references. To get around this, the documentation has been updated to restart the `istio-ingress` deployment after the example is first provisioned. This will recycle those pods and they will now be able to pull the correct image
  - https://github.com/istio/istio/issues/46307
  - https://github.com/istio/istio/issues/35789
- The EKS addons were taking quite a bit of time to deploy, CoreDNS routinely taking up to 15 minutes to provision. Historically there has been a better experience when these are deployed via the EKS module which this PR has followed. Once the addons were defined within the EKS module, the addons deploy rather quickly in 1-1.5 minutes
- Since this pattern is creating a load balancer, we commonly face issues with these resources becoming orphaned when destroying the pattern. The example has been updated to set `preserve = true` on the VPC CNI to the CNI is able to continue managing and facilitating networking requests while the cluster is being destroyed. This helps to avoid the situation where the cluster resources were deleted too quickly and not allowing the ALB controller enough time to delete its resources and creaitng orphaned load balancer

### Motivation and Context

- Resolves #1766 

### How was this change tested?

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [x] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR

### Additional Notes

<!-- Anything else we should know when reviewing? -->
