### PR TITLE
chore(karpenter): Ignore kubernetes_groups changes in lifecycle

### DIFF
--- a/patterns/karpenter/main.tf
+++ b/patterns/karpenter/main.tf
@@ -169,6 +169,16 @@ resource "aws_eks_access_entry" "karpenter_node_access_entry" {
   principal_arn     = module.eks_blueprints_addons.karpenter.node_iam_role_arn
   kubernetes_groups = []
   type              = "EC2_LINUX"
+
+  # EKS automatically adds the 'system:nodes' group to kubernetes_groups.
+  # Terraform detects this auto-added group and attempts to remove it.
+  # To prevent this, we ignore changes to kubernetes_groups.
+  # This avoids unnecessary drift between Terraform state and actual EKS state.
+  lifecycle {
+    ignore_changes = [
+      kubernetes_groups
+    ]
+  }
 }
 
 ################################################################################


### PR DESCRIPTION
![CleanShot 2024-09-18 at 16 42 42@2x](https://github.com/user-attachments/assets/e126557a-a759-465d-b8dd-f1750f64c8a0)
Currently there is a situation where a diff always appears.
It is a diff that cannot be applied.
Therefore, they are now included in ignore_changes.