### PR TITLE
fix: Replace un-maintained kubectl provider with an updated fork

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/streetsidesoftware/cspell-cli
-    rev: v8.3.0
+    rev: v8.6.0
     hooks:
       - id: cspell
         args: [--exclude, 'ADOPTERS.md', --exclude, '.pre-commit-config.yaml', --exclude, '.gitignore', --exclude, '*.drawio', --exclude, 'mkdocs.yml', --exclude, '.helmignore', --exclude, '.github/workflows/*', --exclude, 'patterns/istio-multi-cluster/*', --exclude, 'patterns/blue-green-upgrade/*']
@@ -19,7 +19,7 @@ repos:
       - id: detect-aws-credentials
         args: [--allow-missing-credentials]
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.86.0
+    rev: v1.88.1
     hooks:
       - id: terraform_fmt
       - id: terraform_docs

--- a/docs/cSpell_dict.txt
+++ b/docs/cSpell_dict.txt
@@ -4,6 +4,7 @@ addrs
 adot
 agones
 akuity
+alekc
 algbw
 ALLOWVOLUMEEXPANSION
 amazonlinux
@@ -73,7 +74,6 @@ flblogs
 fluentbit
 gameserver
 gameservers
-gavinbunney
 gitops
 helloworld
 heptio

--- a/patterns/appmesh-mtls/versions.tf
+++ b/patterns/appmesh-mtls/versions.tf
@@ -11,8 +11,8 @@ terraform {
       version = ">= 2.9"
     }
     kubectl = {
-      source  = "gavinbunney/kubectl"
-      version = ">= 1.14"
+      source  = "alekc/kubectl"
+      version = ">= 2.0"
     }
   }
 

--- a/patterns/external-secrets/versions.tf
+++ b/patterns/external-secrets/versions.tf
@@ -11,8 +11,8 @@ terraform {
       version = ">= 2.9"
     }
     kubectl = {
-      source  = "gavinbunney/kubectl"
-      version = ">= 1.14"
+      source  = "alekc/kubectl"
+      version = ">= 2.0"
     }
   }
 

--- a/patterns/multi-tenancy-with-teams/main.tf
+++ b/patterns/multi-tenancy-with-teams/main.tf
@@ -8,22 +8,6 @@ provider "kubernetes" {
   token                  = data.aws_eks_cluster_auth.this.token
 }
 
-provider "helm" {
-  kubernetes {
-    host                   = module.eks.cluster_endpoint
-    cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
-    token                  = data.aws_eks_cluster_auth.this.token
-  }
-}
-
-provider "kubectl" {
-  apply_retry_count      = 10
-  host                   = module.eks.cluster_endpoint
-  cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
-  load_config_file       = false
-  token                  = data.aws_eks_cluster_auth.this.token
-}
-
 data "aws_eks_cluster_auth" "this" {
   name = module.eks.cluster_name
 }

--- a/patterns/multi-tenancy-with-teams/versions.tf
+++ b/patterns/multi-tenancy-with-teams/versions.tf
@@ -6,17 +6,9 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 5.34"
     }
-    helm = {
-      source  = "hashicorp/helm"
-      version = ">= 2.9"
-    }
     kubernetes = {
       source  = "hashicorp/kubernetes"
       version = ">= 2.20"
-    }
-    kubectl = {
-      source  = "gavinbunney/kubectl"
-      version = ">= 1.14"
     }
   }
 

--- a/patterns/tls-with-aws-pca-issuer/versions.tf
+++ b/patterns/tls-with-aws-pca-issuer/versions.tf
@@ -11,8 +11,8 @@ terraform {
       version = ">= 2.9"
     }
     kubectl = {
-      source  = "gavinbunney/kubectl"
-      version = ">= 1.14"
+      source  = "alekc/kubectl"
+      version = ">= 2.0"
     }
   }
 


### PR DESCRIPTION
# Description

- Replace unmaintained kubectl provider with an updated fork. We can continue to look at replacing the use of Kubernetes providers from Terraform, but this at least resolves the issue with the defunct provider 

### Motivation and Context

- Resolves #1675

### How was this change tested?

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR

### Additional Notes

<!-- Anything else we should know when reviewing? -->
