### PR TITLE
docs: Fix typo/bug in readme

### DIFF
--- a/patterns/blue-green-upgrade/README.md
+++ b/patterns/blue-green-upgrade/README.md
@@ -90,7 +90,7 @@ cd patterns/blue-green-upgrade/
 cp terraform.tfvars.example terraform.tfvars
 ln -s ../terraform.tfvars environment/terraform.tfvars
 ln -s ../terraform.tfvars eks-blue/terraform.tfvars
-ln -s ../terraform.tfvars eks-blue/terraform.tfvars
+ln -s ../terraform.tfvars eks-green/terraform.tfvars
 ```
 
 - You will need to provide the `hosted_zone_name` for example `my-example.com`. Terraform will create a new hosted zone for the project with name: `${environment}.${hosted_zone_name}` so in our example `eks-blueprint.my-example.com`.


### PR DESCRIPTION
# Description
Fixes the documentation for blue/green eks example

### Motivation and Context
I was following the docs and saw an error

- Resolves #<issue-number>

### How was this change tested?

- [ x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [  ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [  ] Yes, I ran `pre-commit run -a` with this PR

### Additional Notes

