### PR TITLE
fix: Add uninstall before destroy (#1843)

### DIFF
--- a/patterns/istio/README.md
+++ b/patterns/istio/README.md
@@ -295,6 +295,22 @@ kubectl port-forward svc/jaeger 16686:16686 -n istio-system
 
 ## Destroy
 
+The Security Groups created for the ingress gateway load balancer
+are not cleaned up after running `terraform destroy -target="module.eks_blueprints_addons" -auto-approve`.
+This causes the final `terraform destroy` to fail with dependency errors:
+
+```text
+│ Error: deleting EC2 VPC (vpc-03132bca40644d33d): operation error EC2: DeleteVpc, https response error StatusCode: 400, RequestID: 82d7e10d-9651-44cf-9a12-5c719f078726, api error DependencyViolation: The vpc 'vpc-03132bca40644d33d' has dependencies and cannot be deleted.
+```
+
+To ensure a proper clean up manually uninstall the `istio-ingress` helm chart.
+
+```sh
+helm uninstall istio-ingress -n istio-ingress
+```
+
+Once the chart is uninstalled move on to destroy the stack.
+
 {%
    include-markdown "../../docs/_partials/destroy.md"
 %}


### PR DESCRIPTION
# Description

Added step to manually uninstall `istio-ingress` helm release before destroy steps. Fixes #1843

### Motivation and Context

<!-- What inspired you to submit this pull request? -->
- Resolves #1843

### How was this change tested?

- [X] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [X] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [X] Yes, I ran `pre-commit run -a` with this PR

### Additional Notes

<!-- Anything else we should know when reviewing? -->
