### PR TITLE
chore: Update docs to include code section titles and updated EFA results

### DIFF
--- a/docs/patterns/network/vpc-lattice.md
+++ b/docs/patterns/network/vpc-lattice.md
@@ -1,7 +1,0 @@
----
-title: VPC lattice
----
-
-{%
-   include-markdown "../../../patterns/vpc-lattice/README.md"
-%}

--- a/patterns/aws-neuron-efa/README.md
+++ b/patterns/aws-neuron-efa/README.md
@@ -17,9 +17,13 @@ The following components are demonstrated in this pattern:
 
 ## Code
 
+### Cluster
+
 ```terraform hl_lines="26-28 34-80"
 {% include  "../../patterns/aws-neuron-efa/eks.tf" %}
 ```
+
+### Device Plugins
 
 ```terraform hl_lines="9-50"
 {% include  "../../patterns/aws-neuron-efa/helm.tf" %}

--- a/patterns/vpc-lattice/README.md
+++ b/patterns/vpc-lattice/README.md
@@ -5,10 +5,9 @@ This folder contains use case-driven patterns covering different aspects of the 
 ## Use cases
 
 - [Simple Client to Server Communication](./client-server-communication/)
-    - This pattern describes how to expose a simple API within an Amazon EKS cluster deployed in VPC A to a client application hosted in VPC B through Amazon VPC Lattice.
+  - This pattern describes how to expose a simple API within an Amazon EKS cluster deployed in VPC A to a client application hosted in VPC B through Amazon VPC Lattice.
 - [Cross VPC and EKS clusters secure Communication](./cross-cluster-pod-communication/)
-    - This patterns shows how to make 2 services in 2 different EKS clusters and VPC can communicate securely on private domain and sigV4 authorization.
-
+  - This patterns shows how to make 2 services in 2 different EKS clusters and VPC can communicate securely on private domain and sigV4 authorization.
 
 ## Supporting resources
 


### PR DESCRIPTION
# Description

- Remove link to pattern sub-directory README which is not intended to be rendered on doc site - the links are currently broken and its not shown as nested
- Update EFA results shown on NVIDIA GPU w/ EFA - perf improvements reflected in latest results
- Add titles to the code sections on the EFA patterns
- Fix bullet indention to show second order grouping

### Motivation and Context

<!-- What inspired you to submit this pull request? -->
- Resolves #<issue-number>

### How was this change tested?

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR

### Additional Notes

<!-- Anything else we should know when reviewing? -->
