### PR TITLE
fix: Only tag cluster node security group for Karpenter

### DIFF
--- a/patterns/karpenter-mng/eks.tf
+++ b/patterns/karpenter-mng/eks.tf
@@ -61,12 +61,20 @@ module "eks" {
     }
   }
 
-  tags = merge(local.tags, {
+  # cluster_tags = merge(local.tags, {
+  #   NOTE - only use this option if you are using "attach_cluster_primary_security_group"
+  #   and you know what you're doing. In this case, you can remove the "node_security_group_tags" below.
+  #  "karpenter.sh/discovery" = local.name
+  # })
+
+  node_security_group_tags = merge(local.tags, {
     # NOTE - if creating multiple security groups with this module, only tag the
     # security group that Karpenter should utilize with the following tag
     # (i.e. - at most, only one security group should have this tag in your account)
     "karpenter.sh/discovery" = local.name
   })
+
+  tags = local.tags
 }
 
 output "configure_kubectl" {

--- a/patterns/karpenter-mng/main.tf
+++ b/patterns/karpenter-mng/main.tf
@@ -52,7 +52,13 @@ data "aws_ecrpublic_authorization_token" "token" {
   provider = aws.virginia
 }
 
-data "aws_availability_zones" "available" {}
+data "aws_availability_zones" "available" {
+  #Do not include local zones
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
 
 locals {
   name   = "ex-${basename(path.cwd)}"


### PR DESCRIPTION
# Description

<!--
🛑 Please open an issue first to discuss any significant work and flesh out details/direction - we would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/aws-ia/terraform-aws-eks-blueprints/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

A brief description of the change being made with this pull request.
-->

### Motivation and Context

<!-- What inspired you to submit this pull request? -->
- Resolves #1984 

The fix is similar to what have been done on EKS module : https://github.com/terraform-aws-modules/terraform-aws-eks/pull/3097

### How was this change tested?

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [x] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR

### Additional Notes

<!-- Anything else we should know when reviewing? -->
