### PR TITLE
bugfix: Corrections to the Helm chart versions

### DIFF
--- a/patterns/istio/main.tf
+++ b/patterns/istio/main.tf
@@ -127,19 +127,19 @@ module "eks_blueprints_addons" {
 
   helm_releases = {
     istio-base = {
-      chart      = "base"
-      version    = local.istio_chart_version
-      repository = local.istio_chart_url
-      name       = "istio-base"
-      namespace  = kubernetes_namespace_v1.istio_system.metadata[0].name
+      chart         = "base"
+      chart_version = local.istio_chart_version
+      repository    = local.istio_chart_url
+      name          = "istio-base"
+      namespace     = kubernetes_namespace_v1.istio_system.metadata[0].name
     }
 
     istiod = {
-      chart      = "istiod"
-      version    = local.istio_chart_version
-      repository = local.istio_chart_url
-      name       = "istiod"
-      namespace  = kubernetes_namespace_v1.istio_system.metadata[0].name
+      chart         = "istiod"
+      chart_version = local.istio_chart_version
+      repository    = local.istio_chart_url
+      name          = "istiod"
+      namespace     = kubernetes_namespace_v1.istio_system.metadata[0].name
 
       set = [
         {
@@ -151,7 +151,7 @@ module "eks_blueprints_addons" {
 
     istio-ingress = {
       chart            = "gateway"
-      version          = local.istio_chart_version
+      chart_version    = local.istio_chart_version
       repository       = local.istio_chart_url
       name             = "istio-ingress"
       namespace        = "istio-ingress" # per https://github.com/istio/istio/blob/master/manifests/charts/gateways/istio-ingress/values.yaml#L2


### PR DESCRIPTION
# Description

The `main.tf` was referring to Helm `version` attribute instead of the `chart_version`.

### How was this change tested?

- [ ] Yes, I have tested the PR using my local account setup (Provide any test eviden
- [ ] Yes, I ran `pre-commit run -a` with this PR

