### PR TITLE
Missing conf worker data plane logs fluentbit add on

### DIFF
--- a/.github/workflows/plan-examples.yml
+++ b/.github/workflows/plan-examples.yml
@@ -5,6 +5,7 @@ on:
   pull_request_target:
     branches:
       - main
+      - v4
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+      - v4
     paths:
       - '**.tf'
       - '**.yml'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
       - id: detect-aws-credentials
         args: ['--allow-missing-credentials']
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.78.0
+    rev: v1.80.0
     hooks:
       - id: terraform_fmt
       - id: terraform_docs

--- a/modules/kubernetes-addons/README.md
+++ b/modules/kubernetes-addons/README.md
@@ -74,7 +74,7 @@
 | <a name="module_nvidia_device_plugin"></a> [nvidia\_device\_plugin](#module\_nvidia\_device\_plugin) | ./nvidia-device-plugin | n/a |
 | <a name="module_ondat"></a> [ondat](#module\_ondat) | ./ondat | n/a |
 | <a name="module_opentelemetry_operator"></a> [opentelemetry\_operator](#module\_opentelemetry\_operator) | ./opentelemetry-operator | n/a |
-| <a name="module_portworx"></a> [portworx](#module\_portworx) | portworx/portworx-addon/eksblueprints | 0.0.6 |
+| <a name="module_portworx"></a> [portworx](#module\_portworx) | ./portworx | n/a |
 | <a name="module_prometheus"></a> [prometheus](#module\_prometheus) | ./prometheus | n/a |
 | <a name="module_promtail"></a> [promtail](#module\_promtail) | ./promtail | n/a |
 | <a name="module_reloader"></a> [reloader](#module\_reloader) | ./reloader | n/a |
@@ -83,7 +83,7 @@
 | <a name="module_spark_history_server"></a> [spark\_history\_server](#module\_spark\_history\_server) | ./spark-history-server | n/a |
 | <a name="module_spark_k8s_operator"></a> [spark\_k8s\_operator](#module\_spark\_k8s\_operator) | ./spark-k8s-operator | n/a |
 | <a name="module_strimzi_kafka_operator"></a> [strimzi\_kafka\_operator](#module\_strimzi\_kafka\_operator) | ./strimzi-kafka-operator | n/a |
-| <a name="module_sysdig_agent"></a> [sysdig\_agent](#module\_sysdig\_agent) | sysdiglabs/sysdig-addon/eksblueprints | 0.0.3 |
+| <a name="module_sysdig_agent"></a> [sysdig\_agent](#module\_sysdig\_agent) | ./sysdig | n/a |
 | <a name="module_tetrate_istio"></a> [tetrate\_istio](#module\_tetrate\_istio) | ./tetrate-istio | n/a |
 | <a name="module_thanos"></a> [thanos](#module\_thanos) | ./thanos | n/a |
 | <a name="module_traefik"></a> [traefik](#module\_traefik) | ./traefik | n/a |

--- a/modules/kubernetes-addons/aws-for-fluentbit/values.yaml
+++ b/modules/kubernetes-addons/aws-for-fluentbit/values.yaml
@@ -2,7 +2,134 @@ serviceAccount:
   create: false
   name: ${service_account}
 
+input:
+  enabled: true
+  tag: "kube.app.*"
+  path: "/var/log/containers/*.log"
+  db: "/var/log/flb_kube.db"
+  parser: docker
+  dockerMode: "On"
+  memBufLimit: 5MB
+  skipLongLines: "On"
+  refreshInterval: 10
+  extraInputs: >
+    exclude_path   /var/log/containers/aws-node*, /var/log/containers/kube-proxy*
+additionalInputs: |
+  [INPUT]
+      Name              tail
+      tag               host.messages
+      path              /var/log/messages
+      db                /var/log/flb_messages.db
+      parser            syslog
+      Mem_Buf_Limit     5MB
+      Skip_Long_Lines   On
+      Refresh_Interval  10
+      Read_from_Head    true
+  [INPUT]
+      Name                tail
+      Tag                 host.dmesg
+      Path                /var/log/dmesg
+      Key                 message
+      DB                  /var/log/flb_dmesg.db
+      Mem_Buf_Limit       5MB
+      Skip_Long_Lines     On
+      Refresh_Interval    10
+      Read_from_Head      true
+  [INPUT]
+      Name                tail
+      Tag                 host.secure
+      Path                /var/log/secure
+      Parser              syslog
+      DB                  /var/log/flb_secure.db
+      Mem_Buf_Limit       5MB
+      Skip_Long_Lines     On
+      Refresh_Interval    10
+      Read_from_Head      true
+  [INPUT]
+      Name                systemd
+      Tag                 dataplane.systemd.*
+      Systemd_Filter      _SYSTEMD_UNIT=containerd.service
+      Systemd_Filter      _SYSTEMD_UNIT=kubelet.service
+      DB                  /var/log/systemd.db
+      Path                /var/log/journal
+      Read_From_Tail      true
+
+  [INPUT]
+      Name                tail
+      Tag                 dataplane.tail.*
+      Path                /var/log/containers/aws-node*, /var/log/containers/kube-proxy*
+      parser              docker
+      DB                  /var/log/flb_dataplane_tail.db
+      Mem_Buf_Limit       50MB
+      Skip_Long_Lines     On
+      Refresh_Interval    10
+      Rotate_Wait         30
+      #storage.type        filesystem
+      Read_from_Head      true
+filter:
+  enabled: true
+  match: "kube.app.*"
+  kubeURL: "https://kubernetes.default.svc.cluster.local:443"
+  mergeLog: "On"
+  mergeLogKey: "data"
+  keepLog: "On"
+  k8sLoggingParser: "On"
+  k8sLoggingExclude: "Off"
+  bufferSize: "32k"
+  extraFilters: |
+    Kube_Tag_Prefix     kube.app.var.log.containers.
+additionalFilters: |
+    [FILTER]
+        Name                  aws
+        Match                 host.*
+        imds_version          v2
+        az                    true
+        ec2_instance_id       true
+        ec2_instance_type     true
+        private_ip            true
+        hostname              true
+    
+    [FILTER]
+        Name                  modify
+        Match                 dataplane.systemd.*
+        Rename                _HOSTNAME                   hostname
+        Rename                _SYSTEMD_UNIT               systemd_unit
+        Rename                MESSAGE                     message
+        Remove_regex          ^((?!hostname|systemd_unit|message).)*$
+
+    [FILTER]
+        Name                  aws
+        Match                 dataplane.*
+        imds_version          v2
+        az                    true
+        ec2_instance_id       true
+        ec2_instance_type     true
+        private_ip            true
+        hostname              true
 cloudWatchLogs:
   enabled: true
-  region: ${aws_region}
-  logGroupName: ${log_group_name}
+  match: "kube.app.*"
+  region: ${region}
+  logGroupName: "/aws/eks/fluentbit-cloudwatch/logs"
+  logGroupTemplate: /aws/containerinsights/application/$kubernetes['namespace_name']
+  logStreamPrefix: "fluentbit-"
+  logStreamTemplate: $kubernetes['pod_name'].$kubernetes['container_name']
+additionalOutputs: |
+  [OUTPUT]
+      Name                cloudwatch_logs
+      match               host.*
+      region              ${region}
+      log_group_name      /aws/containerinsight/host
+      auto_create_group   true
+      log_stream_template $hostname
+      log_stream_prefix   eks
+      extra_user_agent    container-insights
+  [OUTPUT]
+      Name                cloudwatch_logs
+      match               dataplane.*
+      region              ${region}
+      log_group_name      /aws/containerinsights/dataplane
+      auto_create_group   true
+      log_stream_template $hostname
+      log_stream_prefix   eks
+      extra_user_agent    container-insights

--- a/modules/kubernetes-addons/aws-for-fluentbit/values.yaml
+++ b/modules/kubernetes-addons/aws-for-fluentbit/values.yaml
@@ -109,7 +109,7 @@ additionalFilters: |
 cloudWatchLogs:
   enabled: true
   match: "kube.app.*"
-  region: ${region}
+  region: ${aws_region}
   logGroupName: "/aws/eks/fluentbit-cloudwatch/logs"
   logGroupTemplate: /aws/containerinsights/application/$kubernetes['namespace_name']
   logStreamPrefix: "fluentbit-"
@@ -118,7 +118,7 @@ additionalOutputs: |
   [OUTPUT]
       Name                cloudwatch_logs
       match               host.*
-      region              ${region}
+      region              ${aws_region}
       log_group_name      /aws/containerinsight/host
       auto_create_group   true
       log_stream_template $hostname
@@ -127,7 +127,7 @@ additionalOutputs: |
   [OUTPUT]
       Name                cloudwatch_logs
       match               dataplane.*
-      region              ${region}
+      region              ${aws_region}
       log_group_name      /aws/containerinsights/dataplane
       auto_create_group   true
       log_stream_template $hostname

--- a/modules/kubernetes-addons/main.tf
+++ b/modules/kubernetes-addons/main.tf
@@ -389,12 +389,14 @@ module "kube_prometheus_stack" {
 }
 
 module "portworx" {
-  count         = var.enable_portworx ? 1 : 0
-  source        = "portworx/portworx-addon/eksblueprints"
-  version       = "0.0.6"
+  source = "./portworx"
+
+  count = var.enable_portworx ? 1 : 0
+
   helm_config   = var.portworx_helm_config
   addon_context = local.addon_context
 }
+
 module "prometheus" {
   count       = var.enable_prometheus ? 1 : 0
   source      = "./prometheus"
@@ -441,8 +443,7 @@ module "strimzi_kafka_operator" {
 }
 
 module "sysdig_agent" {
-  source  = "sysdiglabs/sysdig-addon/eksblueprints"
-  version = "0.0.3"
+  source = "./sysdig"
 
   count         = var.enable_sysdig_agent ? 1 : 0
   helm_config   = var.sysdig_agent_helm_config
@@ -450,11 +451,6 @@ module "sysdig_agent" {
 }
 
 module "tetrate_istio" {
-  # source  = "tetratelabs/tetrate-istio-addon/eksblueprints"
-  # version = "0.0.7"
-
-  # TODO - remove local source and revert to remote once
-  # https://github.com/tetratelabs/terraform-eksblueprints-tetrate-istio-addon/pull/12  is merged
   source = "./tetrate-istio"
 
   count = var.enable_tetrate_istio ? 1 : 0

--- a/modules/kubernetes-addons/portworx/README.md
+++ b/modules/kubernetes-addons/portworx/README.md
@@ -1,0 +1,3 @@
+# Portworx add-on for EKS Blueprints
+
+Local copy of https://github.com/portworx/terraform-eksblueprints-portworx-addon

--- a/modules/kubernetes-addons/portworx/locals.tf
+++ b/modules/kubernetes-addons/portworx/locals.tf
@@ -1,0 +1,86 @@
+resource "random_string" "id" {
+  length  = 4
+  special = false
+  upper   = false
+}
+
+locals {
+  name                 = "portworx-${random_string.id.result}"
+  namespace            = "kube-system"
+  service_account_name = "${local.name}-sa-${random_string.id.result}"
+
+  aws_marketplace_config = try(var.helm_config["set"][index(var.helm_config.set[*].name, "aws.marketplace")], null)
+  use_aws_marketplace    = local.aws_marketplace_config != null ? local.aws_marketplace_config["value"] : false
+
+  default_helm_config = {
+    name        = local.name
+    description = "A Helm chart for portworx"
+    chart       = "portworx"
+    repository  = "https://raw.githubusercontent.com/portworx/eks-blueprint-helm/main/repo/stable"
+    version     = "2.11.0"
+    namespace   = local.namespace
+    values      = local.default_helm_values
+  }
+
+  helm_config = merge(
+    local.default_helm_config,
+    var.helm_config
+  )
+
+  irsa_iam_policies_list = local.use_aws_marketplace != false ? [aws_iam_policy.portworx_eksblueprint_metering[0].arn] : []
+
+  irsa_config = {
+    create_kubernetes_namespace       = false
+    kubernetes_namespace              = local.namespace
+    create_kubernetes_service_account = true
+    kubernetes_service_account        = local.service_account_name
+    irsa_iam_policies                 = local.irsa_iam_policies_list
+  }
+
+  default_helm_values = [templatefile("${path.module}/values.yaml", {
+    imageVersion           = "2.11.0"
+    clusterName            = local.name
+    drives                 = "type=gp2,size=200"
+    useInternalKVDB        = true
+    kvdbDevice             = "type=gp2,size=150"
+    envVars                = ""
+    maxStorageNodesPerZone = 3
+    useOpenshiftInstall    = false
+    etcdEndPoint           = ""
+    dataInterface          = ""
+    managementInterface    = ""
+    useStork               = true
+    storkVersion           = "2.11.0"
+    customRegistryURL      = ""
+    registrySecret         = ""
+    licenseSecret          = ""
+    monitoring             = false
+    enableCSI              = false
+    enableAutopilot        = false
+    KVDBauthSecretName     = ""
+    eksServiceAccount      = local.service_account_name
+    awsAccessKeyId         = ""
+    awsSecretAccessKey     = ""
+    deleteType             = "UninstallAndWipe"
+    }
+  )]
+}
+
+resource "aws_iam_policy" "portworx_eksblueprint_metering" {
+  count = try(local.use_aws_marketplace, false) ? 1 : 0
+  name  = "portworx_eksblueprint_metering-${random_string.id.result}"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = [
+          "aws-marketplace:MeterUsage",
+          "aws-marketplace:RegisterUsage"
+        ],
+        Effect   = "Allow",
+        Resource = "*"
+      },
+    ]
+  })
+}

--- a/modules/kubernetes-addons/portworx/main.tf
+++ b/modules/kubernetes-addons/portworx/main.tf
@@ -1,0 +1,7 @@
+module "helm_addon" {
+  source = "../helm-addon"
+
+  addon_context = var.addon_context
+  helm_config   = local.helm_config
+  irsa_config   = local.irsa_config
+}

--- a/modules/kubernetes-addons/portworx/values.yaml
+++ b/modules/kubernetes-addons/portworx/values.yaml
@@ -1,0 +1,123 @@
+# Please uncomment and specify values for these options as per your requirements.
+
+deployOperator: true                    # Deploy the Portworx operator
+deployCluster: true                     # Deploy the Portworx cluster
+
+imageVersion: ${imageVersion}               # Version of the PX Image.
+pxOperatorImageVersion: 1.9.0       # Version of the PX operator image.
+
+openshiftInstall: ${useOpenshiftInstall}                 # Defaults to false for installing Portworx on Openshift .
+isTargetOSCoreOS: false                 # Is your target OS CoreOS? Defaults to false.
+pksInstall: false                       # installation on PKS (Pivotal Container Service)
+EKSInstall: true                        # installation on EKS.
+AKSInstall: false                      # installation on AKS
+etcdEndPoint:  ${etcdEndPoint}        # The ETCD endpoint. Should be in the format etcd:http://<your-etcd-endpoint>:2379. If there are multiple etcd endpoints they need to be ";" seperated.
+                                      # the default value is empty since it requires to be explicity set using either the --set option of -f values.yaml.
+clusterName: ${clusterName}             # This is the default. please change it to your cluster name.
+usefileSystemDrive: false             # true/false Instructs PX to use an unmounted Drive even if it has a filesystem.
+usedrivesAndPartitions: false         # Defaults to false. Change to true and PX will use unmounted drives and partitions.
+drives: ${drives}                          # NOTE: This is a ";" seperated list of drives. For eg: "/dev/sda;/dev/sdb;/dev/sdc" or
+                                      # "type=gp2,size=200;type=gp3,size=500". Defaults to use -A switch.
+journalDevice:
+maxStorageNodesPerZone: ${maxStorageNodesPerZone}  # The maximum number of storage nodes desired per zone, in case of cloud drive provisioning
+
+secretType: k8s                       # Defaults to k8s, but can be kvdb/k8s/aws-kms/vault/ibm-kp. It is autopopulated to ibm-kp
+                                      # if the environment is IKS.
+
+dataInterface: ${dataInterface}                   # Name of the interface <ethX>
+managementInterface: none             # Name of the interface <ethX>
+serviceType: none                     # Kubernetes service type for services deployed by the Operator. Direct Values like
+                                      # 'LoadBalancer', 'NodePort' will change all services. To change the types of specific
+                                      # services, value can be specified as 'portworx-service:LoadBalancer;portworx-api:ClusterIP'
+
+envVars:  ${envVars}                        # DEPRECATED: Use envs section to set env variables
+                                      # NOTE: This is a ";" seperated list of environment variables.
+                                      # For eg: MYENV1=myvalue1;MYENV2=myvalue2
+
+envs:                                 # Add environment variables to the Portworx container in all Kubernetes supported formats
+  # - name: AWS_CA_BUNDLE
+  #   value: "/etc/pwx/objectstore-cert/objectstore.pem"
+  # - name: AWS_ACCESS_KEY_ID
+  #   valueFrom:
+  #     secretKeyRef:
+  #       name: aws-creds
+  #       key: access-key
+
+miscArgs: none                        # Miscellaneous arguments that will be passed to portworx verbatim. Only use this if there is
+                                      # no equivalent way to specify these options directly via a StorageCluster spec field.
+
+disableStorageClass: false            # Instructs Operator to not install the default Portworx StorageClasses.
+
+stork: ${useStork}                           # Use Stork https://docs.portworx.com/scheduler/kubernetes/stork.html for hyperconvergence.
+storkVersion: ${storkVersion}                       # Optional: version of Stork. For eg: 2.7.0, when it's empty Portworx operator will pick up
+                                      # version according to Portworx version.
+
+storkSpec:                            # Optional Stork configurations
+  args:                               # Pass arguments to Stork container. Example: verbose='true';webhook-controller='false'
+  volumes:                            # Add volumes to Stork container. Refer the top level volumes for schema.
+
+customRegistryURL: ${customRegistryURL}       #Url wherre to pull Portworx image from
+registrySecret: ${registrySecret}         #Image registery credentials to pull Portworx Images from a secure registry
+licenseSecret:  ${licenseSecret}         #Kubernetes secret name that has Portworx licensing information
+
+monitoring: ${monitoring}
+
+deployOnMaster:  false                # For POC only
+csi: ${enableCSI}                     # Enable CSI
+aut: ${enableAutopilot}               # Enable AutoPilot
+
+
+internalKVDB: ${useInternalKVDB}      # internal KVDB
+kvdbDevice: ${kvdbDevice}             # specify a separate device to store KVDB data, only used when internalKVDB is set to true
+
+etcd:                                 # DEPRECATED: Use kvdb.authSecretName for configuring secure etcd
+  credentials: none:none              # Username and password for ETCD authentication in the form user:password
+  certPath: none                      # Base path where the certificates are placed. (example: if the certificates ca,crt and the key are in /etc/pwx/etcdcerts the value should be provided as /etc/pwx/etcdcerts)
+  ca: none                            # Location of CA file for ETCD authentication. Should be /path/to/server.ca
+  cert: none                          # Location of certificate for ETCD authentication. Should be /path/to/server.crt
+  key: none                           # Location of certificate key for ETCD authentication Should be /path/to/servery.key
+
+consul:                               # DEPRECATED: Use kvdb.authSecretName for configuring secure consul
+  token: none                         # ACL token value used for Consul authentication. (example: 398073a8-5091-4d9c-871a-bbbeb030d1f6)
+
+kvdb:
+  authSecretName: ${KVDBauthSecretName}    # Refer https://docs.portworx.com/reference/etcd/#securing-with-certificates-in-kubernetes to
+                                      # create a kvdb secret and specify the name of the secret here
+
+volumes:                              # Add volumes to Portworx container. Supported volume types: Host, Secret, ConfigMap
+  # - name: objectstore-cert
+  #   mountPath: /etc/pwx/objectstore-cert
+  #   secret:
+  #     secretName: objectstore-cert
+  #     items:
+  #     - key: objectstore.pem
+  #       path: objectstore.pem
+
+tolerations:                          # Add tolerations
+  # - key: "key"
+  #   operator: "Equal|Exists"
+  #   value: "value"
+  #   effect: "NoSchedule|PreferNoSchedule|NoExecute(1.6 only)"
+
+serviceAccount:
+  hook:
+    create: true
+    name:
+
+aws:
+  marketplace:
+  eksServiceAccount: ${eksServiceAccount}
+  accessKeyId: ${awsAccessKeyId}
+  secretAccessKey: ${awsSecretAccessKey}
+
+deleteType: ${deleteType}
+
+clusterToken:
+  create: true                    # Create cluster token
+  secretName: px-vol-encryption    # Name of kubernetes secret to be created. Requires clusterToken.create to be true.
+  serviceAccountName: px-create-cluster-token  # Service account name to use for post-install hook to create cluster token
+
+#requirePxEnabledTag: true               # if set to true, portworx will only install on nodes with px/enabled: true label. Not required in most scenarios.
+
+deleteStrategy:                          # Optional: Delete strategy for the portworx cluster
+  type:                                  # Valid values: Uninstall, UninstallAndWipe

--- a/modules/kubernetes-addons/portworx/variables.tf
+++ b/modules/kubernetes-addons/portworx/variables.tf
@@ -1,0 +1,11 @@
+variable "helm_config" {
+  description = "Helm chart config. Repository and version required. See https://registry.terraform.io/providers/hashicorp/helm/latest/docs"
+  type        = any
+  default     = {}
+}
+
+variable "addon_context" {
+  description = "Input configuration for the addon"
+  type        = any
+  default     = {}
+}

--- a/modules/kubernetes-addons/portworx/versions.tf
+++ b/modules/kubernetes-addons/portworx/versions.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.67"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.10"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.0"
+    }
+  }
+}

--- a/modules/kubernetes-addons/sysdig/README.md
+++ b/modules/kubernetes-addons/sysdig/README.md
@@ -1,0 +1,3 @@
+# Sysdig Addon for EKS Blueprints
+
+Locally copy of https://github.com/sysdiglabs/terraform-eksblueprints-sysdig-addon

--- a/modules/kubernetes-addons/sysdig/locals.tf
+++ b/modules/kubernetes-addons/sysdig/locals.tf
@@ -1,0 +1,27 @@
+locals {
+  name      = "sysdig"
+  namespace = "sysdig"
+
+  set_values = []
+
+  default_helm_config = {
+    name             = local.name
+    chart            = "sysdig-deploy"
+    repository       = "https://charts.sysdig.com"
+    version          = "1.5.71"
+    namespace        = local.namespace
+    create_namespace = true
+    values           = local.default_helm_values
+    set              = []
+    description      = "Sysdig HelmChart Sysdig-Deploy configuration"
+    wait             = false
+  }
+
+  helm_config = merge(
+    local.default_helm_config,
+    var.helm_config
+  )
+
+  default_helm_values = [templatefile("${path.module}/values-sysdig.yaml", {}, )]
+
+}

--- a/modules/kubernetes-addons/sysdig/main.tf
+++ b/modules/kubernetes-addons/sysdig/main.tf
@@ -1,0 +1,7 @@
+module "helm_addon" {
+  source = "../helm-addon"
+
+  addon_context = var.addon_context
+  set_values    = local.set_values
+  helm_config   = local.helm_config
+}

--- a/modules/kubernetes-addons/sysdig/outputs.tf
+++ b/modules/kubernetes-addons/sysdig/outputs.tf
@@ -1,0 +1,4 @@
+output "argocd_gitops_config" {
+  description = "Configuration used for managing the add-on with ArgoCD"
+  value       = var.manage_via_gitops ? { enable = true } : null
+}

--- a/modules/kubernetes-addons/sysdig/values-sysdig.yaml
+++ b/modules/kubernetes-addons/sysdig/values-sysdig.yaml
@@ -1,0 +1,17 @@
+global:
+  kspm:
+    deploy: true
+agent:
+  sysdig:
+    settings:
+      collector_port: 6443
+nodeAnalyzer:
+  nodeAnalyzer:
+    benchmarkRunner:
+      deploy: false
+    runtimeScanner:
+      settings:
+        eveEnabled: true
+  secure:
+    vulnerabilityManagement:
+      newEngineOnly: true

--- a/modules/kubernetes-addons/sysdig/variables.tf
+++ b/modules/kubernetes-addons/sysdig/variables.tf
@@ -1,0 +1,35 @@
+#Helm config
+variable "helm_config" {
+  type        = any
+  description = "Helm Configuration for Sysdig Agent"
+  default     = {}
+}
+
+# Manage via gitops
+variable "manage_via_gitops" {
+  description = "Determines if the add-on should be managed via GitOps"
+  type        = bool
+  default     = false
+}
+
+# tflint-ignore: terraform_unused_declarations
+variable "cluster_name" {
+  description = "Cluster name"
+  type        = string
+  default     = ""
+}
+
+variable "addon_context" {
+  description = "Input configuration for the addon"
+  type = object({
+    aws_caller_identity_account_id = string
+    aws_caller_identity_arn        = string
+    aws_eks_cluster_endpoint       = string
+    aws_partition_id               = string
+    aws_region_name                = string
+    eks_cluster_id                 = string
+    eks_oidc_issuer_url            = string
+    eks_oidc_provider_arn          = string
+    tags                           = map(string)
+  })
+}

--- a/modules/kubernetes-addons/sysdig/versions.tf
+++ b/modules/kubernetes-addons/sysdig/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.0.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.72"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.10"
+    }
+  }
+}


### PR DESCRIPTION
# Description

<!--
🛑 Please open an issue first to discuss any significant work and flesh out details/direction - we would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/aws-ia/terraform-aws-eks-blueprints/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

A brief description of the change being made with this pull request.
-->

### Motivation and Context

<!-- What inspired you to submit this pull request? -->
- Resolves #<issue-number>

### How was this change tested?

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR

### Additional Notes

<!-- Anything else we should know when reviewing? --> While using fluentbit in EKS, I observed only pods logs are being sent to the cloudwatch. I am suggesting to add configurations for the worker node logs and dataplane logs as well. So I have added the configurations in values.yaml file. Please review and see if its useful.
