### PR TITLE
chore: Update ML pattern dependencies to latest

### DIFF
--- a/.github/scripts/mkdocs-hooks.py
+++ b/.github/scripts/mkdocs-hooks.py
@@ -10,12 +10,11 @@ def on_page_markdown(markdown, **kwargs):
 
 def on_files(files, config, **kwargs):
     # Add targeted-odcr screenshots to the generated build
-    path = 'patterns/targeted-odcr/assets/'
     for odcr_file in [1, 2]:
         files.append(
             File(
-                src_dir=f'./{path}',
-                dest_dir=os.path.join(config.site_dir, path),
+                src_dir='./patterns/targeted-odcr/assets/',
+                dest_dir=os.path.join(config.site_dir, 'patterns/machine-learning/targeted-odcr/assets/'),
                 path=f'odcr-screenshot{odcr_file}.png',
                 use_directory_urls=True
             )
@@ -34,7 +33,7 @@ def on_files(files, config, **kwargs):
     for svg in ['cached.svg', 'uncached.svg', 'state-machine.png']:
         files.append(
             File(
-                src_dir=f'./patterns/ml-container-cache/assets/',
+                src_dir='./patterns/ml-container-cache/assets/',
                 dest_dir=os.path.join(config.site_dir, 'patterns/machine-learning/ml-container-cache/assets/'),
                 path=svg,
                 use_directory_urls=True

--- a/patterns/aws-neuron-efa/README.md
+++ b/patterns/aws-neuron-efa/README.md
@@ -19,7 +19,7 @@ The following components are demonstrated in this pattern:
 
 ### Cluster
 
-```terraform hl_lines="26-28 34-80"
+```terraform hl_lines="32-34 40-86"
 {% include  "../../patterns/aws-neuron-efa/eks.tf" %}
 ```
 
@@ -43,10 +43,10 @@ See [here](https://aws-ia.github.io/terraform-aws-eks-blueprints/getting-started
 
     ```text
     NAME                                        STATUS   ROLES    AGE   VERSION               INSTANCE-TYPE
-    ip-10-0-12-200.us-east-2.compute.internal   Ready    <none>   82m   v1.31.0-eks-a737599   m5.large
-    ip-10-0-24-248.us-east-2.compute.internal   Ready    <none>   82m   v1.31.0-eks-a737599   m5.large
-    ip-10-0-39-213.us-east-2.compute.internal   Ready    <none>   75m   v1.31.0-eks-a737599   trn1.32xlarge
-    ip-10-0-43-172.us-east-2.compute.internal   Ready    <none>   75m   v1.31.0-eks-a737599   trn1.32xlarge
+    ip-10-0-12-200.us-east-2.compute.internal   Ready    <none>   82m   v1.32.0-eks-a737599   m5.large
+    ip-10-0-24-248.us-east-2.compute.internal   Ready    <none>   82m   v1.32.0-eks-a737599   m5.large
+    ip-10-0-39-213.us-east-2.compute.internal   Ready    <none>   75m   v1.32.0-eks-a737599   trn1.32xlarge
+    ip-10-0-43-172.us-east-2.compute.internal   Ready    <none>   75m   v1.32.0-eks-a737599   trn1.32xlarge
     ```
 
     You should see two EFA-enabled (in this example `trn1.32xlarge`) nodes in the list.

--- a/patterns/aws-neuron-efa/eks.tf
+++ b/patterns/aws-neuron-efa/eks.tf
@@ -4,22 +4,28 @@
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 20.26"
+  version = "~> 20.34"
 
   cluster_name    = local.name
-  cluster_version = "1.31"
+  cluster_version = "1.32"
 
   # Give the Terraform identity admin access to the cluster
   # which will allow it to deploy resources into the cluster
   enable_cluster_creator_admin_permissions = true
   cluster_endpoint_public_access           = true
 
+  # These will become the default in the next major version of the module
+  bootstrap_self_managed_addons   = false
+  enable_irsa                     = false
+  enable_security_groups_for_pods = false
+
   cluster_addons = {
     coredns                = {}
     eks-pod-identity-agent = {}
     kube-proxy             = {}
     vpc-cni = {
-      most_recent = true
+      most_recent    = true
+      before_compute = true
     }
   }
 

--- a/patterns/aws-neuron-efa/helm.tf
+++ b/patterns/aws-neuron-efa/helm.tf
@@ -10,7 +10,7 @@ resource "helm_release" "neuron" {
   name             = "neuron"
   repository       = "oci://public.ecr.aws/neuron"
   chart            = "neuron-helm-chart"
-  version          = "1.0.0"
+  version          = "1.1.1"
   namespace        = "neuron"
   create_namespace = true
   wait             = false
@@ -33,7 +33,7 @@ resource "helm_release" "aws_efa_device_plugin" {
   name       = "aws-efa-k8s-device-plugin"
   repository = "https://aws.github.io/eks-charts"
   chart      = "aws-efa-k8s-device-plugin"
-  version    = "v0.5.5"
+  version    = "v0.5.7"
   namespace  = "kube-system"
   wait       = false
 

--- a/patterns/ml-capacity-block/README.md
+++ b/patterns/ml-capacity-block/README.md
@@ -2,7 +2,7 @@
 
 This pattern demonstrates how to consume/utilize ML capacity block reservations (CBR) with Amazon EKS. The solution is comprised of primarily of the following components:
 
-1. The node group, either EKS managed or self-managed, that will utilize the CBR should have the subnets provided to it restricted to the availability zone where the CBR has been allocated. For example - if the CBR is allocated to `us-west-2b`, the node group should only have subnet IDs provided to it that reside in `us-west-2b`. If the subnets that reside in other AZs are provided, its possible to encounter an error such as `InvalidParameterException: The following supplied instance types do not exist ...`. It is not guaranteed that this error will always be shown, and may appear random since the underlying autoscaling group(s) will provision nodes into different AZs at random. It will only occur when the underlying autoscaling group tries to provision instances into an AZ where capacity is not allocated and there is insufficient on-demand capacity for the desired instance type.
+1. EKS managed node group that will utilize the CBR should have the subnets provided to it restricted to the availability zone where the CBR has been allocated. For example - if the CBR is allocated to `us-west-2b`, the node group should only have subnet IDs provided to it that reside in `us-west-2b`. If the subnets that reside in other AZs are provided, its possible to encounter an error such as `InvalidParameterException: The following supplied instance types do not exist ...`. It is not guaranteed that this error will always be shown, and may appear random since the underlying autoscaling group(s) will provision nodes into different AZs at random. It will only occur when the underlying autoscaling group tries to provision instances into an AZ where capacity is not allocated and there is insufficient on-demand capacity for the desired instance type.
 2. The launch template utilized should specify the `instance_market_options` and `capacity_reservation_specification` arguments. This is how the CBR is utilized by the node group (i.e. - tells the autoscaling group to launch instances utilizing provided capacity reservation).
 3. In the case of EKS managed node group(s), the `capacity_type` should be set to `"CAPACITY_BLOCK"`.
 
@@ -13,7 +13,7 @@ This pattern demonstrates how to consume/utilize ML capacity block reservations 
 
 ## Code
 
-```terraform hl_lines="5-11 93-107 119-122 161-174"
+```terraform hl_lines="5-11 99-113"
 {% include  "../../patterns/ml-capacity-block/eks.tf" %}
 ```
 

--- a/patterns/ml-capacity-block/eks.tf
+++ b/patterns/ml-capacity-block/eks.tf
@@ -16,22 +16,28 @@ variable "capacity_reservation_id" {
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 20.26"
+  version = "~> 20.34"
 
   cluster_name    = local.name
-  cluster_version = "1.31"
+  cluster_version = "1.32"
 
   # Give the Terraform identity admin access to the cluster
   # which will allow it to deploy resources into the cluster
   enable_cluster_creator_admin_permissions = true
   cluster_endpoint_public_access           = true
 
+  # These will become the default in the next major version of the module
+  bootstrap_self_managed_addons   = false
+  enable_irsa                     = false
+  enable_security_groups_for_pods = false
+
   cluster_addons = {
     coredns                = {}
     eks-pod-identity-agent = {}
     kube-proxy             = {}
     vpc-cni = {
-      most_recent = true
+      most_recent    = true
+      before_compute = true
     }
   }
 
@@ -113,65 +119,6 @@ module "eks" {
       min_size     = 2
       max_size     = 2
       desired_size = 2
-    }
-  }
-
-  # Self-managed node group equivalent for ML capacity block reservation
-  # This is not required for ML CBR support with EKS managed node groups,
-  # its just showing use with both node group types. Users should select
-  # the one that works for their use case.
-  self_managed_node_groups = {
-    cbr2 = {
-      # The EKS AL2023 NVIDIA AMI provides all of the necessary components
-      # for accelerated workloads w/ EFA
-      ami_type      = "AL2023_x86_64_NVIDIA"
-      instance_type = "p5e.48xlarge"
-
-      # Mount instance store volumes in RAID-0 for kubelet and containerd
-      # https://github.com/awslabs/amazon-eks-ami/blob/master/doc/USER_GUIDE.md#raid-0-for-kubelet-and-containerd-raid0
-      cloudinit_pre_nodeadm = [
-        {
-          content_type = "application/node.eks.aws"
-          content      = <<-EOT
-            ---
-            apiVersion: node.eks.aws/v1alpha1
-            kind: NodeConfig
-            spec:
-              instance:
-                localStorage:
-                  strategy: RAID0
-              kubelet:
-                flags:
-                  - --node-labels=vpc.amazonaws.com/efa.present=true,nvidia.com/gpu.present=true
-                  - --register-with-taints=nvidia.com/gpu=true:NoSchedule
-          EOT
-        }
-      ]
-
-      min_size     = 2
-      max_size     = 2
-      desired_size = 2
-
-      # This will:
-      # 1. Create a placement group to place the instances close to one another
-      # 2. Ignore subnets that reside in AZs that do not support the instance type
-      # 3. Expose all of the available EFA interfaces on the launch template
-      enable_efa_support = true
-
-      # First subnet is in the "${local.region}a" availability zone
-      # where the capacity reservation is created
-      # TODO - Update the subnet to match the availability zone of *YOUR capacity reservation
-      subnet_ids = [element(module.vpc.private_subnets, 0)]
-
-      # ML capacity block reservation
-      instance_market_options = {
-        market_type = "capacity-block"
-      }
-      capacity_reservation_specification = {
-        capacity_reservation_target = {
-          capacity_reservation_id = var.capacity_reservation_id
-        }
-      }
     }
   }
 

--- a/patterns/ml-capacity-block/helm.tf
+++ b/patterns/ml-capacity-block/helm.tf
@@ -6,7 +6,7 @@ resource "helm_release" "nvidia_device_plugin" {
   name             = "nvidia-device-plugin"
   repository       = "https://nvidia.github.io/k8s-device-plugin"
   chart            = "nvidia-device-plugin"
-  version          = "0.16.2"
+  version          = "0.17.1"
   namespace        = "nvidia-device-plugin"
   create_namespace = true
   wait             = false
@@ -16,7 +16,7 @@ resource "helm_release" "aws_efa_device_plugin" {
   name       = "aws-efa-k8s-device-plugin"
   repository = "https://aws.github.io/eks-charts"
   chart      = "aws-efa-k8s-device-plugin"
-  version    = "v0.5.5"
+  version    = "v0.5.7"
   namespace  = "kube-system"
   wait       = false
 

--- a/patterns/ml-container-cache/README.md
+++ b/patterns/ml-container-cache/README.md
@@ -15,7 +15,7 @@ The main benefit of caching, or pre-pulling, container images onto an EBS volume
 
 ## Results
 
-The following results use the PyTorch [nvcr.io/nvidia/pytorch:24.08-py3](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/pytorch/tags) image which is 9.5 GB compressed and 20.4 GB decompressed on disk.
+The following results use the PyTorch [nvcr.io/nvidia/pytorch:25.02-py3](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/pytorch/tags) image which is 9.5 GB compressed and 20.4 GB decompressed on disk.
 
 Pod start up time duration is captured via pod events using [ktime](https://github.com/clowdhaus/ktime).
 
@@ -45,7 +45,7 @@ When the PyTorch image is not present on the EBS volume, it takes roughly 6 minu
 
 ### Cluster
 
-```terraform hl_lines="5-9 52-64 66-78"
+```terraform hl_lines="5-9 56-68 70-82"
 {% include  "../../patterns/ml-container-cache/eks.tf" %}
 ```
 

--- a/patterns/ml-container-cache/cache_builder.tf
+++ b/patterns/ml-container-cache/cache_builder.tf
@@ -6,8 +6,8 @@ module "ebs_snapshot_builder" {
 
   # Images to cache
   public_images = [
-    "nvcr.io/nvidia/k8s-device-plugin:v0.16.2", # 120 MB compressed / 351 MB decompressed
-    "nvcr.io/nvidia/pytorch:24.08-py3",         # 9.5 GB compressed / 20.4 GB decompressed
+    "nvcr.io/nvidia/k8s-device-plugin:v0.17.1", # 120 MB compressed / 351 MB decompressed
+    "nvcr.io/nvidia/pytorch:25.02-py3",         # 9.5 GB compressed / 20.4 GB decompressed
   ]
 
   # AZs where EBS fast snapshot restore will be enabled

--- a/patterns/ml-container-cache/eks.tf
+++ b/patterns/ml-container-cache/eks.tf
@@ -14,29 +14,33 @@ data "aws_ssm_parameter" "snapshot_id" {
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 20.24"
+  version = "~> 20.34"
 
   cluster_name    = local.name
-  cluster_version = "1.31"
+  cluster_version = "1.32"
 
   # Give the Terraform identity admin access to the cluster
   # which will allow it to deploy resources into the cluster
   enable_cluster_creator_admin_permissions = true
   cluster_endpoint_public_access           = true
 
+  # These will become the default in the next major version of the module
+  bootstrap_self_managed_addons   = false
+  enable_irsa                     = false
+  enable_security_groups_for_pods = false
+
   cluster_addons = {
     coredns                = {}
     eks-pod-identity-agent = {}
     kube-proxy             = {}
-    vpc-cni                = {}
+    vpc-cni = {
+      most_recent    = true
+      before_compute = true
+    }
   }
 
   vpc_id     = module.vpc.vpc_id
   subnet_ids = module.vpc.private_subnets
-
-  eks_managed_node_group_defaults = {
-    ebs_optimized = true
-  }
 
   eks_managed_node_groups = {
     gpu = {

--- a/patterns/ml-container-cache/helm.tf
+++ b/patterns/ml-container-cache/helm.tf
@@ -6,22 +6,8 @@ resource "helm_release" "nvidia_device_plugin" {
   name             = "nvidia-device-plugin"
   repository       = "https://nvidia.github.io/k8s-device-plugin"
   chart            = "nvidia-device-plugin"
-  version          = "0.16.2" # Matches image that is cached
+  version          = "0.17.1" # Matches image that is cached
   namespace        = "nvidia-device-plugin"
   create_namespace = true
   wait             = false
-
-  values = [
-    <<-EOT
-      affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-            - matchExpressions:
-              - key: 'nvidia.com/gpu.present'
-                operator: In
-                values:
-                - 'true'
-    EOT
-  ]
 }

--- a/patterns/ml-container-cache/pod-cached.yaml
+++ b/patterns/ml-container-cache/pod-cached.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
     - name: example
-      image: nvcr.io/nvidia/pytorch:24.08-py3
+      image: nvcr.io/nvidia/pytorch:25.02-py3
       imagePullPolicy: IfNotPresent
       command: ['python3']
       args: ['-c', 'import torch; print(torch.cuda.is_available()); print(torch.cuda.device_count())']

--- a/patterns/ml-container-cache/pod-uncached.yaml
+++ b/patterns/ml-container-cache/pod-uncached.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
     - name: example
-      image: nvcr.io/nvidia/pytorch:24.08-py3
+      image: nvcr.io/nvidia/pytorch:25.02-py3
       imagePullPolicy: IfNotPresent
       command: ['python3']
       args: ['-c', 'import torch; print(torch.cuda.is_available()); print(torch.cuda.device_count())']

--- a/patterns/multi-node-vllm/Dockerfile
+++ b/patterns/multi-node-vllm/Dockerfile
@@ -25,14 +25,11 @@ RUN <<EOT
   rm -rf /var/{log,dpkg.log}
 EOT
 
-ARG PYTHON_MINOR_VERSION=11
-
 # vLLM requires python3-dev
-
 RUN <<EOT
   apt update
   apt install -y \
-    python3.${PYTHON_MINOR_VERSION} \
+    python3.11 \
     python3-dev \
     python3-pip \
     python-is-python3

--- a/patterns/multi-node-vllm/README.md
+++ b/patterns/multi-node-vllm/README.md
@@ -22,7 +22,7 @@ The following components are demonstrated in this pattern:
 
 ### Cluster
 
-```terraform hl_lines="30-32 50-97"
+```terraform hl_lines="32-34 52-99"
 {% include  "../../patterns/multi-node-vllm/eks.tf" %}
 ```
 
@@ -34,7 +34,7 @@ The following components are demonstrated in this pattern:
 
 ### Dockerfile
 
-```dockerfile hl_lines="6-69 75-80"
+```dockerfile hl_lines="44-45 48-120"
 {% include  "../../patterns/multi-node-vllm/Dockerfile" %}
 ```
 
@@ -57,10 +57,10 @@ See [here](https://aws-ia.github.io/terraform-aws-eks-blueprints/getting-started
 
     ```text
     NAME                                        STATUS   ROLES    AGE    VERSION               INSTANCE-TYPE
-    ip-10-0-20-54.us-east-2.compute.internal    Ready    <none>   12m    v1.31.4-eks-aeac579   g6e.8xlarge
-    ip-10-0-23-209.us-east-2.compute.internal   Ready    <none>   12m    v1.31.4-eks-aeac579   g6e.8xlarge
-    ip-10-0-26-209.us-east-2.compute.internal   Ready    <none>   12m    v1.31.4-eks-aeac579   m7a.xlarge
-    ip-10-0-40-21.us-east-2.compute.internal    Ready    <none>   12m    v1.31.4-eks-aeac579   m7a.xlarge
+    ip-10-0-20-54.us-east-2.compute.internal    Ready    <none>   12m    v1.32.0-eks-aeac579   g6e.8xlarge
+    ip-10-0-23-209.us-east-2.compute.internal   Ready    <none>   12m    v1.32.0-eks-aeac579   g6e.8xlarge
+    ip-10-0-26-209.us-east-2.compute.internal   Ready    <none>   12m    v1.32.0-eks-aeac579   m7a.xlarge
+    ip-10-0-40-21.us-east-2.compute.internal    Ready    <none>   12m    v1.32.0-eks-aeac579   m7a.xlarge
     ```
 
 2. Verify that the lws, EFA device plugin, and NVIDIA device plugin pods are running:

--- a/patterns/multi-node-vllm/eks.tf
+++ b/patterns/multi-node-vllm/eks.tf
@@ -4,10 +4,10 @@
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 20.33"
+  version = "~> 20.34"
 
   cluster_name    = local.name
-  cluster_version = "1.31"
+  cluster_version = "1.32"
 
   # Gives Terraform identity admin access to cluster which will
   # allow deploying resources into the cluster
@@ -20,9 +20,11 @@ module "eks" {
   enable_security_groups_for_pods = false
 
   cluster_addons = {
-    coredns    = {}
-    kube-proxy = {}
+    coredns                = {}
+    eks-pod-identity-agent = {}
+    kube-proxy             = {}
     vpc-cni = {
+      most_recent    = true
       before_compute = true
     }
   }

--- a/patterns/multi-node-vllm/helm.tf
+++ b/patterns/multi-node-vllm/helm.tf
@@ -6,7 +6,7 @@ resource "helm_release" "nvidia_device_plugin" {
   name             = "nvidia-device-plugin"
   repository       = "https://nvidia.github.io/k8s-device-plugin"
   chart            = "nvidia-device-plugin"
-  version          = "0.17.0"
+  version          = "0.17.1"
   namespace        = "nvidia-device-plugin"
   create_namespace = true
   wait             = false
@@ -37,7 +37,7 @@ resource "helm_release" "aws_efa_device_plugin" {
 ################################################################################
 
 locals {
-  lws_version = "v0.5.0"
+  lws_version = "v0.5.1"
 }
 
 data "http" "lws" {

--- a/patterns/nvidia-gpu-efa/README.md
+++ b/patterns/nvidia-gpu-efa/README.md
@@ -19,7 +19,7 @@ The following components are demonstrated in this pattern:
 
 ### Cluster
 
-```terraform hl_lines="26-28 34-80"
+```terraform hl_lines="32-35 40-86"
 {% include  "../../patterns/nvidia-gpu-efa/eks.tf" %}
 ```
 
@@ -50,10 +50,10 @@ See [here](https://aws-ia.github.io/terraform-aws-eks-blueprints/getting-started
 
     ```text
     NAME                                        STATUS   ROLES    AGE   VERSION               INSTANCE-TYPE
-    ip-10-0-1-16.us-east-2.compute.internal     Ready    <none>   12h   v1.29.3-eks-ae9a62a   p5.48xlarge
-    ip-10-0-12-113.us-east-2.compute.internal   Ready    <none>   14h   v1.29.3-eks-ae9a62a   m5.large
-    ip-10-0-12-201.us-east-2.compute.internal   Ready    <none>   12h   v1.29.3-eks-ae9a62a   p5.48xlarge
-    ip-10-0-46-217.us-east-2.compute.internal   Ready    <none>   14h   v1.29.3-eks-ae9a62a   m5.large
+    ip-10-0-1-16.us-east-2.compute.internal     Ready    <none>   12h   v1.32.0-eks-ae9a62a   p5.48xlarge
+    ip-10-0-12-113.us-east-2.compute.internal   Ready    <none>   14h   v1.32.0-eks-ae9a62a   m5.large
+    ip-10-0-12-201.us-east-2.compute.internal   Ready    <none>   12h   v1.32.0-eks-ae9a62a   p5.48xlarge
+    ip-10-0-46-217.us-east-2.compute.internal   Ready    <none>   14h   v1.32.0-eks-ae9a62a   m5.large
 
     ```
 

--- a/patterns/nvidia-gpu-efa/eks.tf
+++ b/patterns/nvidia-gpu-efa/eks.tf
@@ -4,22 +4,28 @@
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 20.26"
+  version = "~> 20.34"
 
   cluster_name    = local.name
-  cluster_version = "1.31"
+  cluster_version = "1.32"
 
   # Give the Terraform identity admin access to the cluster
   # which will allow it to deploy resources into the cluster
   enable_cluster_creator_admin_permissions = true
   cluster_endpoint_public_access           = true
 
+  # These will become the default in the next major version of the module
+  bootstrap_self_managed_addons   = false
+  enable_irsa                     = false
+  enable_security_groups_for_pods = false
+
   cluster_addons = {
     coredns                = {}
     eks-pod-identity-agent = {}
     kube-proxy             = {}
     vpc-cni = {
-      most_recent = true
+      most_recent    = true
+      before_compute = true
     }
   }
 

--- a/patterns/nvidia-gpu-efa/helm.tf
+++ b/patterns/nvidia-gpu-efa/helm.tf
@@ -6,7 +6,7 @@ resource "helm_release" "nvidia_device_plugin" {
   name             = "nvidia-device-plugin"
   repository       = "https://nvidia.github.io/k8s-device-plugin"
   chart            = "nvidia-device-plugin"
-  version          = "0.16.2"
+  version          = "0.17.1"
   namespace        = "nvidia-device-plugin"
   create_namespace = true
   wait             = false
@@ -16,7 +16,7 @@ resource "helm_release" "aws_efa_device_plugin" {
   name       = "aws-efa-k8s-device-plugin"
   repository = "https://aws.github.io/eks-charts"
   chart      = "aws-efa-k8s-device-plugin"
-  version    = "v0.5.5"
+  version    = "v0.5.7"
   namespace  = "kube-system"
   wait       = false
 

--- a/patterns/targeted-odcr/README.md
+++ b/patterns/targeted-odcr/README.md
@@ -18,7 +18,7 @@ This pattern demonstrates how to consume/utilize on-demand capacity reservations
 
 ## Code
 
-```terraform hl_lines="5-8 94-104 124-147"
+```terraform hl_lines="5-8 100-110 130-153"
 {% include  "../../patterns/targeted-odcr/eks.tf" %}
 ```
 

--- a/patterns/targeted-odcr/eks.tf
+++ b/patterns/targeted-odcr/eks.tf
@@ -13,22 +13,28 @@ variable "capacity_reservation_arns" {
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 20.26"
+  version = "~> 20.34"
 
   cluster_name    = local.name
-  cluster_version = "1.31"
+  cluster_version = "1.32"
 
   # Give the Terraform identity admin access to the cluster
   # which will allow it to deploy resources into the cluster
   enable_cluster_creator_admin_permissions = true
   cluster_endpoint_public_access           = true
 
+  # These will become the default in the next major version of the module
+  bootstrap_self_managed_addons   = false
+  enable_irsa                     = false
+  enable_security_groups_for_pods = false
+
   cluster_addons = {
     coredns                = {}
     eks-pod-identity-agent = {}
     kube-proxy             = {}
     vpc-cni = {
-      most_recent = true
+      most_recent    = true
+      before_compute = true
     }
   }
 

--- a/patterns/targeted-odcr/helm.tf
+++ b/patterns/targeted-odcr/helm.tf
@@ -6,7 +6,7 @@ resource "helm_release" "nvidia_device_plugin" {
   name             = "nvidia-device-plugin"
   repository       = "https://nvidia.github.io/k8s-device-plugin"
   chart            = "nvidia-device-plugin"
-  version          = "0.16.2"
+  version          = "0.17.1"
   namespace        = "nvidia-device-plugin"
   create_namespace = true
   wait             = false
@@ -16,7 +16,7 @@ resource "helm_release" "aws_efa_device_plugin" {
   name       = "aws-efa-k8s-device-plugin"
   repository = "https://aws.github.io/eks-charts"
   chart      = "aws-efa-k8s-device-plugin"
-  version    = "v0.5.5"
+  version    = "v0.5.7"
   namespace  = "kube-system"
   wait       = false
 


### PR DESCRIPTION
# Description

- Update ML pattern dependencies to latest
- Fix asset path for targeted ODCR - currently the images are not rendered correctly on the site https://aws-ia.github.io/terraform-aws-eks-blueprints/patterns/machine-learning/targeted-odcr/#validate
- Remove self-managed node group from ML CBR; we want to encourage customers to use EKS managed node groups

### Motivation and Context

- Ensure latest releases are used and used consistently across the ML patterns

### How was this change tested?

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR

### Additional Notes

<!-- Anything else we should know when reviewing? -->
