### PR TITLE
feat: Updating readme for installation of latest Istio Addon for Kiali

### DIFF
--- a/patterns/istio/README.md
+++ b/patterns/istio/README.md
@@ -35,7 +35,7 @@ cluster with deployed Istio.
 ```sh
 for ADDON in kiali jaeger prometheus grafana
 do
-    ADDON_URL="https://raw.githubusercontent.com/istio/istio/release-1.18/samples/addons/$ADDON.yaml"
+    ADDON_URL="https://raw.githubusercontent.com/istio/istio/release-1.20/samples/addons/$ADDON.yaml"
     kubectl apply -f $ADDON_URL
 done
 ```

--- a/patterns/istio/main.tf
+++ b/patterns/istio/main.tf
@@ -38,7 +38,7 @@ locals {
   azs      = slice(data.aws_availability_zones.available.names, 0, 3)
 
   istio_chart_url     = "https://istio-release.storage.googleapis.com/charts"
-  istio_chart_version = "1.18.1"
+  istio_chart_version = "1.20.2"
 
   tags = {
     Blueprint  = local.name
@@ -55,7 +55,7 @@ module "eks" {
   version = "~> 19.16"
 
   cluster_name                   = local.name
-  cluster_version                = "1.27"
+  cluster_version                = "1.28"
   cluster_endpoint_public_access = true
 
   cluster_addons = {


### PR DESCRIPTION
# Description

Updating readme for installation of Kiali which is Istio Addon for observability for Istio version 1.20

### Motivation and Context
End of life for 1.81 version from Jan 4, 2024. 

### How was this change tested?

- [X ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ X] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ X] Yes, I ran `pre-commit run -a` with this PR

### Additional Notes

<!-- Anything else we should know when reviewing? -->
