### PR TITLE
chore: Update EKS module version to `v20.0`

### DIFF
--- a/.github/workflows/e2e-parallel-destroy.yml
+++ b/.github/workflows/e2e-parallel-destroy.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
         with:
-          terraform_version: 1.0.0
+          terraform_version: 1.3.10
 
       - name: Terraform Destroy
         working-directory: ${{ matrix.example_path }}

--- a/.github/workflows/e2e-parallel-full.yml
+++ b/.github/workflows/e2e-parallel-full.yml
@@ -101,7 +101,8 @@ jobs:
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
         with:
-          terraform_version: 1.0.0
+          terraform_version: 1.3.10
+
 
       - name: Terraform Apply
         id: apply

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
       - id: detect-aws-credentials
         args: ['--allow-missing-credentials']
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.83.5
+    rev: v1.86.0
     hooks:
       - id: terraform_fmt
       - id: terraform_docs
@@ -29,6 +29,7 @@ repos:
           - '--args=--only=terraform_naming_convention'
           - '--args=--only=terraform_required_version'
           - '--args=--only=terraform_required_providers'
+          - '--args=--only=terraform_unused_required_providers'
           - '--args=--only=terraform_workspace_remote'
       - id: terraform_validate
         exclude: (docs|modules)

--- a/patterns/agones-game-controller/main.tf
+++ b/patterns/agones-game-controller/main.tf
@@ -2,18 +2,6 @@ provider "aws" {
   region = local.region
 }
 
-provider "kubernetes" {
-  host                   = module.eks.cluster_endpoint
-  cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
-
-  exec {
-    api_version = "client.authentication.k8s.io/v1beta1"
-    command     = "aws"
-    # This requires the awscli to be installed locally where Terraform is executed
-    args = ["eks", "get-token", "--cluster-name", module.eks.cluster_name]
-  }
-}
-
 provider "helm" {
   kubernetes {
     host                   = module.eks.cluster_endpoint
@@ -34,7 +22,7 @@ locals {
   name   = basename(path.cwd)
   region = "us-west-2"
 
-  cluster_version = "1.27"
+  cluster_version = "1.29"
 
   vpc_cidr = "10.0.0.0/16"
   azs      = slice(data.aws_availability_zones.available.names, 0, 3)
@@ -54,7 +42,7 @@ locals {
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 19.16"
+  version = "~> 20.0"
 
   cluster_name                   = local.name
   cluster_version                = local.cluster_version

--- a/patterns/agones-game-controller/versions.tf
+++ b/patterns/agones-game-controller/versions.tf
@@ -1,18 +1,14 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.3"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.47"
+      version = ">= 5.34"
     }
     helm = {
       source  = "hashicorp/helm"
       version = ">= 2.9"
-    }
-    kubernetes = {
-      source  = "hashicorp/kubernetes"
-      version = ">= 2.20"
     }
   }
 

--- a/patterns/appmesh-mtls/main.tf
+++ b/patterns/appmesh-mtls/main.tf
@@ -2,18 +2,6 @@ provider "aws" {
   region = local.region
 }
 
-provider "kubernetes" {
-  host                   = module.eks.cluster_endpoint
-  cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
-
-  exec {
-    api_version = "client.authentication.k8s.io/v1beta1"
-    command     = "aws"
-    # This requires the awscli to be installed locally where Terraform is executed
-    args = ["eks", "get-token", "--cluster-name", module.eks.cluster_name]
-  }
-}
-
 provider "helm" {
   kubernetes {
     host                   = module.eks.cluster_endpoint
@@ -66,10 +54,10 @@ locals {
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 19.16"
+  version = "~> 20.0"
 
   cluster_name                   = local.name
-  cluster_version                = "1.27"
+  cluster_version                = "1.29"
   cluster_endpoint_public_access = true
 
   vpc_id     = module.vpc.vpc_id

--- a/patterns/appmesh-mtls/versions.tf
+++ b/patterns/appmesh-mtls/versions.tf
@@ -1,18 +1,14 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.3"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.47"
+      version = ">= 5.34"
     }
     helm = {
       source  = "hashicorp/helm"
       version = ">= 2.9"
-    }
-    kubernetes = {
-      source  = "hashicorp/kubernetes"
-      version = ">= 2.20"
     }
     kubectl = {
       source  = "gavinbunney/kubectl"

--- a/patterns/aws-vpc-cni-network-policy/main.tf
+++ b/patterns/aws-vpc-cni-network-policy/main.tf
@@ -49,10 +49,10 @@ locals {
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 19.16"
+  version = "~> 20.0"
 
   cluster_name                   = local.name
-  cluster_version                = "1.27" # Must be 1.25 or higher
+  cluster_version                = "1.29" # Must be 1.25 or higher
   cluster_endpoint_public_access = true
 
   vpc_id     = module.vpc.vpc_id
@@ -118,7 +118,6 @@ module "addons" {
     coredns    = {}
     kube-proxy = {}
     vpc-cni = {
-      preserve    = true
       most_recent = true # Must be 1.14.0 or higher
 
       timeouts = {

--- a/patterns/aws-vpc-cni-network-policy/versions.tf
+++ b/patterns/aws-vpc-cni-network-policy/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.3"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.47"
+      version = ">= 5.34"
     }
     helm = {
       source  = "hashicorp/helm"

--- a/patterns/blue-green-upgrade/eks-blue/providers.tf
+++ b/patterns/blue-green-upgrade/eks-blue/providers.tf
@@ -14,9 +14,5 @@ terraform {
       source  = "hashicorp/helm"
       version = ">= 2.9.0"
     }
-    kubectl = {
-      source  = "gavinbunney/kubectl"
-      version = ">= 1.14"
-    }
   }
 }

--- a/patterns/blue-green-upgrade/eks-green/providers.tf
+++ b/patterns/blue-green-upgrade/eks-green/providers.tf
@@ -14,9 +14,5 @@ terraform {
       source  = "hashicorp/helm"
       version = ">= 2.9.0"
     }
-    kubectl = {
-      source  = "gavinbunney/kubectl"
-      version = ">= 1.14"
-    }
   }
 }

--- a/patterns/elastic-fabric-adapter/versions.tf
+++ b/patterns/elastic-fabric-adapter/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.3"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.47"
+      version = ">= 5.34"
     }
     helm = {
       source  = "hashicorp/helm"

--- a/patterns/external-secrets/main.tf
+++ b/patterns/external-secrets/main.tf
@@ -2,18 +2,6 @@ provider "aws" {
   region = local.region
 }
 
-provider "kubernetes" {
-  host                   = module.eks.cluster_endpoint
-  cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
-
-  exec {
-    api_version = "client.authentication.k8s.io/v1beta1"
-    command     = "aws"
-    # This requires the awscli to be installed locally where Terraform is executed
-    args = ["eks", "get-token", "--cluster-name", module.eks.cluster_name]
-  }
-}
-
 provider "helm" {
   kubernetes {
     host                   = module.eks.cluster_endpoint
@@ -70,10 +58,10 @@ locals {
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 19.16"
+  version = "~> 20.0"
 
   cluster_name                   = local.name
-  cluster_version                = "1.27"
+  cluster_version                = "1.29"
   cluster_endpoint_public_access = true
 
   vpc_id     = module.vpc.vpc_id
@@ -98,7 +86,7 @@ module "eks" {
 
 module "eks_blueprints_addons" {
   source  = "aws-ia/eks-blueprints-addons/aws"
-  version = "~> 1.0"
+  version = "~> 1.14"
 
   cluster_name      = module.eks.cluster_name
   cluster_endpoint  = module.eks.cluster_endpoint

--- a/patterns/external-secrets/versions.tf
+++ b/patterns/external-secrets/versions.tf
@@ -1,18 +1,14 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.3"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.47"
+      version = ">= 5.34"
     }
     helm = {
       source  = "hashicorp/helm"
       version = ">= 2.9"
-    }
-    kubernetes = {
-      source  = "hashicorp/kubernetes"
-      version = ">= 2.20"
     }
     kubectl = {
       source  = "gavinbunney/kubectl"

--- a/patterns/fargate-serverless/main.tf
+++ b/patterns/fargate-serverless/main.tf
@@ -50,10 +50,10 @@ locals {
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 19.16"
+  version = "~> 20.0"
 
   cluster_name                   = local.name
-  cluster_version                = "1.27"
+  cluster_version                = "1.29"
   cluster_endpoint_public_access = true
 
   vpc_id     = module.vpc.vpc_id
@@ -92,7 +92,7 @@ module "eks" {
 
 module "eks_blueprints_addons" {
   source  = "aws-ia/eks-blueprints-addons/aws"
-  version = "~> 1.0"
+  version = "~> 1.14"
 
   cluster_name      = module.eks.cluster_name
   cluster_endpoint  = module.eks.cluster_endpoint

--- a/patterns/fargate-serverless/versions.tf
+++ b/patterns/fargate-serverless/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.3"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.47"
+      version = ">= 5.34"
     }
     helm = {
       source  = "hashicorp/helm"

--- a/patterns/fully-private-cluster/main.tf
+++ b/patterns/fully-private-cluster/main.tf
@@ -23,10 +23,10 @@ locals {
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 19.16"
+  version = "~> 20.0"
 
   cluster_name    = local.name
-  cluster_version = "1.27"
+  cluster_version = "1.29"
 
   # EKS Addons
   cluster_addons = {

--- a/patterns/fully-private-cluster/versions.tf
+++ b/patterns/fully-private-cluster/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.3"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.47"
+      version = ">= 5.34"
     }
   }
 

--- a/patterns/gitops/getting-started-argocd/versions.tf
+++ b/patterns/gitops/getting-started-argocd/versions.tf
@@ -1,18 +1,18 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.3"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.67.0"
+      version = ">= 5.34"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.10.1"
+      version = ">= 2.10"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "2.22.0"
+      version = ">= 2.22"
     }
   }
 

--- a/patterns/gitops/multi-cluster-hub-spoke-argocd/hub/versions.tf
+++ b/patterns/gitops/multi-cluster-hub-spoke-argocd/hub/versions.tf
@@ -1,18 +1,18 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.3"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.67.0"
+      version = ">= 5.34"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.10.1"
+      version = ">= 2.10"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "2.22.0"
+      version = ">= 2.22"
     }
   }
 

--- a/patterns/ipv6-eks-cluster/main.tf
+++ b/patterns/ipv6-eks-cluster/main.tf
@@ -2,32 +2,6 @@ provider "aws" {
   region = local.region
 }
 
-provider "kubernetes" {
-  host                   = module.eks.cluster_endpoint
-  cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
-
-  exec {
-    api_version = "client.authentication.k8s.io/v1beta1"
-    command     = "aws"
-    # This requires the awscli to be installed locally where Terraform is executed
-    args = ["eks", "get-token", "--cluster-name", module.eks.cluster_name]
-  }
-}
-
-provider "helm" {
-  kubernetes {
-    host                   = module.eks.cluster_endpoint
-    cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
-
-    exec {
-      api_version = "client.authentication.k8s.io/v1beta1"
-      command     = "aws"
-      # This requires the awscli to be installed locally where Terraform is executed
-      args = ["eks", "get-token", "--cluster-name", module.eks.cluster_name]
-    }
-  }
-}
-
 data "aws_availability_zones" "available" {}
 
 locals {
@@ -49,10 +23,10 @@ locals {
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 19.16"
+  version = "~> 20.0"
 
   cluster_name                   = local.name
-  cluster_version                = "1.27"
+  cluster_version                = "1.29"
   cluster_endpoint_public_access = true
 
   # IPV6

--- a/patterns/ipv6-eks-cluster/versions.tf
+++ b/patterns/ipv6-eks-cluster/versions.tf
@@ -1,18 +1,10 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.3"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.47"
-    }
-    helm = {
-      source  = "hashicorp/helm"
-      version = ">= 2.9"
-    }
-    kubernetes = {
-      source  = "hashicorp/kubernetes"
-      version = ">= 2.20"
+      version = ">= 5.34"
     }
   }
 

--- a/patterns/istio-multi-cluster/3.istio-multi-primary/versions.tf
+++ b/patterns/istio-multi-cluster/3.istio-multi-primary/versions.tf
@@ -2,14 +2,6 @@ terraform {
   required_version = ">= 1.0"
 
   required_providers {
-    aws = {
-      source  = "hashicorp/aws"
-      version = ">= 4.47"
-    }
-    helm = {
-      source  = "hashicorp/helm"
-      version = ">= 2.9"
-    }
     kubernetes = {
       source  = "hashicorp/kubernetes"
       version = ">= 2.20"

--- a/patterns/istio/main.tf
+++ b/patterns/istio/main.tf
@@ -52,18 +52,16 @@ locals {
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 19.16"
+  version = "~> 20.0"
 
   cluster_name                   = local.name
-  cluster_version                = "1.28"
+  cluster_version                = "1.29"
   cluster_endpoint_public_access = true
 
   cluster_addons = {
     coredns    = {}
     kube-proxy = {}
-    vpc-cni = {
-      preserve = true
-    }
+    vpc-cni    = {}
   }
 
   vpc_id     = module.vpc.vpc_id
@@ -115,7 +113,7 @@ resource "kubernetes_namespace_v1" "istio_system" {
 
 module "eks_blueprints_addons" {
   source  = "aws-ia/eks-blueprints-addons/aws"
-  version = "~> 1.0"
+  version = "~> 1.14"
 
   cluster_name      = module.eks.cluster_name
   cluster_endpoint  = module.eks.cluster_endpoint

--- a/patterns/istio/versions.tf
+++ b/patterns/istio/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.3"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.47"
+      version = ">= 5.34"
     }
     helm = {
       source  = "hashicorp/helm"

--- a/patterns/karpenter/main.tf
+++ b/patterns/karpenter/main.tf
@@ -59,10 +59,10 @@ locals {
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 19.18"
+  version = "~> 19.21"
 
   cluster_name                   = local.name
-  cluster_version                = "1.28"
+  cluster_version                = "1.29"
   cluster_endpoint_public_access = true
 
   vpc_id     = module.vpc.vpc_id
@@ -113,7 +113,7 @@ module "eks" {
 
 module "eks_blueprints_addons" {
   source  = "aws-ia/eks-blueprints-addons/aws"
-  version = "~> 1.11"
+  version = "~> 1.14"
 
   cluster_name      = module.eks.cluster_name
   cluster_endpoint  = module.eks.cluster_endpoint

--- a/patterns/karpenter/versions.tf
+++ b/patterns/karpenter/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.3"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.47"
+      version = ">= 5.34"
     }
     helm = {
       source  = "hashicorp/helm"

--- a/patterns/kubecost/outputs.tf
+++ b/patterns/kubecost/outputs.tf
@@ -15,5 +15,5 @@ output "s3_cur_report_prefix" {
 
 output "region" {
   description = "region"
-  value       = var.region
+  value       = local.region
 }

--- a/patterns/kubecost/variables.tf
+++ b/patterns/kubecost/variables.tf
@@ -1,27 +1,3 @@
-variable "region" {
-  description = "AWS region"
-  type        = string
-  default     = "us-east-1"
-}
-
-variable "name" {
-  description = "EKS Cluster Name and the VPC name"
-  type        = string
-  default     = ""
-}
-
-variable "cluster_version" {
-  type        = string
-  description = "Kubernetes Version"
-  default     = "1.28"
-}
-
-variable "capacity_type" {
-  type        = string
-  description = "Capacity SPOT or ON_DEMAND"
-  default     = "SPOT"
-}
-
 variable "kubecost_token" {
   type        = string
   description = "To find or obtain Kubecost token, go to https://www.kubecost.com/install#show-instructions"

--- a/patterns/kubecost/versions.tf
+++ b/patterns/kubecost/versions.tf
@@ -1,18 +1,21 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.3"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.47"
+      version = ">= 5.34"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.9"
-    }
-    kubernetes = {
-      source  = "hashicorp/kubernetes"
-      version = ">= 2.20"
+      version = ">= 2.10"
     }
   }
+
+  # ##  Used for end-to-end testing on project; update to suit your needs
+  # backend "s3" {
+  #   bucket = "terraform-ssp-github-actions-state"
+  #   region = "us-west-2"
+  #   key    = "e2e/kubecost/terraform.tfstate"
+  # }
 }

--- a/patterns/multi-tenancy-with-teams/main.tf
+++ b/patterns/multi-tenancy-with-teams/main.tf
@@ -50,10 +50,10 @@ locals {
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 19.16"
+  version = "~> 19.21"
 
   cluster_name                   = local.name
-  cluster_version                = "1.27"
+  cluster_version                = "1.29"
   cluster_endpoint_public_access = true
 
   vpc_id     = module.vpc.vpc_id

--- a/patterns/multi-tenancy-with-teams/versions.tf
+++ b/patterns/multi-tenancy-with-teams/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.3"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.47"
+      version = ">= 5.34"
     }
     helm = {
       source  = "hashicorp/helm"

--- a/patterns/private-public-ingress/main.tf
+++ b/patterns/private-public-ingress/main.tf
@@ -2,18 +2,6 @@ provider "aws" {
   region = local.region
 }
 
-provider "kubernetes" {
-  host                   = module.eks.cluster_endpoint
-  cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
-
-  exec {
-    api_version = "client.authentication.k8s.io/v1beta1"
-    command     = "aws"
-    # This requires the awscli to be installed locally where Terraform is executed
-    args = ["eks", "get-token", "--cluster-name", module.eks.cluster_name]
-  }
-}
-
 provider "helm" {
   kubernetes {
     host                   = module.eks.cluster_endpoint
@@ -25,20 +13,6 @@ provider "helm" {
       # This requires the awscli to be installed locally where Terraform is executed
       args = ["eks", "get-token", "--cluster-name", module.eks.cluster_name]
     }
-  }
-}
-
-provider "kubectl" {
-  apply_retry_count      = 5
-  host                   = module.eks.cluster_endpoint
-  cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
-  load_config_file       = false
-
-  exec {
-    api_version = "client.authentication.k8s.io/v1beta1"
-    command     = "aws"
-    # This requires the awscli to be installed locally where Terraform is executed
-    args = ["eks", "get-token", "--cluster-name", module.eks.cluster_name]
   }
 }
 
@@ -63,10 +37,10 @@ locals {
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 19.16"
+  version = "~> 20.0"
 
   cluster_name                   = local.name
-  cluster_version                = "1.27"
+  cluster_version                = "1.29"
   cluster_endpoint_public_access = true
 
   vpc_id     = module.vpc.vpc_id
@@ -124,7 +98,7 @@ resource "aws_security_group" "ingress_nginx_external" {
 # ingress-nginx controller, exposed by an internet facing Network Load Balancer
 module "ingres_nginx_external" {
   source  = "aws-ia/eks-blueprints-addons/aws"
-  version = "~> 1.0"
+  version = "~> 1.14"
 
   cluster_name      = module.eks.cluster_name
   cluster_endpoint  = module.eks.cluster_endpoint
@@ -199,7 +173,7 @@ resource "aws_security_group" "ingress_nginx_internal" {
 # ingress-nginx controller, exposed by an internal Network Load Balancer
 module "ingres_nginx_internal" {
   source  = "aws-ia/eks-blueprints-addons/aws"
-  version = "~> 1.6.0"
+  version = "~> 1.14"
 
   cluster_name      = module.eks.cluster_name
   cluster_endpoint  = module.eks.cluster_endpoint
@@ -245,7 +219,7 @@ module "ingres_nginx_internal" {
 
 module "eks_blueprints_addons" {
   source  = "aws-ia/eks-blueprints-addons/aws"
-  version = "~> 1.0"
+  version = "~> 1.14"
 
   cluster_name      = module.eks.cluster_name
   cluster_endpoint  = module.eks.cluster_endpoint

--- a/patterns/private-public-ingress/versions.tf
+++ b/patterns/private-public-ingress/versions.tf
@@ -1,22 +1,14 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.3"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.47"
+      version = ">= 5.34"
     }
     helm = {
       source  = "hashicorp/helm"
       version = ">= 2.9"
-    }
-    kubernetes = {
-      source  = "hashicorp/kubernetes"
-      version = ">= 2.20"
-    }
-    kubectl = {
-      source  = "gavinbunney/kubectl"
-      version = ">= 1.14"
     }
   }
 }

--- a/patterns/privatelink-access/eks.tf
+++ b/patterns/privatelink-access/eks.tf
@@ -16,10 +16,10 @@ provider "kubernetes" {
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 19.16"
+  version = "~> 19.21"
 
   cluster_name    = local.name
-  cluster_version = "1.27"
+  cluster_version = "1.29"
 
   cluster_endpoint_public_access = true
   manage_aws_auth_configmap      = true

--- a/patterns/privatelink-access/versions.tf
+++ b/patterns/privatelink-access/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.3"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = ">= 5.34"
     }
     dns = {
       source  = "hashicorp/dns"

--- a/patterns/sso-iam-identity-center/main.tf
+++ b/patterns/sso-iam-identity-center/main.tf
@@ -24,10 +24,10 @@ locals {
 #tfsec:ignore:aws-eks-enable-control-plane-logging
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 19.13"
+  version = "~> 19.21"
 
   cluster_name                   = local.name
-  cluster_version                = "1.27"
+  cluster_version                = "1.29"
   cluster_endpoint_public_access = true
 
   # EKS Addons

--- a/patterns/sso-iam-identity-center/versions.tf
+++ b/patterns/sso-iam-identity-center/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.3"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.47"
+      version = ">= 5.34"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/patterns/sso-okta/main.tf
+++ b/patterns/sso-okta/main.tf
@@ -24,10 +24,10 @@ locals {
 #tfsec:ignore:aws-eks-enable-control-plane-logging
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 19.13"
+  version = "~> 20.0"
 
   cluster_name                   = local.name
-  cluster_version                = "1.27"
+  cluster_version                = "1.29"
   cluster_endpoint_public_access = true
 
   # EKS Addons

--- a/patterns/sso-okta/versions.tf
+++ b/patterns/sso-okta/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.3"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.47"
+      version = ">= 5.34"
     }
     okta = {
       source  = "okta/okta"

--- a/patterns/stateful/main.tf
+++ b/patterns/stateful/main.tf
@@ -55,10 +55,10 @@ locals {
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 19.16"
+  version = "~> 20.0"
 
   cluster_name                   = local.name
-  cluster_version                = "1.27"
+  cluster_version                = "1.29"
   cluster_endpoint_public_access = true
 
   vpc_id     = module.vpc.vpc_id
@@ -194,7 +194,7 @@ module "eks" {
 
 module "eks_blueprints_addons" {
   source  = "aws-ia/eks-blueprints-addons/aws"
-  version = "~> 1.0"
+  version = "~> 1.14"
 
   cluster_name      = module.eks.cluster_name
   cluster_endpoint  = module.eks.cluster_endpoint

--- a/patterns/stateful/outputs.tf
+++ b/patterns/stateful/outputs.tf
@@ -2,6 +2,7 @@ output "configure_kubectl" {
   description = "Configure kubectl: make sure you're logged in with the correct AWS profile and run the following command to update your kubeconfig"
   value       = "aws eks --region ${local.region} update-kubeconfig --name ${module.eks.cluster_name}"
 }
+
 output "velero_s3_backup_location" {
   description = "S3 backup location"
   value       = local.velero_s3_backup_location

--- a/patterns/stateful/versions.tf
+++ b/patterns/stateful/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.3"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.47"
+      version = ">= 5.34"
     }
     helm = {
       source  = "hashicorp/helm"
@@ -13,10 +13,6 @@ terraform {
     kubernetes = {
       source  = "hashicorp/kubernetes"
       version = ">= 2.20"
-    }
-    random = {
-      source  = "hashicorp/random"
-      version = ">= 3.0"
     }
   }
 

--- a/patterns/tls-with-aws-pca-issuer/main.tf
+++ b/patterns/tls-with-aws-pca-issuer/main.tf
@@ -2,18 +2,6 @@ provider "aws" {
   region = local.region
 }
 
-provider "kubernetes" {
-  host                   = module.eks.cluster_endpoint
-  cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
-
-  exec {
-    api_version = "client.authentication.k8s.io/v1beta1"
-    command     = "aws"
-    # This requires the awscli to be installed locally where Terraform is executed
-    args = ["eks", "get-token", "--cluster-name", module.eks.cluster_name]
-  }
-}
-
 provider "helm" {
   kubernetes {
     host                   = module.eks.cluster_endpoint
@@ -64,10 +52,10 @@ locals {
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 19.16"
+  version = "~> 20.0"
 
   cluster_name                   = local.name
-  cluster_version                = "1.27"
+  cluster_version                = "1.29"
   cluster_endpoint_public_access = true
 
   vpc_id     = module.vpc.vpc_id
@@ -92,7 +80,7 @@ module "eks" {
 
 module "eks_blueprints_addons" {
   source  = "aws-ia/eks-blueprints-addons/aws"
-  version = "~> 1.0"
+  version = "~> 1.14"
 
   cluster_name      = module.eks.cluster_name
   cluster_endpoint  = module.eks.cluster_endpoint

--- a/patterns/tls-with-aws-pca-issuer/versions.tf
+++ b/patterns/tls-with-aws-pca-issuer/versions.tf
@@ -1,18 +1,14 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.3"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.47"
+      version = ">= 5.34"
     }
     helm = {
       source  = "hashicorp/helm"
       version = ">= 2.9"
-    }
-    kubernetes = {
-      source  = "hashicorp/kubernetes"
-      version = ">= 2.20"
     }
     kubectl = {
       source  = "gavinbunney/kubectl"

--- a/patterns/vpc-lattice/client-server-communication/client.tf
+++ b/patterns/vpc-lattice/client-server-communication/client.tf
@@ -4,7 +4,7 @@
 
 module "client" {
   source  = "terraform-aws-modules/ec2-instance/aws"
-  version = "5.5.0"
+  version = "~> 5.0"
 
   name = "client"
 
@@ -90,7 +90,7 @@ module "endpoint_sg" {
 
 module "client_vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "~> 5.4"
+  version = "~> 5.0"
 
   name = local.name
   cidr = local.client_vpc_cidr

--- a/patterns/vpc-lattice/client-server-communication/eks.tf
+++ b/patterns/vpc-lattice/client-server-communication/eks.tf
@@ -4,12 +4,11 @@
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 19.21"
+  version = "~> 20.0"
 
   cluster_name                   = local.name
-  cluster_version                = "1.28"
+  cluster_version                = "1.29"
   cluster_endpoint_public_access = true
-  enable_irsa                    = true
 
   vpc_id     = module.cluster_vpc.vpc_id
   subnet_ids = module.cluster_vpc.private_subnets
@@ -33,7 +32,7 @@ module "eks" {
 
 module "cluster_vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "~> 5.4"
+  version = "~> 5.0"
 
   name = local.name
   cidr = local.cluster_vpc_cidr

--- a/patterns/vpc-lattice/client-server-communication/main.tf
+++ b/patterns/vpc-lattice/client-server-communication/main.tf
@@ -10,19 +10,6 @@ data "aws_availability_zones" "available" {
   }
 }
 
-
-provider "kubernetes" {
-  host                   = module.eks.cluster_endpoint
-  cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
-
-  exec {
-    api_version = "client.authentication.k8s.io/v1beta1"
-    command     = "aws"
-    # This requires the awscli to be installed locally where Terraform is executed
-    args = ["eks", "get-token", "--cluster-name", module.eks.cluster_name]
-  }
-}
-
 provider "helm" {
   kubernetes {
     host                   = module.eks.cluster_endpoint

--- a/patterns/vpc-lattice/client-server-communication/versions.tf
+++ b/patterns/vpc-lattice/client-server-communication/versions.tf
@@ -1,18 +1,14 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.3"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.30"
+      version = ">= 5.34"
     }
     helm = {
       source  = "hashicorp/helm"
       version = ">= 2.9"
-    }
-    kubernetes = {
-      source  = "hashicorp/kubernetes"
-      version = ">= 2.24"
     }
     time = {
       source  = "hashicorp/time"

--- a/patterns/wireguard-with-cilium/eks.tf
+++ b/patterns/wireguard-with-cilium/eks.tf
@@ -4,10 +4,10 @@
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 19.16"
+  version = "~> 20.0"
 
   cluster_name                   = local.name
-  cluster_version                = "1.28"
+  cluster_version                = "1.29"
   cluster_endpoint_public_access = true
 
   # EKS Addons
@@ -60,7 +60,7 @@ output "configure_kubectl" {
 
 module "eks_blueprints_addons" {
   source  = "aws-ia/eks-blueprints-addons/aws"
-  version = "~> 1.7"
+  version = "~> 1.14"
 
   cluster_name      = module.eks.cluster_name
   cluster_endpoint  = module.eks.cluster_endpoint

--- a/patterns/wireguard-with-cilium/main.tf
+++ b/patterns/wireguard-with-cilium/main.tf
@@ -1,18 +1,14 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.3"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.47"
+      version = ">= 5.34"
     }
     helm = {
       source  = "hashicorp/helm"
       version = ">= 2.9"
-    }
-    kubernetes = {
-      source  = "hashicorp/kubernetes"
-      version = ">= 2.20"
     }
   }
 
@@ -26,18 +22,6 @@ terraform {
 
 provider "aws" {
   region = local.region
-}
-
-provider "kubernetes" {
-  host                   = module.eks.cluster_endpoint
-  cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
-
-  exec {
-    api_version = "client.authentication.k8s.io/v1beta1"
-    command     = "aws"
-    # This requires the awscli to be installed locally where Terraform is executed
-    args = ["eks", "get-token", "--cluster-name", module.eks.cluster_name]
-  }
 }
 
 provider "helm" {


### PR DESCRIPTION
# Description

- Update EKS module version to `v20.0`
	- There are a few patterns that are still on v19 and will require additional changes - saving those for separate PR(s)

### Motivation and Context

- Updating to latest module

### How was this change tested?

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [x] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR

### Additional Notes

<!-- Anything else we should know when reviewing? -->
