### PR TITLE
chore: Update documentation for installing EFA device plugin to use official EKS chart

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
       - id: detect-aws-credentials
         args: [--allow-missing-credentials]
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.88.1
+    rev: v1.88.2
     hooks:
       - id: terraform_fmt
       - id: terraform_docs

--- a/docs/cSpell_dict.txt
+++ b/docs/cSpell_dict.txt
@@ -144,6 +144,7 @@ tcpdump
 templatefile
 tfstate
 tfvars
+tolerations
 tolist
 toset
 velero

--- a/patterns/elastic-fabric-adapter/README.md
+++ b/patterns/elastic-fabric-adapter/README.md
@@ -8,6 +8,10 @@ See [here](https://aws-ia.github.io/terraform-aws-eks-blueprints/getting-started
 
 ## Validate
 
+!!! note
+
+    The following steps are shown with `g5.8xlarge` due to cost and availability. Values shown below will change based on the instance type selected (i.e. - `p5.48xlarge` has 8 GPUs and 32 EFA interfaces)
+
 1. List the nodes by instance type:
 
     ```sh

--- a/patterns/elastic-fabric-adapter/versions.tf
+++ b/patterns/elastic-fabric-adapter/versions.tf
@@ -10,10 +10,6 @@ terraform {
       source  = "hashicorp/helm"
       version = ">= 2.9"
     }
-    kubernetes = {
-      source  = "hashicorp/kubernetes"
-      version = ">= 2.20"
-    }
   }
 
   # ##  Used for end-to-end testing on project; update to suit your needs


### PR DESCRIPTION
# Description

- Update documentation for installing EFA device plugin to use official EKS chart
- Replace use of GPU operator with NVIDIA K8s device plugin
- Update EKS module version to use EFA enablement features

### Motivation and Context

Ref: https://github.com/aws-neuron/aws-neuron-sdk/pull/850
Ref: https://github.com/aws-samples/aws-efa-eks/pull/22#issuecomment-1995125135
Ref: https://github.com/awsdocs/amazon-eks-user-guide/pull/747

### How was this change tested?

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR

### Additional Notes

<!-- Anything else we should know when reviewing? -->
