### PR TITLE
docs: Fix vpc-cni-custoom-networking doc

### DIFF
--- a/docs/snippets/vpc-cni-custom-networking.md
+++ b/docs/snippets/vpc-cni-custom-networking.md
@@ -57,7 +57,7 @@ To enable VPC CNI custom networking, you must configuring the following componen
             env = {
                AWS_VPC_K8S_CNI_CUSTOM_NETWORK_CFG = "true"
                ENI_CONFIG_LABEL_DEF               = "topology.kubernetes.io/zone"
-            })
+            }})
          }
       }
 


### PR DESCRIPTION
Just a simple syntax issue in the doc example.  Just missing a single }

