### PR TITLE
chore: Update Karpenter MNG pattern to use updated module w/ pod identity association included

### DIFF
--- a/patterns/karpenter-mng/README.md
+++ b/patterns/karpenter-mng/README.md
@@ -13,7 +13,7 @@ This pattern demonstrates how to provision Karpenter on an EKS managed node grou
 
 The areas of significance related to this pattern are highlighted in the code provided below:
 
-```terraform hl_lines="20-28 31 49-62 67-70 89-91 97-100 108-132"
+```terraform hl_lines="20-28 31 49-62 67-70 89-92 102-126"
 {% include  "../../patterns/karpenter-mng/eks.tf" %}
 ```
 

--- a/patterns/karpenter-mng/eks.tf
+++ b/patterns/karpenter-mng/eks.tf
@@ -4,7 +4,7 @@
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 20.9"
+  version = "~> 20.10"
 
   cluster_name    = local.name
   cluster_version = "1.29"
@@ -87,17 +87,11 @@ module "karpenter" {
   cluster_name = module.eks.cluster_name
 
   # Name needs to match role name passed to the EC2NodeClass
-  node_iam_role_use_name_prefix = false
-  node_iam_role_name            = local.name
+  node_iam_role_use_name_prefix   = false
+  node_iam_role_name              = local.name
+  create_pod_identity_association = true
 
   tags = local.tags
-}
-
-resource "aws_eks_pod_identity_association" "karpenter" {
-  cluster_name    = module.eks.cluster_name
-  namespace       = "kube-system"
-  service_account = "karpenter"
-  role_arn        = module.karpenter.iam_role_arn
 }
 
 ################################################################################


### PR DESCRIPTION
# Description
- Update Karpenter MNG pattern to use updated module w/ pod identity association included following https://github.com/terraform-aws-modules/terraform-aws-eks/pull/3031

### Motivation and Context

- Simplifies configuration used

### How was this change tested?

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR

### Additional Notes

<!-- Anything else we should know when reviewing? -->
