### PR TITLE
docs: Updated Stateful Pattern Readme to include validation of Velero

### DIFF
--- a/patterns/stateful/README.md
+++ b/patterns/stateful/README.md
@@ -42,7 +42,7 @@ See [here](https://aws-ia.github.io/terraform-aws-eks-blueprints/getting-started
 
 ## Validate Storage
 
-For validating `velero` see [here](https://github.com/awshans/terraform-aws-eks-blueprints/tree/main/patterns/stateful/README.md#Validate-Velero-Install)
+For validating `velero` see [here](https://aws-ia.github.io/terraform-aws-eks-blueprints/tree/main/patterns/stateful/README.md#Validate-Velero-Install)
 
 The following command will update the `kubeconfig` on your local machine and allow you to interact with your EKS Cluster using `kubectl` to validate the Velero deployment.
 

--- a/patterns/stateful/README.md
+++ b/patterns/stateful/README.md
@@ -42,8 +42,6 @@ See [here](https://aws-ia.github.io/terraform-aws-eks-blueprints/getting-started
 
 ## Validate
 
-For validating `velero` see [here](https://aws-ia.github.io/terraform-aws-eks-blueprints/tree/main/patterns/stateful/README.md#Validate-Velero-Install)
-
 The following command will update the `kubeconfig` on your local machine and allow you to interact with your EKS Cluster using `kubectl` to validate the Velero deployment.
 
 1. Run `update-kubeconfig` command:
@@ -135,17 +133,7 @@ The following command will update the `kubeconfig` on your local machine and all
     /dev/nvme1n1    24594768 2886716  20433380  13% /run/containerd
     ```
 
-## Validate Velero Install
-
-The following command will update the `kubeconfig` on your local machine and allow you to interact with your EKS Cluster using `kubectl` to validate the Velero deployment.
-
-1. Run `update-kubeconfig` command:
-
-    ```bash
-    aws eks --region <REGION> update-kubeconfig --name <CLUSTER_NAME>
-    ```
-
-2. Test by listing velero resources provisioned:
+6. Test by listing velero resources provisioned:
 
     ```bash
     kubectl get all -n velero
@@ -164,7 +152,7 @@ The following command will update the `kubeconfig` on your local machine and all
     replicaset.apps/velero-b4d8fd5c7   1         1         1       114s
     ```
 
-3. Get backup location using velero [CLI](https://velero.io/docs/v1.8/basic-install/#install-the-cli)
+7. Get backup location using velero [CLI](https://velero.io/docs/v1.8/basic-install/#install-the-cli)
 
     ```bash
     velero backup-location get

--- a/patterns/stateful/README.md
+++ b/patterns/stateful/README.md
@@ -40,7 +40,7 @@ In addition, the following properties are configured on the nodegroup volumes:
 
 See [here](https://aws-ia.github.io/terraform-aws-eks-blueprints/getting-started/#prerequisites) for the prerequisites and steps to deploy this pattern.
 
-## Validate Storage
+## Validate
 
 For validating `velero` see [here](https://aws-ia.github.io/terraform-aws-eks-blueprints/tree/main/patterns/stateful/README.md#Validate-Velero-Install)
 


### PR DESCRIPTION
# Description

<!--
🛑 Please open an issue first to discuss any significant work and flesh out details/direction - we would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/aws-ia/terraform-aws-eks-blueprints/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

A brief description of the change being made with this pull request.
-->

would be line 45 of the stateful readme had a link to content which no long existed. [readme](https://github.com/aws-ia/terraform-aws-eks-blueprints/blob/main/patterns/stateful/README.md?plain=1)

I migrated the content from the old page to a "Validate Velero" section and updated the current Validation area to be to focused on validation of local storage attachment. 

### Motivation and Context

<!-- What inspired you to submit this pull request? -->
- Resolves #<issue-number>

### How was this change tested?

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [x] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR

### Additional Notes

<!-- Anything else we should know when reviewing? -->
