### PR TITLE
chore: Update AWS provider to 'ecr' for ECR authentication

### DIFF
--- a/patterns/bottlerocket/addons.tf
+++ b/patterns/bottlerocket/addons.tf
@@ -2,7 +2,7 @@
 # EKS Blueprints Addons
 ################################################################################
 data "aws_ecrpublic_authorization_token" "token" {
-  provider = aws.virginia
+  provider = aws.ecr
 }
 
 module "eks_blueprints_addons" {

--- a/patterns/bottlerocket/main.tf
+++ b/patterns/bottlerocket/main.tf
@@ -18,9 +18,11 @@ provider "aws" {
   region = local.region
 }
 
+# This provider is required for ECR to autheticate with public repos. Please note ECR authetication requires us-east-1 as region hence its hardcoded below.
+# If your region is same as us-east-1 then you can just use one aws provider
 provider "aws" {
+  alias  = "ecr"
   region = "us-east-1"
-  alias  = "virginia"
 }
 
 provider "kubernetes" {

--- a/patterns/karpenter-mng/main.tf
+++ b/patterns/karpenter-mng/main.tf
@@ -24,10 +24,11 @@ provider "aws" {
   region = local.region
 }
 
-# Required for public ECR where Karpenter artifacts are hosted
+# This provider is required for ECR to autheticate with public repos. Please note ECR authetication requires us-east-1 as region hence its hardcoded below.
+# If your region is same as us-east-1 then you can just use one aws provider
 provider "aws" {
+  alias  = "ecr"
   region = "us-east-1"
-  alias  = "virginia"
 }
 
 provider "helm" {
@@ -49,7 +50,7 @@ provider "helm" {
 ################################################################################
 
 data "aws_ecrpublic_authorization_token" "token" {
-  provider = aws.virginia
+  provider = aws.ecr
 }
 
 data "aws_availability_zones" "available" {

--- a/patterns/karpenter/main.tf
+++ b/patterns/karpenter/main.tf
@@ -2,10 +2,11 @@ provider "aws" {
   region = local.region
 }
 
-# Required for public ECR where Karpenter artifacts are hosted
+# This provider is required for ECR to autheticate with public repos. Please note ECR authetication requires us-east-1 as region hence its hardcoded below.
+# If your region is same as us-east-1 then you can just use one aws provider
 provider "aws" {
+  alias  = "ecr"
   region = "us-east-1"
-  alias  = "virginia"
 }
 
 provider "kubernetes" {
@@ -35,7 +36,7 @@ provider "helm" {
 }
 
 data "aws_ecrpublic_authorization_token" "token" {
-  provider = aws.virginia
+  provider = aws.ecr
 }
 
 data "aws_availability_zones" "available" {}


### PR DESCRIPTION
# Description

- Updated AWS provider configuration to use alias 'ecr' and hardcode the region to 'us-east-1' for ECR authentication in patterns that use public ECR images and require authentication.

<!--
🛑 Please open an issue first to discuss any significant work and flesh out details/direction - we would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/aws-ia/terraform-aws-eks-blueprints/blob/main/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

A brief description of the change being made with this pull request.
-->

### Motivation and Context

<!-- What inspired you to submit this pull request? -->
- The intention is to keep the consistency in all repositories. This change ensures clear documentation and prevents users from mistakenly altering the region. 

### How was this change tested?

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [] Yes, I ran `pre-commit run -a` with this PR

### Additional Notes

There is a provider here [link](https://github.com/aws-ia/terraform-aws-eks-blueprints/blob/1975b53c9ebe5f8dcde979ccdae3d87dcb5e43cd/patterns/blue-green-upgrade/modules/eks_cluster/main.tf#L1C1-L5C2) with the old format, but it's not being used, so I didn't change it. Is it ok to update?