### PR TITLE
Fix terraform state removal typo for eks cluster access

### DIFF
--- a/docs/_partials/destroy.md
+++ b/docs/_partials/destroy.md
@@ -1,7 +1,8 @@
 ```sh
 # Necessary to avoid removing Terraform's permissions too soon before its finished
 # cleaning up the resources it deployed inside the cluster
-terraform state rm 'module.eks.aws_eks_access_entry.this["cluster_creator_admin"]' || true
+terraform state rm 'module.eks.aws_eks_access_entry.this["cluster_creator"]' || true
+terraform state rm 'module.eks.aws_eks_access_policy_association.this["cluster_creator_admin"]' || true
 
 terraform destroy -target="module.eks_blueprints_addons" -auto-approve
 terraform destroy -target="module.eks" -auto-approve


### PR DESCRIPTION
# Description
Fixes terraform state removal typo in `destroy.md` for eks cluster access.

### Motivation and Context

<!-- What inspired you to submit this pull request? -->
- Resolves #1890

### How was this change tested?

- [X] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [X] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [X] Yes, I ran `pre-commit run -a` with this PR

### Additional Notes

Below destroy test was executed for `patterns/istio` project.

#### Command

```console
terraform state rm 'module.eks.aws_eks_access_entry.this["cluster_creator"]' || true
terraform state rm 'module.eks.aws_eks_access_policy_association.this["cluster_creator_admin"]' || true

terraform destroy -target="module.eks_blueprints_addons" -auto-approve
terraform destroy -target="module.eks" -auto-approve
terraform destroy -auto-approve
```

#### Output snippet
```
Removed module.eks.aws_eks_access_entry.this["cluster_creator"]
Successfully removed 1 resource instance(s).
Removed module.eks.aws_eks_access_policy_association.this["cluster_creator_admin"]
Successfully removed 1 resource instance(s).
module.eks_blueprints_addons.module.aws_load_balancer_controller.data.aws_partition.current[0]: Reading...
module.eks_blueprints_addons.data.aws_partition.current: Reading...
...

module.eks_blueprints_addons.helm_release.this["istiod"]: Destruction complete after 39s
module.eks_blueprints_addons.time_sleep.this: Destroying... [id=2024-02-27T07:53:31Z]
module.eks_blueprints_addons.time_sleep.this: Destruction complete after 0s
╷
│ Warning: Resource targeting is in effect
│ 
│ You are creating a plan with the -target option, which means that the result of this plan may not represent all of the changes requested by the current
│ configuration.
│ 
│ The -target option is not for routine use, and is provided only for exceptional situations such as recovering from errors or mistakes, or when Terraform
│ specifically suggests to use it as part of an error message.
╵
╷
│ Warning: Applied changes may be incomplete
│ 
│ The plan was created with the -target option in effect, so some changes requested in the configuration may have been ignored and the output values may
│ not be fully updated. Run the following command to verify that no other changes are pending:
│     terraform plan
│ 
│ Note that the -target option is not suitable for routine use, and is provided only for exceptional situations such as recovering from errors or
│ mistakes, or when Terraform specifically suggests to use it as part of an error message.
╵

Destroy complete! Resources: 7 destroyed.
module.eks.data.aws_partition.current: Reading...
module.eks.module.kms.data.aws_partition.current[0]: Reading...
...

module.eks.aws_security_group.cluster[0]: Destruction complete after 1s
module.eks.aws_security_group.node[0]: Destruction complete after 1s
╷
│ Warning: Resource targeting is in effect
│ 
│ You are creating a plan with the -target option, which means that the result of this plan may not represent all of the changes requested by the current configuration.
│ 
│ The -target option is not for routine use, and is provided only for exceptional situations such as recovering from errors or mistakes, or when Terraform specifically suggests to use it as part of an
│ error message.
╵
╷
│ Warning: Applied changes may be incomplete
│ 
│ The plan was created with the -target option in effect, so some changes requested in the configuration may have been ignored and the output values may not be fully updated. Run the following command to
│ verify that no other changes are pending:
│     terraform plan
│ 
│ Note that the -target option is not suitable for routine use, and is provided only for exceptional situations such as recovering from errors or mistakes, or when Terraform specifically suggests to use
│ it as part of an error message.
╵

Destroy complete! Resources: 38 destroyed.
module.eks.module.eks_managed_node_group["initial"].data.aws_partition.current: Reading...
module.eks_blueprints_addons.data.aws_partition.current: Reading...
...

module.vpc.aws_vpc.this[0]: Destroying... [id=vpc-071c2730b1895aaeb]
module.vpc.aws_vpc.this[0]: Destruction complete after 1s
╷
│ Warning: EC2 Default Network ACL (acl-001507ee57774062b) not deleted, removing from state
│ 
│ 
╵

Destroy complete! Resources: 23 destroyed.
```
