### PR TITLE
docs: GitLab Component Reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ related projects that users should be aware of:
    - [`karpenter-blueprints`](https://github.com/aws-samples/karpenter-blueprints) - includes a list of common workload scenarios,
    some of them go in depth with the explanation of why configuring Karpenter and Kubernetes objects in such a way is important.
 
-5. Amazon EKS Blueprints With GitLab Lifecycle Managed Environments CD Component
+5. Amazon EKS Blueprints With GitLab Lifecycle Managed Environments CD Component ([Community Maintained Here](https://gitlab.com/guided-explorations/ci-components/aws/terraform-aws-eks-blueprints))
    - Deploys, Manages, Updates and Destroys EKS Blueprints using GitLab Lifecycle Managed Environments.
    - Terraform code overrides so that environments are named after GitLab branches and project id for global uniqueness within an AWS account and therefore allowing deployment of many clusters in the same AWS Account and Region (especially helpful for classrooms and highly shared developer AWS Accounts)
    - Terraform state is stored on GitLab backend, so the environment becomes a shared team asset

--- a/README.md
+++ b/README.md
@@ -89,6 +89,15 @@ related projects that users should be aware of:
    - [`karpenter-blueprints`](https://github.com/aws-samples/karpenter-blueprints) - includes a list of common workload scenarios,
    some of them go in depth with the explanation of why configuring Karpenter and Kubernetes objects in such a way is important.
 
+5. Amazon EKS Blueprints With GitLab Lifecycle Managed Environments CD Component
+   - Deploys, Manages, Updates and Destroys EKS Blueprints using GitLab Lifecycle Managed Environments.
+   - Terraform code overrides so that environments are named after GitLab branches and project id for global uniqueness within an AWS account and therefore allowing deployment of many clusters in the same AWS Account and Region (especially helpful for classrooms and highly shared developer AWS Accounts)
+   - Terraform state is stored on GitLab backend, so the environment becomes a shared team asset
+   - Can be used to develop new blueprints
+   - Can be used for Developer Self-Service (IDP like) provisioning of EKS Blueprints as a baseline environment
+   - [Amazon EKS Blueprints With GitLab Lifecycle Managed Environments CD Component](https://gitlab.com/explore/catalog/guided-explorations/ci-components/aws/terraform-aws-eks-blueprints) - Click "Readme" tab for further documentation on benefits and features.
+   - [Calling AWS EKS Blueprints CD Component](https://gitlab.com/guided-explorations/ci-components/working-code-examples/calling-aws-eks-blueprints-cd-component) - example of this component being used.
+
 ## Terraform Caveats
 
 EKS Blueprints for Terraform does not intend to teach users the recommended practices for Terraform


### PR DESCRIPTION
# Description

Enable folks to find the GitLab CD Component that can wrap any EKS Blueprint.

### Motivation and Context

<!-- What inspired you to submit this pull request? -->
- Resolves #2092
- Makes blueprint branch based development much easier
- enables developer IDP workflows with a completed EKS Blueprint through GitLab Environments as Code.

### How was this change tested?

While this is a Doc only PR - the target component code was tested here: https://gitlab.com/guided-explorations/ci-components/working-code-examples/calling-aws-eks-blueprints-cd-component/-/pipelines

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR

### Additional Notes

<!-- Anything else we should know when reviewing? -->
