### PR TITLE
fix: Additional annotation added for NLB in `istio` pattern

### DIFF
--- a/patterns/istio/README.md
+++ b/patterns/istio/README.md
@@ -14,7 +14,11 @@ concepts.
 
 ## Deploy
 
-See [here](https://aws-ia.github.io/terraform-aws-eks-blueprints/getting-started/#prerequisites) for the prerequisites and steps to deploy this pattern.
+See [here](https://aws-ia.github.io/terraform-aws-eks-blueprints/getting-started/#prerequisites) for the prerequisites and run the following command to deploy this pattern.
+
+```sh
+terraform apply --auto-approve
+```
 
 Once the resources have been provisioned, you will need to replace the `istio-ingress` pods due to a [`istiod` dependency issue](https://github.com/istio/istio/issues/35789). Use the following command to perform a rolling restart of the `istio-ingress` pods:
 

--- a/patterns/istio/main.tf
+++ b/patterns/istio/main.tf
@@ -165,9 +165,10 @@ module "eks_blueprints_addons" {
             }
             service = {
               annotations = {
-                "service.beta.kubernetes.io/aws-load-balancer-type"       = "nlb"
-                "service.beta.kubernetes.io/aws-load-balancer-scheme"     = "internet-facing"
-                "service.beta.kubernetes.io/aws-load-balancer-attributes" = "load_balancing.cross_zone.enabled=true"
+                "service.beta.kubernetes.io/aws-load-balancer-type"            = "external"
+                "service.beta.kubernetes.io/aws-load-balancer-nlb-target-type" = "ip"
+                "service.beta.kubernetes.io/aws-load-balancer-scheme"          = "internet-facing"
+                "service.beta.kubernetes.io/aws-load-balancer-attributes"      = "load_balancing.cross_zone.enabled=true"
               }
             }
           }


### PR DESCRIPTION
# Description

Additional annotation was required below for the Service of `Type=LoadBalancer` to be picked by AWS Loadbalancer Controller regardless of whether the AWS Load Balancer Controller was created later than the Service itself.

`"service.beta.kubernetes.io/aws-load-balancer-nlb-target-type" = "ip"`

### Motivation and Context

<!-- What inspired you to submit this pull request? -->
- Resolves #1793

### How was this change tested?

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [x] Yes, I ran `pre-commit run -a` with this PR