### PR TITLE
fix: set IRSA service account in EKS Fargate pattern

### DIFF
--- a/patterns/karpenter/karpenter.tf
+++ b/patterns/karpenter/karpenter.tf
@@ -1,5 +1,6 @@
 locals {
-  namespace = "karpenter"
+  namespace            = "karpenter"
+  service_account_name = "karpenter"
 }
 
 ################################################################################
@@ -22,6 +23,9 @@ module "karpenter" {
   create_pod_identity_association = false
   enable_irsa                     = true
   irsa_oidc_provider_arn          = module.eks.oidc_provider_arn
+  irsa_namespace_service_accounts = [
+    "${local.namespace}:${local.service_account_name}"
+  ]
 
   tags = local.tags
 }
@@ -51,6 +55,7 @@ resource "helm_release" "karpenter" {
     serviceAccount:
       annotations:
         eks.amazonaws.com/role-arn: ${module.karpenter.iam_role_arn}
+      name: ${local.service_account_name}
     webhook:
       enabled: false
     EOT


### PR DESCRIPTION
# Description

### Motivation and Context

Current EKS Fargate pattern doesn't explicitly set the IRSA service account. However, it assumes the namespace and service account name are both `karpenter` when not provided. This causes failure if the user deploys to different namespace or use different helm release name.

This commit resolves this by explicitly setting `irsa_namespace_service_accounts` with the namespace and service account name variable to ensure correct IRSA configuration.

- https://github.com/terraform-aws-modules/terraform-aws-eks/blob/c60b70fbc80606eb4ed8cf47063ac6ed0d8dd435/modules/karpenter/variables.tf#L142-L146
- https://github.com/aws/karpenter-provider-aws/blob/002856721e612ded9f3f09821ed9ec2823d8af06/charts/karpenter/values.yaml#L18-L20

### How was this change tested?

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [x] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR

### Additional Notes

<!-- Anything else we should know when reviewing? -->
