### PR TITLE
refactor: Updates to privatelink-access based on latest working pattern

### DIFF
--- a/patterns/privatelink-access/client.tf
+++ b/patterns/privatelink-access/client.tf
@@ -11,7 +11,7 @@ locals {
 
 module "client_vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "~> 5.0"
+  version = "~> 5.17"
 
   name = local.client_name
   cidr = local.vpc_cidr
@@ -94,7 +94,7 @@ resource "aws_iam_policy" "eks_full_access_policy" {
 
 module "client_security_group" {
   source  = "terraform-aws-modules/security-group/aws"
-  version = "~> 5.0"
+  version = "~> 5.3"
 
   name        = local.client_name
   description = "Security group for SSM access to private cluster"

--- a/patterns/privatelink-access/eks.tf
+++ b/patterns/privatelink-access/eks.tf
@@ -46,14 +46,13 @@ module "eks" {
   }
 
   cluster_security_group_additional_rules = {
-    # Allow tcp/443 from the NLB IP addresses
-    for ip_addr in data.dns_a_record_set.nlb.addrs : "nlb_ingress_${replace(ip_addr, ".", "")}" => {
-      description = "Allow ingress from NLB"
-      type        = "ingress"
+    private_subnets = {
+      cidr_blocks = module.vpc.private_subnets_cidr_blocks
+      description = "Allow ingress from vpc private subnets"
       from_port   = 443
       to_port     = 443
       protocol    = "tcp"
-      cidr_blocks = ["${ip_addr}/32"]
+      type        = "ingress"
     }
   }
 

--- a/patterns/privatelink-access/versions.tf
+++ b/patterns/privatelink-access/versions.tf
@@ -6,10 +6,6 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 5.34"
     }
-    dns = {
-      source  = "hashicorp/dns"
-      version = ">= 3.0"
-    }
     kubernetes = {
       source  = "hashicorp/kubernetes"
       version = ">= 2.20"


### PR DESCRIPTION
# Description
We have used the `privatelink-access` pattern internally and it mostly worked all good. In this PR included are some minor updates that we had to do to make it work:
- Bumping up module versions
- Simplifying security groups to use CIDRs
- Fixing health check to use TCP and not HTTPS as we are using an NLB
- Adding an egress security group rule to allow the NLB to communicate with the EKS cluster

### Motivation and Context
We needed to follow this pattern to connect two VPCs in different accounts and one was hosting an EKS cluster. Contributing back changes that we had to make in order to make the pattern work.

### How was this change tested?

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [x] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR

### Additional Notes
N/A
