### PR TITLE
fix: Map the Terraform entity into the cluster as admin to allow deploying Kubernetes, Helm, and Kubectl resources via providers

### DIFF
--- a/docs/_partials/destroy.md
+++ b/docs/_partials/destroy.md
@@ -1,4 +1,8 @@
 ```sh
+# Necessary to avoid removing Terraform's permissions too soon before its finished
+# cleaning up the resources it deployed inside the cluster
+terraform state rm 'module.eks.aws_eks_access_entry.this["cluster_creator_admin"]' || true
+
 terraform destroy -target="module.eks_blueprints_addons" -auto-approve
 terraform destroy -target="module.eks" -auto-approve
 terraform destroy -auto-approve

--- a/patterns/agones-game-controller/main.tf
+++ b/patterns/agones-game-controller/main.tf
@@ -48,6 +48,10 @@ module "eks" {
   cluster_version                = local.cluster_version
   cluster_endpoint_public_access = true
 
+  # Give the Terraform identity admin access to the cluster
+  # which will allow resources to be deployed into the cluster
+  enable_cluster_creator_admin_permissions = true
+
   vpc_id                   = module.vpc.vpc_id
   control_plane_subnet_ids = module.vpc.private_subnets
   subnet_ids               = module.vpc.public_subnets

--- a/patterns/appmesh-mtls/main.tf
+++ b/patterns/appmesh-mtls/main.tf
@@ -60,6 +60,10 @@ module "eks" {
   cluster_version                = "1.29"
   cluster_endpoint_public_access = true
 
+  # Give the Terraform identity admin access to the cluster
+  # which will allow resources to be deployed into the cluster
+  enable_cluster_creator_admin_permissions = true
+
   vpc_id     = module.vpc.vpc_id
   subnet_ids = module.vpc.private_subnets
 

--- a/patterns/aws-vpc-cni-network-policy/main.tf
+++ b/patterns/aws-vpc-cni-network-policy/main.tf
@@ -55,6 +55,10 @@ module "eks" {
   cluster_version                = "1.29" # Must be 1.25 or higher
   cluster_endpoint_public_access = true
 
+  # Give the Terraform identity admin access to the cluster
+  # which will allow resources to be deployed into the cluster
+  enable_cluster_creator_admin_permissions = true
+
   vpc_id     = module.vpc.vpc_id
   subnet_ids = module.vpc.private_subnets
 

--- a/patterns/elastic-fabric-adapter/main.tf
+++ b/patterns/elastic-fabric-adapter/main.tf
@@ -57,6 +57,10 @@ module "eks" {
   cluster_version                = local.cluster_version
   cluster_endpoint_public_access = true
 
+  # Give the Terraform identity admin access to the cluster
+  # which will allow resources to be deployed into the cluster
+  enable_cluster_creator_admin_permissions = true
+
   cluster_addons = {
     coredns    = {}
     kube-proxy = {}
@@ -252,7 +256,7 @@ resource "kubernetes_daemonset" "aws_efa_k8s_device_plugin" {
 
         container {
           name  = "aws-efa-k8s-device-plugin"
-          image = "602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/aws-efa-k8s-device-plugin:v0.4.3"
+          image = "602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/aws-efa-k8s-device-plugin:v0.4.4"
 
           volume_mount {
             name       = "device-plugin"

--- a/patterns/external-secrets/main.tf
+++ b/patterns/external-secrets/main.tf
@@ -64,6 +64,10 @@ module "eks" {
   cluster_version                = "1.29"
   cluster_endpoint_public_access = true
 
+  # Give the Terraform identity admin access to the cluster
+  # which will allow resources to be deployed into the cluster
+  enable_cluster_creator_admin_permissions = true
+
   vpc_id     = module.vpc.vpc_id
   subnet_ids = module.vpc.private_subnets
 

--- a/patterns/fargate-serverless/main.tf
+++ b/patterns/fargate-serverless/main.tf
@@ -56,6 +56,10 @@ module "eks" {
   cluster_version                = "1.29"
   cluster_endpoint_public_access = true
 
+  # Give the Terraform identity admin access to the cluster
+  # which will allow resources to be deployed into the cluster
+  enable_cluster_creator_admin_permissions = true
+
   vpc_id     = module.vpc.vpc_id
   subnet_ids = module.vpc.private_subnets
 

--- a/patterns/istio/main.tf
+++ b/patterns/istio/main.tf
@@ -58,6 +58,10 @@ module "eks" {
   cluster_version                = "1.29"
   cluster_endpoint_public_access = true
 
+  # Give the Terraform identity admin access to the cluster
+  # which will allow resources to be deployed into the cluster
+  enable_cluster_creator_admin_permissions = true
+
   cluster_addons = {
     coredns    = {}
     kube-proxy = {}

--- a/patterns/kubecost/main.tf
+++ b/patterns/kubecost/main.tf
@@ -66,6 +66,10 @@ module "eks" {
   cluster_version                = "1.29"
   cluster_endpoint_public_access = true
 
+  # Give the Terraform identity admin access to the cluster
+  # which will allow resources to be deployed into the cluster
+  enable_cluster_creator_admin_permissions = true
+
   # EKS Addons
   cluster_addons = {
     aws-ebs-csi-driver = {

--- a/patterns/private-public-ingress/main.tf
+++ b/patterns/private-public-ingress/main.tf
@@ -43,6 +43,10 @@ module "eks" {
   cluster_version                = "1.29"
   cluster_endpoint_public_access = true
 
+  # Give the Terraform identity admin access to the cluster
+  # which will allow resources to be deployed into the cluster
+  enable_cluster_creator_admin_permissions = true
+
   vpc_id     = module.vpc.vpc_id
   subnet_ids = module.vpc.private_subnets
 

--- a/patterns/stateful/main.tf
+++ b/patterns/stateful/main.tf
@@ -61,6 +61,10 @@ module "eks" {
   cluster_version                = "1.29"
   cluster_endpoint_public_access = true
 
+  # Give the Terraform identity admin access to the cluster
+  # which will allow resources to be deployed into the cluster
+  enable_cluster_creator_admin_permissions = true
+
   vpc_id     = module.vpc.vpc_id
   subnet_ids = module.vpc.private_subnets
 

--- a/patterns/tls-with-aws-pca-issuer/main.tf
+++ b/patterns/tls-with-aws-pca-issuer/main.tf
@@ -58,6 +58,10 @@ module "eks" {
   cluster_version                = "1.29"
   cluster_endpoint_public_access = true
 
+  # Give the Terraform identity admin access to the cluster
+  # which will allow resources to be deployed into the cluster
+  enable_cluster_creator_admin_permissions = true
+
   vpc_id     = module.vpc.vpc_id
   subnet_ids = module.vpc.private_subnets
 

--- a/patterns/vpc-lattice/client-server-communication/eks.tf
+++ b/patterns/vpc-lattice/client-server-communication/eks.tf
@@ -10,6 +10,10 @@ module "eks" {
   cluster_version                = "1.29"
   cluster_endpoint_public_access = true
 
+  # Give the Terraform identity admin access to the cluster
+  # which will allow resources to be deployed into the cluster
+  enable_cluster_creator_admin_permissions = true
+
   vpc_id     = module.cluster_vpc.vpc_id
   subnet_ids = module.cluster_vpc.private_subnets
 

--- a/patterns/wireguard-with-cilium/eks.tf
+++ b/patterns/wireguard-with-cilium/eks.tf
@@ -10,6 +10,10 @@ module "eks" {
   cluster_version                = "1.29"
   cluster_endpoint_public_access = true
 
+  # Give the Terraform identity admin access to the cluster
+  # which will allow resources to be deployed into the cluster
+  enable_cluster_creator_admin_permissions = true
+
   # EKS Addons
   cluster_addons = {
     coredns    = {}


### PR DESCRIPTION
# Description

- Map the Terraform entity into the cluster as admin to allow deploying Kubernetes, Helm, and Kubectl resources via providers

### Motivation and Context

- The entity that is executing Terraform commands needs to have access inside the cluster to allow the Kubernetes, Kubectl, and Helm providers to provision the resources they create. Prior to cluster access entry, Terraform was automatically granted these permissions because it was the cluster creator.

### How was this change tested?

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR

### Additional Notes

<!-- Anything else we should know when reviewing? -->
