### PR TITLE
chore: Correct mis-spellings, ignore files with generated content from pre-commit checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     rev: v8.13.3
     hooks:
       - id: cspell
-        args: [--exclude, 'ADOPTERS.md', --exclude, '.pre-commit-config.yaml', --exclude, '.gitignore', --exclude, '*.drawio', --exclude, 'mkdocs.yml', --exclude, '.helmignore', --exclude, '.github/workflows/*', --exclude, 'patterns/istio-multi-cluster/*', --exclude, 'patterns/blue-green-upgrade/*']
+        args: [--exclude, 'ADOPTERS.md', --exclude, '.pre-commit-config.yaml', --exclude, '.gitignore', --exclude, '*.drawio', --exclude, 'mkdocs.yml', --exclude, '.helmignore', --exclude, '.github/workflows/*', --exclude, 'patterns/istio-multi-cluster/*', --exclude, 'patterns/blue-green-upgrade/*', --exclude, '/patterns/vpc-lattice/cross-cluster-pod-communication/*', --exclude, 'patterns/bottlerocket/*', --exclude, 'patterns/nvidia-gpu-efa/generate-efa-nccl-test.sh']
   - repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
     rev: v2.14.0
     hooks:
@@ -19,7 +19,7 @@ repos:
       - id: detect-aws-credentials
         args: [--allow-missing-credentials]
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.92.1
+    rev: v1.96.1
     hooks:
       - id: terraform_fmt
       - id: terraform_docs

--- a/docs/cSpell_dict.txt
+++ b/docs/cSpell_dict.txt
@@ -1,10 +1,12 @@
 acmpca
 acmca_arn
 addrs
+adduser
 adot
 agones
 akuity
 alekc
+alertmanager
 algbw
 ALLOWVOLUMEEXPANSION
 amazonlinux
@@ -56,6 +58,7 @@ daemonset
 datasource
 dcgm
 distro
+dockerhub
 ecrpublic
 ecsdemo
 ecsfrontend
@@ -108,6 +111,7 @@ mktemp
 mountpoint
 mpijob
 mpijobs
+mpirun
 mtls
 nccl
 netcat
@@ -115,12 +119,17 @@ nics
 nodeadm
 nodegroup
 nodeport
+nopasswd
 nvme
 odcr
 oidc
+openmpi
+openpolicyagent
 persistentvolume
 pkce
 pubkey
+pullthroughcache
+ecrpullthroughcache
 privateca
 privatelink
 prometheusservice

--- a/patterns/ecr-pull-through-cache/ecr.tf
+++ b/patterns/ecr-pull-through-cache/ecr.tf
@@ -4,7 +4,7 @@ module "secrets_manager" {
 
   name                    = "ecr-pullthroughcache/docker"
   secret_string           = jsonencode(var.docker_secret)
-  recovery_window_in_days = 0 # Set to 0 for testing purposes, this will immediatly delete the secret. This action is irreversible. https://docs.aws.amazon.com/secretsmanager/latest/apireference/API_DeleteSecret.html
+  recovery_window_in_days = 0 # Set to 0 for testing purposes, this will immediately delete the secret. This action is irreversible. https://docs.aws.amazon.com/secretsmanager/latest/apireference/API_DeleteSecret.html
 }
 
 module "ecr" {

--- a/patterns/ecr-pull-through-cache/variables.tf
+++ b/patterns/ecr-pull-through-cache/variables.tf
@@ -1,5 +1,5 @@
 variable "docker_secret" {
-  description = "Inform your docker username and accessToken to allow pullTroughCache to get images from Docekr.io. E.g. `{username='user',accessToken='pass'}`"
+  description = "Inform your docker username and accessToken to allow pullTroughCache to get images from Docker.io. E.g. `{username='user',accessToken='pass'}`"
   type = object({
     username    = string
     accessToken = string

--- a/patterns/karpenter-mng/main.tf
+++ b/patterns/karpenter-mng/main.tf
@@ -24,7 +24,7 @@ provider "aws" {
   region = local.region
 }
 
-# This provider is required for ECR to autheticate with public repos. Please note ECR authetication requires us-east-1 as region hence its hardcoded below.
+# This provider is required for ECR to authenticate with public repos. Please note ECR authentication requires us-east-1 as region hence its hardcoded below.
 # If your region is same as us-east-1 then you can just use one aws provider
 provider "aws" {
   alias  = "ecr"

--- a/patterns/karpenter/main.tf
+++ b/patterns/karpenter/main.tf
@@ -2,7 +2,7 @@ provider "aws" {
   region = local.region
 }
 
-# This provider is required for ECR to authenticate with public repos. Please note ECR authetication requires us-east-1 as region hence its hardcoded below.
+# This provider is required for ECR to authenticate with public repos. Please note ECR authentication requires us-east-1 as region hence its hardcoded below.
 # If your region is same as us-east-1 then you can just use one aws provider
 provider "aws" {
   alias  = "ecr"


### PR DESCRIPTION
# Description

- Correct mis-spellings, ignore files with generated content from pre-commit checks
- 
### Motivation and Context

<!-- What inspired you to submit this pull request? -->
- Closes #2012 

### How was this change tested?

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR

### Additional Notes

<!-- Anything else we should know when reviewing? -->
