### PR TITLE
fix: Availability Zone AZs Data Source to filter Local Zones

### DIFF
--- a/patterns/agones-game-controller/main.tf
+++ b/patterns/agones-game-controller/main.tf
@@ -16,7 +16,13 @@ provider "helm" {
   }
 }
 
-data "aws_availability_zones" "available" {}
+data "aws_availability_zones" "available" {
+  # Do not include local zones
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
 
 locals {
   name   = basename(path.cwd)

--- a/patterns/aws-vpc-cni-network-policy/main.tf
+++ b/patterns/aws-vpc-cni-network-policy/main.tf
@@ -28,7 +28,13 @@ provider "helm" {
   }
 }
 
-data "aws_availability_zones" "available" {}
+data "aws_availability_zones" "available" {
+  # Do not include local zones
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
 
 locals {
   name   = basename(path.cwd)

--- a/patterns/blue-green-upgrade/environment/main.tf
+++ b/patterns/blue-green-upgrade/environment/main.tf
@@ -20,7 +20,13 @@ locals {
   }
 }
 
-data "aws_availability_zones" "available" {}
+data "aws_availability_zones" "available" {
+  # Do not include local zones
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
 
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"

--- a/patterns/blue-green-upgrade/modules/eks_cluster/main.tf
+++ b/patterns/blue-green-upgrade/modules/eks_cluster/main.tf
@@ -1,7 +1,7 @@
 # Required for public ECR where Karpenter artifacts are hosted
 provider "aws" {
   region = "us-east-1"
-  alias  = "virginia"
+  alias  = "ecr"
 }
 
 locals {

--- a/patterns/bottlerocket/addons.tf
+++ b/patterns/bottlerocket/addons.tf
@@ -42,7 +42,6 @@ module "eks_blueprints_addons" {
   karpenter = {
     repository_username = data.aws_ecrpublic_authorization_token.token.user_name
     repository_password = data.aws_ecrpublic_authorization_token.token.password
-    version             = "v0.36"
   }
 
   enable_bottlerocket_update_operator = true

--- a/patterns/bottlerocket/main.tf
+++ b/patterns/bottlerocket/main.tf
@@ -1,7 +1,13 @@
 ################################################################################
 # Providers
 ################################################################################
-data "aws_availability_zones" "available" {}
+data "aws_availability_zones" "available" {
+  # Do not include local zones
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
 
 data "aws_caller_identity" "current" {}
 

--- a/patterns/ecr-pull-through-cache/main.tf
+++ b/patterns/ecr-pull-through-cache/main.tf
@@ -48,7 +48,14 @@ provider "helm" {
 ################################################################################
 
 data "aws_caller_identity" "current" {}
-data "aws_availability_zones" "available" {}
+
+data "aws_availability_zones" "available" {
+  # Do not include local zones
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
 
 locals {
   name   = basename(path.cwd)

--- a/patterns/external-secrets/main.tf
+++ b/patterns/external-secrets/main.tf
@@ -30,7 +30,14 @@ provider "kubectl" {
   }
 }
 
-data "aws_availability_zones" "available" {}
+data "aws_availability_zones" "available" {
+  # Do not include local zones
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
+
 data "aws_caller_identity" "current" {}
 
 locals {

--- a/patterns/fargate-serverless/main.tf
+++ b/patterns/fargate-serverless/main.tf
@@ -28,7 +28,13 @@ provider "helm" {
   }
 }
 
-data "aws_availability_zones" "available" {}
+data "aws_availability_zones" "available" {
+  # Do not include local zones
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
 
 locals {
   name     = basename(path.cwd)

--- a/patterns/fully-private-cluster/main.tf
+++ b/patterns/fully-private-cluster/main.tf
@@ -2,7 +2,13 @@ provider "aws" {
   region = local.region
 }
 
-data "aws_availability_zones" "available" {}
+data "aws_availability_zones" "available" {
+  # Do not include local zones
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
 
 locals {
   name   = basename(path.cwd)

--- a/patterns/gitops/getting-started-argocd/main.tf
+++ b/patterns/gitops/getting-started-argocd/main.tf
@@ -1,8 +1,16 @@
 provider "aws" {
   region = local.region
 }
+
 data "aws_caller_identity" "current" {}
-data "aws_availability_zones" "available" {}
+
+data "aws_availability_zones" "available" {
+  # Do not include local zones
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
 
 provider "helm" {
   kubernetes {

--- a/patterns/gitops/multi-cluster-hub-spoke-argocd/hub/main.tf
+++ b/patterns/gitops/multi-cluster-hub-spoke-argocd/hub/main.tf
@@ -1,8 +1,16 @@
 provider "aws" {
   region = local.region
 }
+
 data "aws_caller_identity" "current" {}
-data "aws_availability_zones" "available" {}
+
+data "aws_availability_zones" "available" {
+  # Do not include local zones
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
 
 provider "helm" {
   kubernetes {

--- a/patterns/gitops/multi-cluster-hub-spoke-argocd/spokes/main.tf
+++ b/patterns/gitops/multi-cluster-hub-spoke-argocd/spokes/main.tf
@@ -1,9 +1,16 @@
 provider "aws" {
   region = local.region
 }
-data "aws_caller_identity" "current" {}
-data "aws_availability_zones" "available" {}
 
+data "aws_caller_identity" "current" {}
+
+data "aws_availability_zones" "available" {
+  # Do not include local zones
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
 
 data "terraform_remote_state" "cluster_hub" {
   backend = "local"

--- a/patterns/ipv6-eks-cluster/main.tf
+++ b/patterns/ipv6-eks-cluster/main.tf
@@ -2,7 +2,13 @@ provider "aws" {
   region = local.region
 }
 
-data "aws_availability_zones" "available" {}
+data "aws_availability_zones" "available" {
+  # Do not include local zones
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
 
 locals {
   name   = basename(path.cwd)

--- a/patterns/istio/main.tf
+++ b/patterns/istio/main.tf
@@ -28,7 +28,13 @@ provider "helm" {
   }
 }
 
-data "aws_availability_zones" "available" {}
+data "aws_availability_zones" "available" {
+  # Do not include local zones
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
 
 locals {
   name   = basename(path.cwd)

--- a/patterns/karpenter-mng/main.tf
+++ b/patterns/karpenter-mng/main.tf
@@ -54,7 +54,7 @@ data "aws_ecrpublic_authorization_token" "token" {
 }
 
 data "aws_availability_zones" "available" {
-  #Do not include local zones
+  # Do not include local zones
   filter {
     name   = "opt-in-status"
     values = ["opt-in-not-required"]

--- a/patterns/karpenter/main.tf
+++ b/patterns/karpenter/main.tf
@@ -39,7 +39,13 @@ data "aws_ecrpublic_authorization_token" "token" {
   provider = aws.ecr
 }
 
-data "aws_availability_zones" "available" {}
+data "aws_availability_zones" "available" {
+  # Do not include local zones
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
 
 locals {
   name   = "ex-${basename(path.cwd)}"

--- a/patterns/kubecost/main.tf
+++ b/patterns/kubecost/main.tf
@@ -16,8 +16,15 @@ provider "helm" {
   }
 }
 
-data "aws_availability_zones" "available" {}
 data "aws_caller_identity" "current" {}
+
+data "aws_availability_zones" "available" {
+  # Do not include local zones
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
 
 locals {
   name   = basename(path.cwd)

--- a/patterns/ml-capacity-block/main.tf
+++ b/patterns/ml-capacity-block/main.tf
@@ -42,7 +42,13 @@ provider "helm" {
 # Common data/locals
 ################################################################################
 
-data "aws_availability_zones" "available" {}
+data "aws_availability_zones" "available" {
+  # Do not include local zones
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
 
 locals {
   name   = basename(path.cwd)

--- a/patterns/multi-tenancy-with-teams/main.tf
+++ b/patterns/multi-tenancy-with-teams/main.tf
@@ -13,7 +13,14 @@ data "aws_eks_cluster_auth" "this" {
 }
 
 data "aws_caller_identity" "current" {}
-data "aws_availability_zones" "available" {}
+
+data "aws_availability_zones" "available" {
+  # Do not include local zones
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
 
 locals {
   name   = basename(path.cwd)

--- a/patterns/nvidia-gpu-efa/main.tf
+++ b/patterns/nvidia-gpu-efa/main.tf
@@ -42,7 +42,13 @@ provider "helm" {
 # Common data/locals
 ################################################################################
 
-data "aws_availability_zones" "available" {}
+data "aws_availability_zones" "available" {
+  # Do not include local zones
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
 
 locals {
   name   = basename(path.cwd)

--- a/patterns/private-public-ingress/main.tf
+++ b/patterns/private-public-ingress/main.tf
@@ -16,7 +16,13 @@ provider "helm" {
   }
 }
 
-data "aws_availability_zones" "available" {}
+data "aws_availability_zones" "available" {
+  # Do not include local zones
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
 
 locals {
   name   = basename(path.cwd)

--- a/patterns/privatelink-access/main.tf
+++ b/patterns/privatelink-access/main.tf
@@ -2,7 +2,13 @@ provider "aws" {
   region = local.region
 }
 
-data "aws_availability_zones" "available" {}
+data "aws_availability_zones" "available" {
+  # Do not include local zones
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
 
 locals {
   name   = basename(path.cwd)

--- a/patterns/sso-iam-identity-center/main.tf
+++ b/patterns/sso-iam-identity-center/main.tf
@@ -14,7 +14,13 @@ provider "kubernetes" {
   }
 }
 
-data "aws_availability_zones" "available" {}
+data "aws_availability_zones" "available" {
+  # Do not include local zones
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
 
 locals {
   name   = "sso-${basename(path.cwd)}"

--- a/patterns/sso-okta/main.tf
+++ b/patterns/sso-okta/main.tf
@@ -2,7 +2,13 @@ provider "aws" {
   region = local.region
 }
 
-data "aws_availability_zones" "available" {}
+data "aws_availability_zones" "available" {
+  # Do not include local zones
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
 
 locals {
   name   = basename(path.cwd)

--- a/patterns/stateful/main.tf
+++ b/patterns/stateful/main.tf
@@ -29,7 +29,14 @@ provider "helm" {
 }
 
 data "aws_caller_identity" "current" {}
-data "aws_availability_zones" "available" {}
+
+data "aws_availability_zones" "available" {
+  # Do not include local zones
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
 
 locals {
   name   = basename(path.cwd)

--- a/patterns/targeted-odcr/main.tf
+++ b/patterns/targeted-odcr/main.tf
@@ -42,7 +42,13 @@ provider "helm" {
 # Common data/locals
 ################################################################################
 
-data "aws_availability_zones" "available" {}
+data "aws_availability_zones" "available" {
+  # Do not include local zones
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
 
 locals {
   name   = basename(path.cwd)

--- a/patterns/tls-with-aws-pca-issuer/main.tf
+++ b/patterns/tls-with-aws-pca-issuer/main.tf
@@ -30,7 +30,13 @@ provider "kubectl" {
   }
 }
 
-data "aws_availability_zones" "available" {}
+data "aws_availability_zones" "available" {
+  # Do not include local zones
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
 
 locals {
   name   = basename(path.cwd)

--- a/patterns/wireguard-with-cilium/main.tf
+++ b/patterns/wireguard-with-cilium/main.tf
@@ -42,7 +42,13 @@ provider "helm" {
 # Common data/locals
 ################################################################################
 
-data "aws_availability_zones" "available" {}
+data "aws_availability_zones" "available" {
+  # Do not include local zones
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
 
 locals {
   name   = basename(path.cwd)


### PR DESCRIPTION
# Description

Add a filter block on the availability zones data to exclude Local Zones.
Removing version filter for Karpenter helm chart on Bottlerocket pattern.

### Motivation and Context

Patterns deployments fail when Local Zones are enabled in the account. Adding filter to avoid the deployment on accounts with Local Zones enabled.
The parameter for the chart version is wrong on the Bottlerocket pattern, falling on the module default. Removing the version constraint.

### How was this change tested?

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [X] Yes, I ran `pre-commit run -a` with this PR

### Additional Notes

<!-- Anything else we should know when reviewing? -->
