### PR TITLE
chore: Update EKS version to 1.30 where applicable

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/streetsidesoftware/cspell-cli
-    rev: v8.8.0
+    rev: v8.8.2
     hooks:
       - id: cspell
         args: [--exclude, 'ADOPTERS.md', --exclude, '.pre-commit-config.yaml', --exclude, '.gitignore', --exclude, '*.drawio', --exclude, 'mkdocs.yml', --exclude, '.helmignore', --exclude, '.github/workflows/*', --exclude, 'patterns/istio-multi-cluster/*', --exclude, 'patterns/blue-green-upgrade/*']
@@ -19,7 +19,7 @@ repos:
       - id: detect-aws-credentials
         args: [--allow-missing-credentials]
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.89.1
+    rev: v1.90.0
     hooks:
       - id: terraform_fmt
       - id: terraform_docs

--- a/docs/cSpell_dict.txt
+++ b/docs/cSpell_dict.txt
@@ -34,6 +34,7 @@ cainjector
 chdir
 cidrsubnet
 ciliumnetworkpolicy
+cloudinit
 clusterip
 clusterissuer
 clusterrole
@@ -111,6 +112,7 @@ mtls
 nccl
 netcat
 nics
+nodeadm
 nodegroup
 nodeport
 nvme

--- a/patterns/agones-game-controller/main.tf
+++ b/patterns/agones-game-controller/main.tf
@@ -22,8 +22,6 @@ locals {
   name   = basename(path.cwd)
   region = "us-west-2"
 
-  cluster_version = "1.29"
-
   vpc_cidr = "10.0.0.0/16"
   azs      = slice(data.aws_availability_zones.available.names, 0, 3)
 
@@ -42,10 +40,10 @@ locals {
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 20.8"
+  version = "~> 20.11"
 
   cluster_name                   = local.name
-  cluster_version                = local.cluster_version
+  cluster_version                = "1.30"
   cluster_endpoint_public_access = true
 
   # Give the Terraform identity admin access to the cluster

--- a/patterns/aws-vpc-cni-network-policy/main.tf
+++ b/patterns/aws-vpc-cni-network-policy/main.tf
@@ -49,10 +49,10 @@ locals {
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 20.8"
+  version = "~> 20.11"
 
   cluster_name                   = local.name
-  cluster_version                = "1.29" # Must be 1.25 or higher
+  cluster_version                = "1.30" # Must be 1.25 or higher
   cluster_endpoint_public_access = true
 
   # Give the Terraform identity admin access to the cluster

--- a/patterns/external-secrets/main.tf
+++ b/patterns/external-secrets/main.tf
@@ -58,10 +58,10 @@ locals {
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 20.8"
+  version = "~> 20.11"
 
   cluster_name                   = local.name
-  cluster_version                = "1.29"
+  cluster_version                = "1.30"
   cluster_endpoint_public_access = true
 
   # Give the Terraform identity admin access to the cluster

--- a/patterns/fargate-serverless/main.tf
+++ b/patterns/fargate-serverless/main.tf
@@ -50,10 +50,10 @@ locals {
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 20.8"
+  version = "~> 20.11"
 
   cluster_name                   = local.name
-  cluster_version                = "1.29"
+  cluster_version                = "1.30"
   cluster_endpoint_public_access = true
 
   # Give the Terraform identity admin access to the cluster

--- a/patterns/fully-private-cluster/main.tf
+++ b/patterns/fully-private-cluster/main.tf
@@ -23,10 +23,10 @@ locals {
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 20.8"
+  version = "~> 20.11"
 
   cluster_name    = local.name
-  cluster_version = "1.29"
+  cluster_version = "1.30"
 
   # EKS Addons
   cluster_addons = {

--- a/patterns/ipv6-eks-cluster/main.tf
+++ b/patterns/ipv6-eks-cluster/main.tf
@@ -23,10 +23,10 @@ locals {
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 20.8"
+  version = "~> 20.11"
 
   cluster_name                   = local.name
-  cluster_version                = "1.29"
+  cluster_version                = "1.30"
   cluster_endpoint_public_access = true
 
   # IPV6

--- a/patterns/istio/main.tf
+++ b/patterns/istio/main.tf
@@ -52,10 +52,10 @@ locals {
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 20.8"
+  version = "~> 20.11"
 
   cluster_name                   = local.name
-  cluster_version                = "1.29"
+  cluster_version                = "1.30"
   cluster_endpoint_public_access = true
 
   # Give the Terraform identity admin access to the cluster

--- a/patterns/karpenter-mng/eks.tf
+++ b/patterns/karpenter-mng/eks.tf
@@ -4,10 +4,10 @@
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 20.10"
+  version = "~> 20.11"
 
   cluster_name    = local.name
-  cluster_version = "1.29"
+  cluster_version = "1.30"
 
   # Give the Terraform identity admin access to the cluster
   # which will allow it to deploy resources into the cluster
@@ -82,7 +82,7 @@ output "configure_kubectl" {
 
 module "karpenter" {
   source  = "terraform-aws-modules/eks/aws//modules/karpenter"
-  version = "~> 20.9"
+  version = "~> 20.11"
 
   cluster_name = module.eks.cluster_name
 
@@ -105,7 +105,7 @@ resource "helm_release" "karpenter" {
   repository_username = data.aws_ecrpublic_authorization_token.token.user_name
   repository_password = data.aws_ecrpublic_authorization_token.token.password
   chart               = "karpenter"
-  version             = "0.36.1"
+  version             = "0.36.2"
   wait                = false
 
   values = [

--- a/patterns/karpenter/main.tf
+++ b/patterns/karpenter/main.tf
@@ -59,10 +59,10 @@ locals {
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 20.8"
+  version = "~> 20.11"
 
   cluster_name                   = local.name
-  cluster_version                = "1.29"
+  cluster_version                = "1.30"
   cluster_endpoint_public_access = true
 
   vpc_id     = module.vpc.vpc_id

--- a/patterns/kubecost/main.tf
+++ b/patterns/kubecost/main.tf
@@ -38,10 +38,10 @@ locals {
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 20.8"
+  version = "~> 20.11"
 
   cluster_name                   = local.name
-  cluster_version                = "1.29"
+  cluster_version                = "1.30"
   cluster_endpoint_public_access = true
 
   # Give the Terraform identity admin access to the cluster

--- a/patterns/ml-capacity-block/eks.tf
+++ b/patterns/ml-capacity-block/eks.tf
@@ -16,10 +16,10 @@ variable "capacity_reservation_id" {
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 20.9"
+  version = "~> 20.11"
 
   cluster_name    = local.name
-  cluster_version = "1.29"
+  cluster_version = "1.30"
 
   # Give the Terraform identity admin access to the cluster
   # which will allow it to deploy resources into the cluster

--- a/patterns/nvidia-gpu-efa/eks.tf
+++ b/patterns/nvidia-gpu-efa/eks.tf
@@ -4,10 +4,10 @@
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 20.9"
+  version = "~> 20.11"
 
   cluster_name    = local.name
-  cluster_version = "1.29"
+  cluster_version = "1.30"
 
   # Give the Terraform identity admin access to the cluster
   # which will allow it to deploy resources into the cluster

--- a/patterns/private-public-ingress/main.tf
+++ b/patterns/private-public-ingress/main.tf
@@ -37,10 +37,10 @@ locals {
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 20.8"
+  version = "~> 20.11"
 
   cluster_name                   = local.name
-  cluster_version                = "1.29"
+  cluster_version                = "1.30"
   cluster_endpoint_public_access = true
 
   # Give the Terraform identity admin access to the cluster

--- a/patterns/privatelink-access/eks.tf
+++ b/patterns/privatelink-access/eks.tf
@@ -16,10 +16,10 @@ provider "kubernetes" {
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 20.8"
+  version = "~> 20.11"
 
   cluster_name    = local.name
-  cluster_version = "1.29"
+  cluster_version = "1.30"
 
   cluster_endpoint_public_access           = false
   enable_cluster_creator_admin_permissions = true

--- a/patterns/sso-iam-identity-center/main.tf
+++ b/patterns/sso-iam-identity-center/main.tf
@@ -35,10 +35,10 @@ locals {
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 20.8"
+  version = "~> 20.11"
 
   cluster_name                   = local.name
-  cluster_version                = "1.29"
+  cluster_version                = "1.30"
   cluster_endpoint_public_access = true
 
   # EKS Addons

--- a/patterns/sso-okta/main.tf
+++ b/patterns/sso-okta/main.tf
@@ -23,10 +23,10 @@ locals {
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 20.8"
+  version = "~> 20.11"
 
   cluster_name                   = local.name
-  cluster_version                = "1.29"
+  cluster_version                = "1.30"
   cluster_endpoint_public_access = true
 
   # EKS Addons

--- a/patterns/targeted-odcr/eks.tf
+++ b/patterns/targeted-odcr/eks.tf
@@ -13,10 +13,10 @@ variable "capacity_reservation_arns" {
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 20.9"
+  version = "~> 20.11"
 
   cluster_name    = local.name
-  cluster_version = "1.29"
+  cluster_version = "1.30"
 
   # Give the Terraform identity admin access to the cluster
   # which will allow it to deploy resources into the cluster

--- a/patterns/tls-with-aws-pca-issuer/main.tf
+++ b/patterns/tls-with-aws-pca-issuer/main.tf
@@ -52,10 +52,10 @@ locals {
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 20.8"
+  version = "~> 20.11"
 
   cluster_name                   = local.name
-  cluster_version                = "1.29"
+  cluster_version                = "1.30"
   cluster_endpoint_public_access = true
 
   # Give the Terraform identity admin access to the cluster

--- a/patterns/vpc-lattice/client-server-communication/eks.tf
+++ b/patterns/vpc-lattice/client-server-communication/eks.tf
@@ -4,10 +4,10 @@
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 20.8"
+  version = "~> 20.11"
 
   cluster_name                   = local.name
-  cluster_version                = "1.29"
+  cluster_version                = "1.30"
   cluster_endpoint_public_access = true
 
   # Give the Terraform identity admin access to the cluster

--- a/patterns/wireguard-with-cilium/eks.tf
+++ b/patterns/wireguard-with-cilium/eks.tf
@@ -4,10 +4,10 @@
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 20.8"
+  version = "~> 20.11"
 
   cluster_name                   = local.name
-  cluster_version                = "1.29"
+  cluster_version                = "1.30"
   cluster_endpoint_public_access = true
 
   # Give the Terraform identity admin access to the cluster


### PR DESCRIPTION
# Description

- Update EKS version to 1.30 where applicable

### Motivation and Context

- EKS released support for 1.30

### How was this change tested?

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR

### Additional Notes

<!-- Anything else we should know when reviewing? -->
