### PR TITLE
docs: Fix vpc lattice pattern doc

### DIFF
--- a/docs/patterns/vpc-lattice/client-server-communication.md
+++ b/docs/patterns/vpc-lattice/client-server-communication.md
@@ -1,0 +1,7 @@
+---
+title: Amazon VPC Lattice Client-server Communication
+---
+
+{%
+   include-markdown "../../../patterns/vpc-lattice/client-server-communication/README.md"
+%}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: Amazon EKS Blueprints for Terraform
 docs_dir: docs/
-copyright: Copyright &copy; Amazon 2023
+copyright: Copyright &copy; Amazon 2024
 site_author: AWS
 site_url: https://aws-ia.github.io/terraform-aws-eks-blueprints/
 repo_name: terraform-aws-eks-blueprints

--- a/patterns/vpc-lattice/client-server-communication/README.md
+++ b/patterns/vpc-lattice/client-server-communication/README.md
@@ -6,7 +6,7 @@ This pattern demonstrates how to expose an EKS cluster hosted application to an 
 
 With this solution we showcase how to configure Amazon VPC Lattice using the AWS Gateway API Controller in order to manage Amazon VPC Lattice resources through native K8S Gateway API objects. This pattern deploys two distinct VPCs with a client application running in one of them and a server application in the other. The server application is deployed inside an EKS cluster and made exposed to the client application through Amazon VPC Lattice which establishes connectivity between the two applications. Further we demonstrate how to configure a custom domain name for the exposed service using Amazon Route53 and the external-dns project.
 
-![diagram](assets/diagram.png)
+![diagram](https://raw.githubusercontent.com/aws-ia/terraform-aws-eks-blueprints/main/patterns/vpc-lattice/client-server-communication/assets/diagram.png)
 
 
 ## Deploy


### PR DESCRIPTION
# Description

The VPC lattice pattern documentation was not showing properly, this fix it.

<!--
🛑 Please open an issue first to discuss any significant work and flesh out details/direction - we would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/aws-ia/terraform-aws-eks-blueprints/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

A brief description of the change being made with this pull request.
-->

### Motivation and Context

<!-- What inspired you to submit this pull request? -->
- Resolves #<issue-number>

### How was this change tested?

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR

### Additional Notes

<!-- Anything else we should know when reviewing? -->
