### PR TITLE
feat: Updating the EKS and Istio version

### DIFF
--- a/patterns/istio/main.tf
+++ b/patterns/istio/main.tf
@@ -38,7 +38,7 @@ locals {
   azs      = slice(data.aws_availability_zones.available.names, 0, 3)
 
   istio_chart_url     = "https://istio-release.storage.googleapis.com/charts"
-  istio_chart_version = "1.18.1"
+  istio_chart_version = "1.20.2"
 
   tags = {
     Blueprint  = local.name
@@ -55,7 +55,7 @@ module "eks" {
   version = "~> 19.16"
 
   cluster_name                   = local.name
-  cluster_version                = "1.27"
+  cluster_version                = "1.28"
   cluster_endpoint_public_access = true
 
   cluster_addons = {


### PR DESCRIPTION
# Description
Updating the EKS version to 1.28 and Istio chart version to 1.20.2

### Motivation and Context

End of life for 1.81 version from Jan 4, 2024. Check here

<br class="Apple-interchange-newline">
### How was this change tested?

- [ X] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [X ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [X ] Yes, I ran `pre-commit run -a` with this PR

### Additional Notes

<!-- Anything else we should know when reviewing? -->
