### PR TITLE
docs: Update in Custom Networking for vpc-cni instructions

### DIFF
--- a/docs/snippets/vpc-cni-custom-networking.md
+++ b/docs/snippets/vpc-cni-custom-networking.md
@@ -15,7 +15,7 @@ In this example, the `vpc-cni` addon is configured using `before_compute = true`
 
 If you find that your nodes are not being created with the correct number of max pods (i.e. - for `m5.large`, if you are seeing a max pods of 29 instead of 110), most likely the `vpc-cni` was not configured *before* the EC2 instances.
 
-To be able to do this configuration you need access to your cluster from where you are deploying the terraform code. In case it is a private cluster access the VPC through a VPN, Direct Connect or Bastion, and ensure you have enough permissions. 
+To be able to do this configuration you need access to your cluster from where you are deploying the terraform code. In case it is a private cluster access the VPC through a VPN, Direct Connect or Bastion, and ensure the entity used has enough permissions in the cluster. 
 ## Components
 
 To enable VPC CNI custom networking, you must configuring the following components:

--- a/docs/snippets/vpc-cni-custom-networking.md
+++ b/docs/snippets/vpc-cni-custom-networking.md
@@ -24,20 +24,20 @@ To enable VPC CNI custom networking, you must configuring the following componen
 
       ```
       module "vpc" {
-      source  = "terraform-aws-modules/vpc/aws"
+         source  = "terraform-aws-modules/vpc/aws"
 
-      # Truncated for brevity
-      ...
+         # Truncated for brevity
+         ...
 
-      secondary_cidr_blocks = [local.secondary_vpc_cidr] # can add up to 5 total CIDR blocks
+         secondary_cidr_blocks = [local.secondary_vpc_cidr] # can add up to 5 total CIDR blocks
 
-      azs = local.azs
-      private_subnets = concat(
-         [for k, v in local.azs : cidrsubnet(local.vpc_cidr, 4, k)],
-         [for k, v in local.azs : cidrsubnet(local.secondary_vpc_cidr, 2, k)]
-      )
+         azs = local.azs
+         private_subnets = concat(
+            [for k, v in local.azs : cidrsubnet(local.vpc_cidr, 4, k)],
+            [for k, v in local.azs : cidrsubnet(local.secondary_vpc_cidr, 2, k)]
+         )
 
-      ...
+         ...
       }
       ```
 

--- a/docs/snippets/vpc-cni-custom-networking.md
+++ b/docs/snippets/vpc-cni-custom-networking.md
@@ -89,7 +89,7 @@ To enable VPC CNI custom networking, you must configuring the following componen
       }
       ```
    This custom resource can be found in the alekc/kubectl provider. Add it to where the providers are defined:
-   ````
+   ```hcl
       required_providers {
 
          # Truncated for brevity
@@ -104,7 +104,7 @@ To enable VPC CNI custom networking, you must configuring the following componen
    ```
 
 4. Give permissions to the vpc-cni using IPv4 to be used inside the cluster with an irsa role:
-   ```
+   ```hcl
    module "vpc_cni_ipv4_irsa_role" {
       source = "github.com/terraform-aws-modules/terraform-aws-iam.git//modules/iam-role-for-service-accounts-eks"
 
@@ -121,7 +121,7 @@ To enable VPC CNI custom networking, you must configuring the following componen
 
       tags = var.tags
    }
-   ````
+   ```
 
 Once those settings have been successfully applied, you can verify if custom networking is enabled correctly by inspecting one of the `aws-node-*` (AWS VPC CNI) pods:
 

--- a/docs/snippets/vpc-cni-custom-networking.md
+++ b/docs/snippets/vpc-cni-custom-networking.md
@@ -43,7 +43,7 @@ To enable VPC CNI custom networking, you must configuring the following componen
 
 2. Specify the VPC CNI custom networking configuration in the `vpc-cni` addon configuration:
 
-      ```
+      ```hcl
       module "eks" {
          source  = "terraform-aws-modules/eks/aws"
 

--- a/docs/snippets/vpc-cni-custom-networking.md
+++ b/docs/snippets/vpc-cni-custom-networking.md
@@ -69,7 +69,7 @@ To enable VPC CNI custom networking, you must configuring the following componen
 
 3. Create the `ENIConfig` custom resource for each subnet that you want to deploy pods into:
 
-      ```
+      ```hcl
       resource "kubectl_manifest" "eni_config" {
          for_each = zipmap(local.azs, slice(module.vpc.private_subnets, 3, 6))
 

--- a/docs/snippets/vpc-cni-custom-networking.md
+++ b/docs/snippets/vpc-cni-custom-networking.md
@@ -22,7 +22,7 @@ To enable VPC CNI custom networking, you must configuring the following componen
 
 1. Create a VPC with additional CIDR block associations. These additional CIDR blocks will be used to create subnets for the VPC CNI custom networking:
 
-      ```
+      ```hcl
       module "vpc" {
          source  = "terraform-aws-modules/vpc/aws"
 

--- a/docs/v4-to-v5/cluster.md
+++ b/docs/v4-to-v5/cluster.md
@@ -4,7 +4,7 @@ title: Cluster
 
 # Migrate to EKS Module v19.x
 
-Please consult the [docs/v4-to-v5/example](https://github.com/aws-ia/terraform-aws-eks-blueprints/blob/main/docs/v4-to-v5/example) directory for reference configurations. If you find a bug, please open an issue with supporting configuration to reproduce.
+Please consult the [docs/v4-to-v5/example](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs/v4-to-v5/example) directory for reference configurations. If you find a bug, please open an issue with supporting configuration to reproduce.
 
 ## Backwards incompatible changes
 


### PR DESCRIPTION
# Description

<!--
🛑 Please open an issue first to discuss any significant work and flesh out details/direction - we would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/aws-ia/terraform-aws-eks-blueprints/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

A brief description of the change being made with this pull request.
-->
PR includes additional information on the provider for the custom resource for kubectl_manifest, the IRSA role needed and additional clarifications for private clusters. 

### Motivation and Context

<!-- What inspired you to submit this pull request? -->
- Resolves #<issue-number>
After working with the blueprints, I was not able to make work the custom networking only using the documentation and had to do further research that took longer than expected.

### How was this change tested?

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [x] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR
- Change in documentation, not in implementation
### Additional Notes

<!-- Anything else we should know when reviewing? -->
