### PR TITLE
chore: Remove referenc to enable EFA on Karpenter MNG example

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
       - id: detect-aws-credentials
         args: [--allow-missing-credentials]
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.90.0
+    rev: v1.91.0
     hooks:
       - id: terraform_fmt
       - id: terraform_docs

--- a/patterns/karpenter-mng/eks.tf
+++ b/patterns/karpenter-mng/eks.tf
@@ -33,8 +33,6 @@ module "eks" {
     vpc-cni                = {}
   }
 
-  enable_efa_support = true
-
   vpc_id     = module.vpc.vpc_id
   subnet_ids = module.vpc.private_subnets
 


### PR DESCRIPTION
# Description

- Remove referenc to enable EFA on Karpenter MNG example

### Motivation and Context

- Copy+paste error, this does not belong in this pattern

### How was this change tested?

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR

### Additional Notes

<!-- Anything else we should know when reviewing? -->
