### PR TITLE
feat: Make gitops-bridge example to use kubectl to deploy addons and workloads

### DIFF
--- a/patterns/gitops/getting-started-argocd/main.tf
+++ b/patterns/gitops/getting-started-argocd/main.tf
@@ -121,16 +121,6 @@ locals {
     }
   )
 
-  argocd_app_of_appsets_addons = var.enable_gitops_auto_addons ? {
-    addons = file("${path.module}/bootstrap/addons.yaml")
-  } : {}
-  argocd_app_of_appsets_workloads = var.enable_gitops_auto_workloads ? {
-    workloads = file("${path.module}/bootstrap/workloads.yaml")
-  } : {}
-
-  argocd_apps = merge(local.argocd_app_of_appsets_addons, local.argocd_app_of_appsets_workloads)
-
-
   tags = {
     Blueprint  = local.name
     GithubRepo = "github.com/aws-ia/terraform-aws-eks-blueprints"
@@ -147,7 +137,6 @@ module "gitops_bridge_bootstrap" {
     metadata = local.addons_metadata
     addons   = local.addons
   }
-  apps = local.argocd_apps
 }
 
 ################################################################################

--- a/patterns/gitops/getting-started-argocd/variables.tf
+++ b/patterns/gitops/getting-started-argocd/variables.tf
@@ -74,15 +74,3 @@ variable "gitops_workload_path" {
   type        = string
   default     = "getting-started-argocd/k8s"
 }
-
-variable "enable_gitops_auto_addons" {
-  description = "Automatically deploy addons"
-  type        = bool
-  default     = false
-}
-
-variable "enable_gitops_auto_workloads" {
-  description = "Automatically deploy addons"
-  type        = bool
-  default     = false
-}

--- a/patterns/gitops/multi-cluster-hub-spoke-argocd/README.md
+++ b/patterns/gitops/multi-cluster-hub-spoke-argocd/README.md
@@ -59,7 +59,20 @@ that temporary file with the `kubectl` configuration. This approach offers the
 advantage of not altering your existing `kubectl` context, allowing you to work
 in other terminal windows without interference.
 
-### Monitor GitOps Progress for Addons
+### Deploy ArgoCD Apps of ApplicationSets for Addons
+
+This command verifies the initial ArgoCD installation, ArgoCD will be re-configured when the addons are deployed and configured from git.
+```shell
+kubectl --context hub get all -n argocd
+```
+This command creates the application set manifest to deploy the addons.
+```shell
+kubectl --context hub apply -n argocd -f ../hub/bootstrap/addons.yaml
+```
+The application sets defined here will then deploy addons to any spoke clusters provisioned later using Terraform
+
+
+### Monitor GitOps Progress for Addons on Hub EKS Cluster
 
 Wait until all the ArgoCD applications' `HEALTH STATUS` is `Healthy`.
 Use `Ctrl+C` or `Cmd+C` to exit the `watch` command. ArgoCD Applications
@@ -164,15 +177,22 @@ The output have a section `awsAuthConfig` with the `clusterName` and the `roleAR
 
 ### Verify the Addons on Spoke Clusters
 
-Verify that the addons are ready:
+The addons on the spoke clusters are deployed using the Application Sets created on the EKS Hub Cluster. Verify that the addons are ready:
 
 ```shell
 for i in dev staging prod ; do echo $i && kubectl --context $i get deployment -n kube-system ; done
 ```
 
+### Deploy the sample application to EKS Spoke Clusters
+
+This command will deploy the application using kubectl to all clusters connected to the hub cluster, using the manifest files in [./hub/bootstrap/workloads.yaml](./hub/bootstrap/workloads.yaml).
+```shell
+kubectl --context hub apply -n argocd -f ../hub/bootstrap/workloads.yaml
+```
+
 ### Monitor GitOps Progress for Workloads from Hub Cluster (run on Hub Cluster context)
 
-Watch until **all* the Workloads ArgoCD Applications are `Healthy`
+Watch until all the Workloads ArgoCD Applications are `Healthy`
 
 ```shell
 kubectl --context hub get -n argocd applications -w

--- a/patterns/gitops/multi-cluster-hub-spoke-argocd/hub/bootstrap/workloads.yaml
+++ b/patterns/gitops/multi-cluster-hub-spoke-argocd/hub/bootstrap/workloads.yaml
@@ -10,9 +10,6 @@ spec:
     - clusters:
         selector:
           matchExpressions:
-            - key: akuity.io/argo-cd-cluster-name
-              operator: NotIn
-              values: [in-cluster]
             - key: environment
               operator: NotIn
               values: [control-plane]

--- a/patterns/gitops/multi-cluster-hub-spoke-argocd/hub/main.tf
+++ b/patterns/gitops/multi-cluster-hub-spoke-argocd/hub/main.tf
@@ -118,11 +118,6 @@ locals {
     }
   )
 
-  argocd_apps = {
-    addons    = file("${path.module}/bootstrap/addons.yaml")
-    workloads = file("${path.module}/bootstrap/workloads.yaml")
-  }
-
   tags = {
     Blueprint  = local.name
     GithubRepo = "github.com/gitops-bridge-dev/gitops-bridge"
@@ -141,7 +136,7 @@ module "gitops_bridge_bootstrap" {
     metadata     = local.addons_metadata
     addons       = local.addons
   }
-  apps = local.argocd_apps
+
   argocd = {
     namespace = local.argocd_namespace
   }

--- a/patterns/gitops/multi-cluster-hub-spoke-argocd/spokes/deploy.sh
+++ b/patterns/gitops/multi-cluster-hub-spoke-argocd/spokes/deploy.sh
@@ -23,5 +23,6 @@ else
 fi
 
 terraform workspace select $env
+terraform workspace list
 terraform init
 terraform apply -var-file="workspaces/${env}.tfvars"


### PR DESCRIPTION
# Description

This change makes it more clear how the bootstrap of addons and workloads happens, by removing the use of gitops-bridge module to deploy the bootstrap ArgoCD apps.

This change should make it more clearn to the end user trying out the pattern and following step by step the instructions in the README.md of each corresponding gitops pattern.

### Motivation and Context

- Resolves #1882

### How was this change tested?

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [x] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR

### Additional Notes

<!-- Anything else we should know when reviewing? -->
