### PR TITLE
chore: Update targeted ODCR to show p5 to be reflect current usage

### DIFF
--- a/patterns/ml-capacity-block/README.md
+++ b/patterns/ml-capacity-block/README.md
@@ -2,10 +2,10 @@
 
 This pattern demonstrates how to consume/utilize ML capacity block reservations (CBR) with Amazon EKS. The solution is comprised of primarily 2 components:
 
-!!! warning
-      The use of self-managed node group(s) are required at this time to support capacity block reservations within EKS. This pattern will be updated to demonstrate EKS managed node groups once support has been implemented by the EKS service.
-
 1. The self-managed node group that will utilize the CBR should have the subnets provided to it restricted to the availability zone where the CBR has been allocated. For example - if the CBR is allocated to `us-west-2b`, the node group should only have subnet IDs provided to it that reside in `us-west-2b`. If the subnets that reside in other AZs are provided, its possible to encounter an error such as `InvalidParameterException: The following supplied instance types do not exist ...`. It is not guaranteed that this error will always be shown, and may appear random since the underlying autoscaling group(s) will provision nodes into different AZs at random. It will only occur when the underlying autoscaling group tries to provision instances into an AZ where capacity is not allocated and there is insufficient on-demand capacity for the desired instance type.
+
+    !!! warning
+        The use of self-managed node group(s) are required at this time to support capacity block reservations within EKS. This pattern will be updated to demonstrate EKS managed node groups once support has been implemented by the EKS service.
 
 2. The launch template utilized should specify the `instance_market_options` and `capacity_reservation_specification` arguments. This is how the CBR is utilized by the node group (i.e. - tells the autoscaling group to launch instances utilizing provided capacity reservation).
 
@@ -16,7 +16,7 @@ This pattern demonstrates how to consume/utilize ML capacity block reservations 
 
 ## Code
 
-```terraform hl_lines="53-93"
+```terraform hl_lines="5-11 54-56 84-92"
 {% include  "../../patterns/ml-capacity-block/eks.tf" %}
 ```
 

--- a/patterns/ml-capacity-block/helm.tf
+++ b/patterns/ml-capacity-block/helm.tf
@@ -1,0 +1,47 @@
+################################################################################
+# Helm charts
+################################################################################
+
+resource "helm_release" "nvidia_device_plugin" {
+  name             = "nvidia-device-plugin"
+  repository       = "https://nvidia.github.io/k8s-device-plugin"
+  chart            = "nvidia-device-plugin"
+  version          = "0.14.5"
+  namespace        = "nvidia-device-plugin"
+  create_namespace = true
+  wait             = false
+
+  values = [
+    <<-EOT
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: 'nvidia.com/gpu.present'
+                operator: In
+                values:
+                - 'true'
+    EOT
+  ]
+}
+
+resource "helm_release" "aws_efa_device_plugin" {
+  name       = "aws-efa-k8s-device-plugin"
+  repository = "https://aws.github.io/eks-charts"
+  chart      = "aws-efa-k8s-device-plugin"
+  version    = "v0.4.4"
+  namespace  = "kube-system"
+  wait       = false
+
+  values = [
+    <<-EOT
+      nodeSelector:
+        vpc.amazonaws.com/efa.present: 'true'
+      tolerations:
+        - key: nvidia.com/gpu
+          operator: Exists
+          effect: NoSchedule
+    EOT
+  ]
+}

--- a/patterns/ml-capacity-block/main.tf
+++ b/patterns/ml-capacity-block/main.tf
@@ -58,6 +58,15 @@ locals {
 }
 
 ################################################################################
+# Output
+################################################################################
+
+output "configure_kubectl" {
+  description = "Configure kubectl: make sure you're logged in with the correct AWS profile and run the following command to update your kubeconfig"
+  value       = "aws eks --region ${local.region} update-kubeconfig --name ${module.eks.cluster_name}"
+}
+
+################################################################################
 # Supporting Resources
 ################################################################################
 

--- a/patterns/nvidia-gpu-efa/README.md
+++ b/patterns/nvidia-gpu-efa/README.md
@@ -17,8 +17,12 @@ The following components are demonstrated in this pattern:
 
 ## Code
 
-```terraform hl_lines="23-25 31-68"
+```terraform hl_lines="24-26 32-67"
 {% include  "../../patterns/nvidia-gpu-efa/eks.tf" %}
+```
+
+```terraform hl_lines="5-47"
+{% include  "../../patterns/nvidia-gpu-efa/helm.tf" %}
 ```
 
 ## Deploy

--- a/patterns/nvidia-gpu-efa/helm.tf
+++ b/patterns/nvidia-gpu-efa/helm.tf
@@ -1,0 +1,47 @@
+################################################################################
+# Helm charts
+################################################################################
+
+resource "helm_release" "nvidia_device_plugin" {
+  name             = "nvidia-device-plugin"
+  repository       = "https://nvidia.github.io/k8s-device-plugin"
+  chart            = "nvidia-device-plugin"
+  version          = "0.14.5"
+  namespace        = "nvidia-device-plugin"
+  create_namespace = true
+  wait             = false
+
+  values = [
+    <<-EOT
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: 'nvidia.com/gpu.present'
+                operator: In
+                values:
+                - 'true'
+    EOT
+  ]
+}
+
+resource "helm_release" "aws_efa_device_plugin" {
+  name       = "aws-efa-k8s-device-plugin"
+  repository = "https://aws.github.io/eks-charts"
+  chart      = "aws-efa-k8s-device-plugin"
+  version    = "v0.4.4"
+  namespace  = "kube-system"
+  wait       = false
+
+  values = [
+    <<-EOT
+      nodeSelector:
+        vpc.amazonaws.com/efa.present: 'true'
+      tolerations:
+        - key: nvidia.com/gpu
+          operator: Exists
+          effect: NoSchedule
+    EOT
+  ]
+}

--- a/patterns/nvidia-gpu-efa/main.tf
+++ b/patterns/nvidia-gpu-efa/main.tf
@@ -58,6 +58,15 @@ locals {
 }
 
 ################################################################################
+# Output
+################################################################################
+
+output "configure_kubectl" {
+  description = "Configure kubectl: make sure you're logged in with the correct AWS profile and run the following command to update your kubeconfig"
+  value       = "aws eks --region ${local.region} update-kubeconfig --name ${module.eks.cluster_name}"
+}
+
+################################################################################
 # Supporting Resources
 ################################################################################
 

--- a/patterns/targeted-odcr/README.md
+++ b/patterns/targeted-odcr/README.md
@@ -18,7 +18,7 @@ This pattern demonstrates how to consume/utilize on-demand capacity reservations
 
 ## Code
 
-```terraform hl_lines="34-51"
+```terraform hl_lines="5-8 81-88 108-131"
 {% include  "../../patterns/targeted-odcr/eks.tf" %}
 ```
 

--- a/patterns/targeted-odcr/helm.tf
+++ b/patterns/targeted-odcr/helm.tf
@@ -1,0 +1,47 @@
+################################################################################
+# Helm charts
+################################################################################
+
+resource "helm_release" "nvidia_device_plugin" {
+  name             = "nvidia-device-plugin"
+  repository       = "https://nvidia.github.io/k8s-device-plugin"
+  chart            = "nvidia-device-plugin"
+  version          = "0.14.5"
+  namespace        = "nvidia-device-plugin"
+  create_namespace = true
+  wait             = false
+
+  values = [
+    <<-EOT
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: 'nvidia.com/gpu.present'
+                operator: In
+                values:
+                - 'true'
+    EOT
+  ]
+}
+
+resource "helm_release" "aws_efa_device_plugin" {
+  name       = "aws-efa-k8s-device-plugin"
+  repository = "https://aws.github.io/eks-charts"
+  chart      = "aws-efa-k8s-device-plugin"
+  version    = "v0.4.4"
+  namespace  = "kube-system"
+  wait       = false
+
+  values = [
+    <<-EOT
+      nodeSelector:
+        vpc.amazonaws.com/efa.present: 'true'
+      tolerations:
+        - key: nvidia.com/gpu
+          operator: Exists
+          effect: NoSchedule
+    EOT
+  ]
+}


### PR DESCRIPTION
# Description

- Update targeted ODCR to show p5 to be reflect current usage
	- Remove t3 capacity reservations and require reservation ARN be passed in via variable
	- Show usage with NVIDIA GPU instance and EFA which is the common use case today
- Add pod identity agent - start making it a standard on patterns
- Split out Helm charts to separate file to allow importing into docs site when necessary
- Add kubectl output per usual

### Motivation and Context

- While its great to have a pattern that can be deployed and see the reservations, etc. - it did not reflect the current target audience (p4/p5 users with EFA), which led to confusion. This updates the pattern to better reflect what the majority would be using today with capacity allocated in targeted ODCRs (tl;dr - meeting users where they are)

### How was this change tested?

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR

### Additional Notes

<!-- Anything else we should know when reviewing? -->
