### PR TITLE
added elb addtags action for lb irsa policy

### DIFF
--- a/modules/kubernetes-addons/aws-load-balancer-controller/data.tf
+++ b/modules/kubernetes-addons/aws-load-balancer-controller/data.tf
@@ -41,6 +41,7 @@ data "aws_iam_policy_document" "aws_lb" {
       "elasticloadbalancing:DescribeTargetGroupAttributes",
       "elasticloadbalancing:DescribeTargetGroups",
       "elasticloadbalancing:DescribeTargetHealth",
+      "elasticloadbalancing:AddTags",
     ]
   }
 


### PR DESCRIPTION
# Description

Fixes 
`ingress  (combined from similar events): Failed deploy model due to AccessDenied: User: arn:aws:sts:::assumed-role/cg-eks-nyx-aws-load-balancer-controller-sa-irsa is not authorized to perform: elasticloadbalancing:AddTags on resource: arn:aws:elasticloadbalancing:us-east-2::targetgroup/k8s-security-/* because no identity-based policy allows the elasticloadbalancing:AddTags action
`
a lot of users including me still use v4, so I wanted to patch it up and hopefully create a release 