### PR TITLE
fix: Remove unused hashicorp/template provider

### DIFF
--- a/patterns/blue-green-upgrade/modules/eks_cluster/outputs.tf
+++ b/patterns/blue-green-upgrade/modules/eks_cluster/outputs.tf
@@ -49,10 +49,3 @@ output "gitops_metadata" {
   value       = local.addons_metadata
   sensitive   = true
 }
-
-# output "debug" {
-#   description = "debug output"
-#   #value = data.template_file.addons_template.rendered
-#   value = data.template_file.workloads_template.rendered
-#   #value = file("${path.module}/../../bootstrap/addons.yaml")
-# }

--- a/patterns/blue-green-upgrade/modules/eks_cluster/versions.tf
+++ b/patterns/blue-green-upgrade/modules/eks_cluster/versions.tf
@@ -11,9 +11,5 @@ terraform {
       source  = "hashicorp/kubernetes"
       version = "2.22.0"
     }
-    template = {
-      source  = "hashicorp/template"
-      version = ">= 2.2.0"
-    }
   }
 }


### PR DESCRIPTION
# Description

### Fixes
- removed deprecated, unused hashicorp/template provider
- removed the comments in output

### Contexts
- the hashicorp/template provider is deprecated
  and not supported in m1 macos
  - ref. https://discuss.hashicorp.com/t/template-v2-2-0-does-not-have-a-package-available-mac-m1/35099
- also the provider is not used in the module
  - it seems was added at #1769(2e09cf8) for debugging
  - the output for debugging is commented out; not used


### Motivation and Context

- Resolves #1841

### How was this change tested?

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] ~Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature~ not required, should work on m1 macos, just it as.
- [x] Yes, I ran `pre-commit run -a` with this PR
![image](https://github.com/aws-ia/terraform-aws-eks-blueprints/assets/20619567/a512f5aa-496d-42d7-ba82-e71177d14be6)
- tested, it works
### Additional Notes

Signed-off-by: flavono123 <flavono123@gmail.com>
