### PR TITLE
fix: Fix logging for Lambda functions in the `privatelink-access` pattern

### DIFF
--- a/patterns/privatelink-access/lambdas/create_eni.py
+++ b/patterns/privatelink-access/lambdas/create_eni.py
@@ -17,8 +17,8 @@ class StructuredMessage:
         return '%s >>> %s' % (self.message, json.dumps(self.kwargs))
 
 _ = StructuredMessage # optional, to improve readability
-logging.basicConfig(level=logging.DEBUG, format='%(message)s')
-
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
 
 def handler(event, context):
     # Only modify on CreateNetworkInterface events
@@ -27,6 +27,7 @@ def handler(event, context):
 
         # Add the extracted private IP address of the ENI as an IP target in the target group
         try:
+            logger.info('IP address %s is identified as belonging to one of the cluster endpoint ENIs', ip)
             response = ELBV2_CLIENT.register_targets(
                 TargetGroupArn = TARGET_GROUP_ARN,
                 Targets=[{
@@ -34,7 +35,7 @@ def handler(event, context):
                     'Port': 443
                 }]
             )
-            logging.info(_(response))
+            logger.info(_(response))
         except Exception as e:
-            logging.error(_(e))
+            logger.error(_(e))
             raise(e)

--- a/patterns/privatelink-access/lambdas/delete_eni.py
+++ b/patterns/privatelink-access/lambdas/delete_eni.py
@@ -18,8 +18,8 @@ class StructuredMessage:
         return '%s >>> %s' % (self.message, json.dumps(self.kwargs))
 
 _ = StructuredMessage # optional, to improve readability
-logging.basicConfig(level=logging.DEBUG, format='%(message)s')
-
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
 
 def handler(event, context):
 
@@ -32,7 +32,7 @@ def handler(event, context):
     )['TargetHealthDescriptions']
 
     if not targetHealthDescriptions:
-        logging.info("Did not find any TargetHealthDescriptions, quitting!")
+        logger.info("Did not find any TargetHealthDescriptions, quitting!")
         return
 
     # Iterate over the list of TargetHealthDescriptions and extract the list of
@@ -54,7 +54,7 @@ def handler(event, context):
     )['NetworkInterfaces']
 
     if not networkInterfaces:
-        logging.info("Did not find any EKS API ENIs to compare with, quitting!")
+        logger.info("Did not find any EKS API ENIs to compare with, quitting!")
         return
 
     for networkInterface in networkInterfaces:
@@ -71,17 +71,17 @@ def handler(event, context):
             unhealthyTargetsToDeregister.append(unhealthyTarget)
 
     if not unhealthyTargetsToDeregister:
-        logging.info("There are no unhealthy targets to deregister, quitting!")
+        logger.info("There are no unhealthy targets to deregister, quitting!")
         return
 
-    logging.info("Targets are to be deregistered: %s", unhealthyTargetsToDeregister)
+    logger.info("Targets to be deregistered are: %s", unhealthyTargetsToDeregister)
 
     try:
         response = ELBV2_CLIENT.deregister_targets(
             TargetGroupArn = TARGET_GROUP_ARN,
             Targets=unhealthyTargetsToDeregister
         )
-        logging.info(_(response))
+        logger.info(_(response))
     except Exception as e:
-        logging.error(_(e))
+        logger.error(_(e))
         raise(e)


### PR DESCRIPTION
# Description

This PR fixes the broken/non-functional logging in the Lambda functions of the `privatelink-access` pattern. 

### Motivation and Context

- Resolves #1798 

### How was this change tested?

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I ran `pre-commit run -a` with this PR

### Additional Notes

None