### PR TITLE
chore: Remove `pull_request_target` from plan examples workflow

### DIFF
--- a/.github/workflows/plan-examples.yml
+++ b/.github/workflows/plan-examples.yml
@@ -1,10 +1,6 @@
 name: plan-examples
 
 on:
-  # Review https://securitylab.github.com/research/github-actions-preventing-pwn-requests/ and better understand the risks of using pull_request_target before making major changes to this workflow.
-  pull_request_target:
-    branches:
-      - main
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
# Description

- Remove `pull_request_target` from plan examples workflow

### Motivation and Context

- N/A

### How was this change tested?

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR

### Additional Notes

- Issue opened to track the replacement for this https://github.com/aws-ia/terraform-aws-eks-blueprints/issues/1807
