### PR TITLE
refactor: Updated code with IAM access entries

### DIFF
--- a/patterns/privatelink-access/README.md
+++ b/patterns/privatelink-access/README.md
@@ -15,25 +15,9 @@ terraform apply -target=module.eventbridge -target=module.nlb --auto-approve
 terraform apply --auto-approve
 ```
 
-Once the pattern has successfully deployed, you will be provided with multiple
-output values.
-
-Review the output value for `cluster_endpoint_private`, it should look similar
-to snippet below:
-
-```sh
-aws eks update-cluster-config \
---region us-west-2 \
---name privatelink-access \
---resources-vpc-config endpointPublicAccess=false,endpointPrivateAccess=true
-```
-
-Copy the command and run it in a terminal session to take cluster API
-endpoint private.
-
 ## Test access to EKS Kubernetes API server endpoint
 
-Of the other output values, the value `ssm_test` is provided to aid in quickly
+Of the output values, the value `ssm_test` is provided to aid in quickly
 testing the connectivity from the client EC2 instance to the private EKS cluster
 via AWS PrivateLink. Copy the output value, which looks like the snippet shown
 below (as an example) and paste it into your terminal to execute and check the
@@ -95,23 +79,6 @@ kube-system   kube-proxy-mm2zc           1/1     Running   0          1m
 ```
 
 ## Destroy
-
-Before we could destroy/teardown all the resources created, we need to ensure
-that the cluster state is restored for the Terraform to do a complete cleanup.
-This would mean that we make cluster API endpoint public again.
-
-Review the output value for `cluster_endpoint_public`, it should look similar
-to snippet below:
-
-```sh
-aws eks update-cluster-config \
---region us-west-2 \
---name privatelink-access \
---resources-vpc-config endpointPublicAccess=true,endpointPrivateAccess=true
-```
-
-Copy the command and run it in a terminal session to take cluster API
-endpoint public.
 
 {%
    include-markdown "../../docs/_partials/destroy.md"

--- a/patterns/privatelink-access/eks.tf
+++ b/patterns/privatelink-access/eks.tf
@@ -16,19 +16,28 @@ provider "kubernetes" {
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 19.21"
+  version = "~> 20.0"
 
   cluster_name    = local.name
   cluster_version = "1.29"
 
-  cluster_endpoint_public_access = true
-  manage_aws_auth_configmap      = true
+  cluster_endpoint_public_access           = false
+  enable_cluster_creator_admin_permissions = true
 
-  aws_auth_roles = [{
-    rolearn  = module.client_ec2_instance.iam_role_arn
-    username = "ec2-client"
-    groups   = ["system:masters"]
-  }]
+  access_entries = {
+    ec2-access-entry = {
+      principal_arn = module.client_ec2_instance.iam_role_arn
+      policy_associations = {
+        cluster-admin-policy = {
+          policy_arn = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy"
+          access_scope = {
+            namespaces = []
+            type       = "cluster"
+          }
+        }
+      }
+    }
+  }
 
   cluster_addons = {
     coredns    = {}

--- a/patterns/privatelink-access/outputs.tf
+++ b/patterns/privatelink-access/outputs.tf
@@ -23,25 +23,3 @@ output "ssm_test" {
     --output text
   EOT
 }
-
-output "cluster_endpoint_private" {
-  description = "Command to set the EKS API server endpoint access private"
-  value       = <<-EOT
-
-    aws eks update-cluster-config \
-    --region ${local.region} \
-    --name ${module.eks.cluster_name} \
-    --resources-vpc-config endpointPublicAccess=false,endpointPrivateAccess=true
-  EOT
-}
-
-output "cluster_endpoint_public" {
-  description = "Command to set the EKS API server endpoint access private"
-  value       = <<-EOT
-
-    aws eks update-cluster-config \
-    --region ${local.region} \
-    --name ${module.eks.cluster_name} \
-    --resources-vpc-config endpointPublicAccess=true,endpointPrivateAccess=true
-  EOT
-}


### PR DESCRIPTION
# Description

Refactored the pattern to use the IAM access entries instead of using `aws-auth` configmap.

### Motivation and Context

- Resolves #1816 

### How was this change tested?

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [x] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR
