### PR TITLE
updated multicluster with pod identity and cluster access management

### DIFF
--- a/patterns/gitops/multi-cluster-hub-spoke-argocd/README.md
+++ b/patterns/gitops/multi-cluster-hub-spoke-argocd/README.md
@@ -110,20 +110,6 @@ echo "ArgoCD Password: $(kubectl --context hub get secrets argocd-initial-admin-
 echo "ArgoCD URL: https://$(kubectl --context hub get svc -n argocd argo-cd-argocd-server -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')"
 ```
 
-## Verify that ArgoCD Service Accounts has the annotation for IRSA
-
-```shell
-kubectl --context hub get sa -n argocd argocd-application-controller -o json | jq '.metadata.annotations."eks.amazonaws.com/role-arn"'
-kubectl --context hub get sa -n argocd argocd-server  -o json | jq '.metadata.annotations."eks.amazonaws.com/role-arn"'
-```
-
-The output should match the `arn` for the IAM Role that will assume the IAM Role in spoke/remote clusters
-
-```text
-arn:aws:iam::0123456789:role/argocd-hub-0123abc..
-arn:aws:iam::0123456789:role/argocd-hub-0123abc..
-```
-
 ## Deploy the Spoke EKS Cluster
 
 Use the `deploy.sh` script to create terraform workspace, initialize Terraform, and deploy the EKS clusters:

--- a/patterns/gitops/multi-cluster-hub-spoke-argocd/hub/main.tf
+++ b/patterns/gitops/multi-cluster-hub-spoke-argocd/hub/main.tf
@@ -107,7 +107,8 @@ locals {
       aws_vpc_id       = module.vpc.vpc_id
     },
     {
-      argocd_iam_role_arn = module.argocd_irsa.iam_role_arn
+      #Satish
+      #argocd_iam_role_arn = module.argocd_irsa.iam_role_arn
       argocd_namespace    = local.argocd_namespace
     },
     {
@@ -145,40 +146,88 @@ module "gitops_bridge_bootstrap" {
 ################################################################################
 # ArgoCD EKS Access
 ################################################################################
-module "argocd_irsa" {
-  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "~> 5.20"
-
-  role_name_prefix           = "argocd-hub-"
-  assume_role_condition_test = "StringLike"
-  role_policy_arns = {
-    ArgoCD_EKS_Policy = aws_iam_policy.irsa_policy.arn
-  }
-  oidc_providers = {
-    main = {
-      provider_arn               = module.eks.oidc_provider_arn
-      namespace_service_accounts = ["${local.argocd_namespace}:argocd-*"]
+data "aws_iam_policy_document" "eks_assume" {
+  statement {
+    effect = "Allow"
+    principals {
+      type        = "Service"
+      identifiers = ["pods.eks.amazonaws.com"]
     }
+    actions = ["sts:AssumeRole","sts:TagSession"]
   }
-
-  tags = local.tags
 }
-
-
-resource "aws_iam_policy" "irsa_policy" {
-  name        = "${module.eks.cluster_name}-argocd-irsa"
-  description = "IAM Policy for ArgoCD Hub"
-  policy      = data.aws_iam_policy_document.irsa_policy.json
-  tags        = local.tags
+resource "aws_iam_role" "argocd_hub" {
+  name               = "${module.eks.cluster_name}-argocd-hub"
+  assume_role_policy = data.aws_iam_policy_document.eks_assume.json
 }
-
-data "aws_iam_policy_document" "irsa_policy" {
+data "aws_iam_policy_document" "aws_assume_policy" {
   statement {
     effect    = "Allow"
     resources = ["*"]
-    actions   = ["sts:AssumeRole"]
+    actions   = ["sts:AssumeRole","sts:TagSession"]
   }
 }
+resource "aws_iam_policy" "aws_assume_policy" {
+  name        = "${module.eks.cluster_name}-argocd-aws-assume"
+  description = "IAM Policy for ArgoCD Hub"
+  policy      = data.aws_iam_policy_document.aws_assume_policy.json
+  tags        = local.tags
+}
+resource "aws_iam_role_policy_attachment" "aws_assume_policy" {
+  role       = aws_iam_role.argocd_hub.name
+  policy_arn = aws_iam_policy.aws_assume_policy.arn
+}
+resource "aws_eks_pod_identity_association" "argocd_app_controller" {
+  cluster_name    = module.eks.cluster_name
+  namespace       = "argocd"
+  service_account = "argocd-application-controller"
+  role_arn        = aws_iam_role.argocd_hub.arn
+}
+resource "aws_eks_pod_identity_association" "argocd_api_server" {
+  cluster_name    = module.eks.cluster_name
+  namespace       = "argocd"
+  service_account = "argocd-server"
+  role_arn        = aws_iam_role.argocd_hub.arn
+}
+
+################################################################################
+# ArgoCD EKS Access
+################################################################################
+#Satish
+# module "argocd_irsa" {
+#   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
+#   version = "~> 5.20"
+
+#   role_name_prefix           = "argocd-hub-"
+#   assume_role_condition_test = "StringLike"
+#   role_policy_arns = {
+#     ArgoCD_EKS_Policy = aws_iam_policy.irsa_policy.arn
+#   }
+#   oidc_providers = {
+#     main = {
+#       provider_arn               = module.eks.oidc_provider_arn
+#       namespace_service_accounts = ["${local.argocd_namespace}:argocd-*"]
+#     }
+#   }
+
+#   tags = local.tags
+# }
+
+
+# resource "aws_iam_policy" "irsa_policy" {
+#   name        = "${module.eks.cluster_name}-argocd-irsa"
+#   description = "IAM Policy for ArgoCD Hub"
+#   policy      = data.aws_iam_policy_document.irsa_policy.json
+#   tags        = local.tags
+# }
+
+# data "aws_iam_policy_document" "irsa_policy" {
+#   statement {
+#     effect    = "Allow"
+#     resources = ["*"]
+#     actions   = ["sts:AssumeRole"]
+#   }
+# }
 
 ################################################################################
 # EKS Blueprints Addons
@@ -221,7 +270,7 @@ module "eks_blueprints_addons" {
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 19.13"
+  version = "~> 20.8.4"
 
   cluster_name                   = local.name
   cluster_version                = local.cluster_version
@@ -231,6 +280,10 @@ module "eks" {
   vpc_id     = module.vpc.vpc_id
   subnet_ids = module.vpc.private_subnets
 
+  authentication_mode = "API"
+  
+  enable_cluster_creator_admin_permissions = true
+  
   eks_managed_node_groups = {
     initial = {
       instance_types = ["t3.medium"]
@@ -242,6 +295,9 @@ module "eks" {
   }
   # EKS Addons
   cluster_addons = {
+    eks-pod-identity-agent = {
+      most_recent = true
+    }
     vpc-cni = {
       # Specify the VPC CNI addon should be deployed before compute to ensure
       # the addon is configured before data plane compute resources are created

--- a/patterns/gitops/multi-cluster-hub-spoke-argocd/hub/outputs.tf
+++ b/patterns/gitops/multi-cluster-hub-spoke-argocd/hub/outputs.tf
@@ -1,7 +1,7 @@
 output "configure_kubectl" {
   description = "Configure kubectl: make sure you're logged in with the correct AWS profile and run the following command to update your kubeconfig"
   value       = <<-EOT
-    export KUBECONFIG="/tmp/hup-spoke"
+    export KUBECONFIG="/tmp/hub-spoke"
     aws eks --region ${local.region} update-kubeconfig --name ${module.eks.cluster_name} --alias hub
   EOT
 }
@@ -10,7 +10,7 @@ output "configure_kubectl" {
 output "configure_argocd" {
   description = "Terminal Setup"
   value       = <<-EOT
-    export KUBECONFIG="/tmp/hup-spoke"
+    export KUBECONFIG="/tmp/hub-spoke"
     aws eks --region ${local.region} update-kubeconfig --name ${module.eks.cluster_name} --alias hub
     export ARGOCD_OPTS="--port-forward --port-forward-namespace argocd --grpc-web"
     kubectl --context hub config set-context --current --namespace argocd
@@ -25,7 +25,7 @@ output "configure_argocd" {
 output "access_argocd" {
   description = "ArgoCD Access"
   value       = <<-EOT
-    export KUBECONFIG="/tmp/hup-spoke"
+    export KUBECONFIG="/tmp/hub-spoke"
     aws eks --region ${local.region} update-kubeconfig --name ${module.eks.cluster_name} --alias hub
     echo "ArgoCD Username: admin"
     echo "ArgoCD Password: $(kubectl --context hub get secrets argocd-initial-admin-secret -n argocd --template="{{index .data.password | base64decode}}")"
@@ -33,11 +33,6 @@ output "access_argocd" {
     EOT
 }
 
-
-output "argocd_iam_role_arn" {
-  description = "IAM Role for ArgoCD Cluster Hub, use to connect to spoke clusters"
-  value       = module.argocd_irsa.iam_role_arn
-}
 
 output "cluster_name" {
   description = "Cluster Hub name"

--- a/patterns/gitops/multi-cluster-hub-spoke-argocd/hub/variables.tf
+++ b/patterns/gitops/multi-cluster-hub-spoke-argocd/hub/variables.tf
@@ -11,7 +11,7 @@ variable "region" {
 variable "kubernetes_version" {
   description = "Kubernetes version"
   type        = string
-  default     = "1.28"
+  default     = "1.29"
 }
 variable "addons" {
   description = "Kubernetes addons"
@@ -19,12 +19,15 @@ variable "addons" {
   default = {
     enable_aws_load_balancer_controller = true
     enable_metrics_server               = true
-    # Enable argocd with IRSA
-    enable_aws_argocd = true
-    # Disable argocd without IRSA
-    enable_argocd = false
+    enable_argocd = true
   }
 }
+
+output "argocd_iam_role_arn" {
+  description = "IAM Role for ArgoCD Cluster Hub, use to connect to spoke clusters"
+  value       = aws_iam_role.argocd_hub.arn
+}
+
 # Addons Git
 variable "gitops_addons_org" {
   description = "Git repository org/user contains for addons"

--- a/patterns/gitops/multi-cluster-hub-spoke-argocd/spokes/main.tf
+++ b/patterns/gitops/multi-cluster-hub-spoke-argocd/spokes/main.tf
@@ -186,13 +186,13 @@ module "gitops_bridge_bootstrap_hub" {
 # ArgoCD EKS Access
 ################################################################################
 resource "aws_iam_role" "spoke" {
-  name               = "${module.eks.cluster_name}-argocd-spoke"
+  name               = "${local.name}-argocd-spoke"
   assume_role_policy = data.aws_iam_policy_document.assume_role_policy.json
 }
 
 data "aws_iam_policy_document" "assume_role_policy" {
   statement {
-    actions = ["sts:AssumeRole"]
+    actions = ["sts:AssumeRole","sts:TagSession"]
     principals {
       type        = "AWS"
       identifiers = [data.terraform_remote_state.cluster_hub.outputs.argocd_iam_role_arn]
@@ -243,7 +243,7 @@ module "eks_blueprints_addons" {
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 19.13"
+  version = "~> 20.8.4"
 
   cluster_name                   = local.name
   cluster_version                = local.cluster_version
@@ -252,18 +252,28 @@ module "eks" {
 
   vpc_id     = module.vpc.vpc_id
   subnet_ids = module.vpc.private_subnets
+  
+  authentication_mode = "API"
 
-  manage_aws_auth_configmap = true
-  aws_auth_roles = [
-    # Granting access to ArgoCD from hub cluster
-    {
-      rolearn  = aws_iam_role.spoke.arn
-      username = "gitops-role"
-      groups = [
-        "system:masters"
-      ]
-    },
-  ]
+  # Cluster access entry
+  # To add the current caller identity as an administrator
+  enable_cluster_creator_admin_permissions = true
+
+  access_entries = {
+    # One access entry with a policy associated
+    example = {
+      principal_arn     = aws_iam_role.spoke.arn
+
+      policy_associations = {
+        argocd = {
+          policy_arn = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy"
+          access_scope = {
+            type       = "cluster"
+          }
+        }
+      }
+    }
+  }
 
   eks_managed_node_groups = {
     initial = {
@@ -276,6 +286,9 @@ module "eks" {
   }
   # EKS Addons
   cluster_addons = {
+    eks-pod-identity-agent = {
+      most_recent = true
+    }  
     vpc-cni = {
       # Specify the VPC CNI addon should be deployed before compute to ensure
       # the addon is configured before data plane compute resources are created

--- a/patterns/gitops/multi-cluster-hub-spoke-argocd/spokes/outputs.tf
+++ b/patterns/gitops/multi-cluster-hub-spoke-argocd/spokes/outputs.tf
@@ -1,7 +1,7 @@
 output "configure_kubectl" {
   description = "Configure kubectl: make sure you're logged in with the correct AWS profile and run the following command to update your kubeconfig"
   value       = <<-EOT
-    export KUBECONFIG="/tmp/hup-spoke"
+    export KUBECONFIG="/tmp/hub-spoke"
     aws eks --region ${local.region} update-kubeconfig --name ${module.eks.cluster_name} --alias ${local.environment}
   EOT
 }

--- a/patterns/gitops/multi-cluster-hub-spoke-argocd/spokes/workspaces/dev.tfvars
+++ b/patterns/gitops/multi-cluster-hub-spoke-argocd/spokes/workspaces/dev.tfvars
@@ -1,6 +1,6 @@
 vpc_cidr           = "10.1.0.0/16"
 region             = "us-west-2"
-kubernetes_version = "1.28"
+kubernetes_version = "1.29"
 addons = {
   enable_aws_load_balancer_controller = true
   enable_metrics_server               = true

--- a/patterns/gitops/multi-cluster-hub-spoke-argocd/spokes/workspaces/prod.tfvars
+++ b/patterns/gitops/multi-cluster-hub-spoke-argocd/spokes/workspaces/prod.tfvars
@@ -1,6 +1,6 @@
 vpc_cidr           = "10.3.0.0/16"
 region             = "us-west-2"
-kubernetes_version = "1.28"
+kubernetes_version = "1.29"
 addons = {
   enable_aws_load_balancer_controller = true
   enable_metrics_server               = true

--- a/patterns/gitops/multi-cluster-hub-spoke-argocd/spokes/workspaces/staging.tfvars
+++ b/patterns/gitops/multi-cluster-hub-spoke-argocd/spokes/workspaces/staging.tfvars
@@ -1,6 +1,6 @@
 vpc_cidr           = "10.2.0.0/16"
 region             = "us-west-2"
-kubernetes_version = "1.28"
+kubernetes_version = "1.29"
 addons = {
   enable_aws_load_balancer_controller = true
   enable_metrics_server               = true


### PR DESCRIPTION
# Description

<!--
🛑 Please open an issue first to discuss any significant work and flesh out details/direction - we would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/aws-ia/terraform-aws-eks-blueprints/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

updated hub and spoke to support pod identity instead of IRSA
-->

### Motivation and Context

<!-- What inspired you to submit this pull request? -->
- Resolves #<issue1916> Moves from IRSA and pod identity

### How was this change tested?
Created hub and spoke to validate pod identity. Hub can connect to spoke. Hub was able to install load balancer and metrics server on the spoke
- [X ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [X] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [X] Yes, I ran `pre-commit run -a` with this PR

### Additional Notes

<!-- Anything else we should know when reviewing? -->
