### PR TITLE
fix: Pin AWS and Helm providers max supported version due to new major provider version breaking changes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/streetsidesoftware/cspell-cli
-    rev: v8.17.3
+    rev: v9.0.1
     hooks:
       - id: cspell
         args: [--exclude, 'ADOPTERS.md', --exclude, '.pre-commit-config.yaml', --exclude, '.gitignore', --exclude, '*.drawio', --exclude, 'mkdocs.yml', --exclude, '.helmignore', --exclude, '.github/workflows/*', --exclude, 'patterns/istio-multi-cluster/*', --exclude, 'patterns/blue-green-upgrade/*', --exclude, '/patterns/vpc-lattice/cross-cluster-pod-communication/*', --exclude, 'patterns/bottlerocket/*', --exclude, 'patterns/nvidia-gpu-efa/generate-efa-nccl-test.sh']
@@ -19,7 +19,7 @@ repos:
       - id: detect-aws-credentials
         args: [--allow-missing-credentials]
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.97.4
+    rev: v1.99.4
     hooks:
       - id: terraform_fmt
       - id: terraform_docs

--- a/docs/cSpell_dict.txt
+++ b/docs/cSpell_dict.txt
@@ -20,6 +20,7 @@ argoproj
 athenaaccess
 athenacurcfn
 autoscaler
+automode
 awscli
 awscliv2
 awslabs
@@ -59,6 +60,7 @@ datasource
 dcgm
 distro
 dockerhub
+dshm
 ecrpublic
 ecsdemo
 ecsfrontend
@@ -87,6 +89,7 @@ iedn
 iezn
 ingressgateway
 instanceids
+ingressclass
 ipam
 irsa
 istio
@@ -99,7 +102,9 @@ kubeconfig
 kubecost
 kubeflow
 kubelet
+ktime
 kyverno
+leaderworkerset
 libfabric
 logtag
 loglevel
@@ -114,13 +119,17 @@ mpijobs
 mpirun
 mtls
 nccl
+nvcr
 netcat
 nics
 nodeadm
+nodeclass
 nodegroup
 nodeport
+nodepool
 nopasswd
 nvme
+nvls
 odcr
 oidc
 openmpi
@@ -130,6 +139,7 @@ pkce
 pubkey
 pullthroughcache
 ecrpullthroughcache
+persistentvolumeclaim
 privateca
 privatelink
 prometheusservice
@@ -149,6 +159,7 @@ secretstore
 secretuser
 selfsigned
 serviceaccount
+serverside
 SHA512WITHRSA
 sleepdocs
 ssoadmin
@@ -168,6 +179,7 @@ vpclattice
 webfront
 wontfix
 yamlencode
+vllm
 xlarge
 xonotic
 xrds

--- a/patterns/agones-game-controller/versions.tf
+++ b/patterns/agones-game-controller/versions.tf
@@ -4,11 +4,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.34"
+      version = ">= 5.34, < 6.0"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.9"
+      version = ">= 2.9, < 3.0"
     }
   }
 

--- a/patterns/aws-neuron-efa/main.tf
+++ b/patterns/aws-neuron-efa/main.tf
@@ -4,11 +4,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.70"
+      version = ">= 5.34, < 6.0"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.16"
+      version = ">= 2.9, < 3.0"
     }
   }
 

--- a/patterns/aws-vpc-cni-network-policy/versions.tf
+++ b/patterns/aws-vpc-cni-network-policy/versions.tf
@@ -4,11 +4,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.34"
+      version = ">= 5.34, < 6.0"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.9"
+      version = ">= 2.9, < 3.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/patterns/blue-green-upgrade/eks-blue/providers.tf
+++ b/patterns/blue-green-upgrade/eks-blue/providers.tf
@@ -4,15 +4,15 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0.0"
+      version = ">= 5.34, < 6.0"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = ">= 2.9, < 3.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
       version = ">= 2.20.0"
-    }
-    helm = {
-      source  = "hashicorp/helm"
-      version = ">= 2.9.0"
     }
   }
 }

--- a/patterns/blue-green-upgrade/eks-green/providers.tf
+++ b/patterns/blue-green-upgrade/eks-green/providers.tf
@@ -4,15 +4,15 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0.0"
+      version = ">= 5.34, < 6.0"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = ">= 2.9, < 3.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
       version = ">= 2.20.0"
-    }
-    helm = {
-      source  = "hashicorp/helm"
-      version = ">= 2.9.0"
     }
   }
 }

--- a/patterns/blue-green-upgrade/modules/eks_cluster/versions.tf
+++ b/patterns/blue-green-upgrade/modules/eks_cluster/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0.0"
+      version = ">= 5.34, < 6.0"
     }
 
     kubernetes = {

--- a/patterns/bottlerocket/versions.tf
+++ b/patterns/bottlerocket/versions.tf
@@ -4,11 +4,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = ">= 5.34, < 6.0"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.9"
+      version = ">= 2.9, < 3.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/patterns/ecr-pull-through-cache/main.tf
+++ b/patterns/ecr-pull-through-cache/main.tf
@@ -4,11 +4,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.34"
+      version = ">= 5.34, < 6.0"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.9"
+      version = ">= 2.9, < 3.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/patterns/eks-automode/automode-custom-nodepools/README.md
+++ b/patterns/eks-automode/automode-custom-nodepools/README.md
@@ -36,10 +36,11 @@ NodePool:
 
 Terraform file `eks-automode-config.tf` applies NodeClass and NodePool objects. It also creates the node IAM role and EKS Access Entry for custom nodes, and applies default EBS storage class and AWS LB ingress class.
 
-To add new Node Pools and Node Classes, just add theis yaml files to the folder and update file `eks-automode-config.tf` with the added yaml file names.
+To add new Node Pools and Node Classes, just add the yaml files to the folder and update file `eks-automode-config.tf` with the added yaml file names.
 
 Deploy
 ---
+
 Apply terraform files:
 
 ```bash
@@ -48,6 +49,7 @@ terraform apply
 
 Validate
 ---
+
 Deploy the sample application provided in this pattern to use custom NodePools to provision nodes in the cluster.
 
 ```bash
@@ -78,6 +80,7 @@ ingress.networking.k8s.io/httpd-ingress   alb     *       k8s-sampleap-httpding-
 
 Destroy
 ---
+
 First, remove the sample app and/or any other application that you deployed ot the cluster:
 
 ```bash

--- a/patterns/eks-automode/automode-custom-nodepools/eks-automode-config.tf
+++ b/patterns/eks-automode/automode-custom-nodepools/eks-automode-config.tf
@@ -24,7 +24,7 @@ resource "kubectl_manifest" "storageclass_yamls" {
   yaml_body = file("${path.module}/eks-automode-config/${each.value}")
 }
 
-# Apply default ingress class for EKS AutoMode plus ingress class paramters. AWS Load Balancer Controller runs on AWS side, managed by AWS.
+# Apply default ingress class for EKS AutoMode plus ingress class parameters. AWS Load Balancer Controller runs on AWS side, managed by AWS.
 resource "kubectl_manifest" "ingressclass_yamls" {
   for_each = toset(local.ingressclass_yamls)
 

--- a/patterns/eks-automode/automode-custom-nodepools/main.tf
+++ b/patterns/eks-automode/automode-custom-nodepools/main.tf
@@ -1,26 +1,18 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.3"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.47"
-    }
-    kubernetes = {
-      source  = "hashicorp/kubernetes"
-      version = ">= 2.10"
+      version = ">= 5.34, < 6.0"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.4"
+      version = ">= 2.9, < 3.0"
     }
     kubectl = {
-      source  = "gavinbunney/kubectl"
-      version = ">= 1.14"
-    }
-    random = {
-      source  = "hashicorp/random"
-      version = ">= 3.3"
+      source  = "alekc/kubectl"
+      version = ">= 2.1"
     }
   }
 }

--- a/patterns/external-secrets/versions.tf
+++ b/patterns/external-secrets/versions.tf
@@ -4,11 +4,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.34"
+      version = ">= 5.34, < 6.0"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.9"
+      version = ">= 2.9, < 3.0"
     }
     kubectl = {
       source  = "alekc/kubectl"

--- a/patterns/fargate-serverless/versions.tf
+++ b/patterns/fargate-serverless/versions.tf
@@ -4,11 +4,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.34"
+      version = ">= 5.34, < 6.0"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.9"
+      version = ">= 2.9, < 3.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/patterns/fully-private-cluster/versions.tf
+++ b/patterns/fully-private-cluster/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.34"
+      version = ">= 5.34, < 6.0"
     }
   }
 

--- a/patterns/gitops/getting-started-argocd/versions.tf
+++ b/patterns/gitops/getting-started-argocd/versions.tf
@@ -4,11 +4,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.34"
+      version = ">= 5.34, < 6.0"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.10"
+      version = ">= 2.9, < 3.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/patterns/gitops/multi-cluster-hub-spoke-argocd/hub/versions.tf
+++ b/patterns/gitops/multi-cluster-hub-spoke-argocd/hub/versions.tf
@@ -4,11 +4,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.34"
+      version = ">= 5.34, < 6.0"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.10"
+      version = ">= 2.9, < 3.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/patterns/gitops/multi-cluster-hub-spoke-argocd/spokes/versions.tf
+++ b/patterns/gitops/multi-cluster-hub-spoke-argocd/spokes/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.67.0"
+      version = ">= 5.34, < 6.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/patterns/ipv6-eks-cluster/versions.tf
+++ b/patterns/ipv6-eks-cluster/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.34"
+      version = ">= 5.34, < 6.0"
     }
   }
 

--- a/patterns/istio/versions.tf
+++ b/patterns/istio/versions.tf
@@ -4,11 +4,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.34"
+      version = ">= 5.34, < 6.0"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.9"
+      version = ">= 2.9, < 3.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/patterns/karpenter-mng/main.tf
+++ b/patterns/karpenter-mng/main.tf
@@ -4,11 +4,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.34"
+      version = ">= 5.34, < 6.0"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.9"
+      version = ">= 2.9, < 3.0"
     }
   }
 

--- a/patterns/karpenter/main.tf
+++ b/patterns/karpenter/main.tf
@@ -4,11 +4,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.34"
+      version = ">= 5.34, < 6.0"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.9"
+      version = ">= 2.9, < 3.0"
     }
   }
 

--- a/patterns/kubecost/versions.tf
+++ b/patterns/kubecost/versions.tf
@@ -4,11 +4,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.34"
+      version = ">= 5.34, < 6.0"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.10"
+      version = ">= 2.9, < 3.0"
     }
   }
 

--- a/patterns/ml-capacity-block/main.tf
+++ b/patterns/ml-capacity-block/main.tf
@@ -4,11 +4,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.70"
+      version = ">= 5.34, < 6.0"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.16"
+      version = ">= 2.9, < 3.0"
     }
   }
 

--- a/patterns/ml-container-cache/main.tf
+++ b/patterns/ml-container-cache/main.tf
@@ -4,11 +4,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.34"
+      version = ">= 5.34, < 6.0"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.9"
+      version = ">= 2.9, < 3.0"
     }
   }
 

--- a/patterns/multi-node-vllm/main.tf
+++ b/patterns/multi-node-vllm/main.tf
@@ -4,11 +4,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.38"
+      version = ">= 5.34, < 6.0"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.7"
+      version = ">= 2.9, < 3.0"
     }
     http = {
       source  = "hashicorp/http"

--- a/patterns/multi-tenancy-with-teams/versions.tf
+++ b/patterns/multi-tenancy-with-teams/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.34"
+      version = ">= 5.34, < 6.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/patterns/nvidia-gpu-efa/main.tf
+++ b/patterns/nvidia-gpu-efa/main.tf
@@ -4,11 +4,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.70"
+      version = ">= 5.34, < 6.0"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.16"
+      version = ">= 2.9, < 3.0"
     }
   }
 

--- a/patterns/private-public-ingress/versions.tf
+++ b/patterns/private-public-ingress/versions.tf
@@ -4,11 +4,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.34"
+      version = ">= 5.34, < 6.0"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.9"
+      version = ">= 2.9, < 3.0"
     }
   }
 }

--- a/patterns/privatelink-access/versions.tf
+++ b/patterns/privatelink-access/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.34"
+      version = ">= 5.34, < 6.0"
     }
     dns = {
       source  = "hashicorp/dns"

--- a/patterns/sso-iam-identity-center/versions.tf
+++ b/patterns/sso-iam-identity-center/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.34"
+      version = ">= 5.34, < 6.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/patterns/sso-okta/versions.tf
+++ b/patterns/sso-okta/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.34"
+      version = ">= 5.34, < 6.0"
     }
     okta = {
       source  = "okta/okta"

--- a/patterns/stateful/versions.tf
+++ b/patterns/stateful/versions.tf
@@ -4,11 +4,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.34"
+      version = ">= 5.34, < 6.0"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.9"
+      version = ">= 2.9, < 3.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/patterns/targeted-odcr/main.tf
+++ b/patterns/targeted-odcr/main.tf
@@ -4,11 +4,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.70"
+      version = ">= 5.34, < 6.0"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.16"
+      version = ">= 2.9, < 3.0"
     }
   }
 

--- a/patterns/tls-with-aws-pca-issuer/versions.tf
+++ b/patterns/tls-with-aws-pca-issuer/versions.tf
@@ -4,11 +4,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.34"
+      version = ">= 5.34, < 6.0"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.9"
+      version = ">= 2.9, < 3.0"
     }
     kubectl = {
       source  = "alekc/kubectl"

--- a/patterns/vpc-lattice/client-server-communication/versions.tf
+++ b/patterns/vpc-lattice/client-server-communication/versions.tf
@@ -4,11 +4,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.34"
+      version = ">= 5.34, < 6.0"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.9"
+      version = ">= 2.9, < 3.0"
     }
     time = {
       source  = "hashicorp/time"

--- a/patterns/vpc-lattice/cross-cluster-pod-communication/cluster/versions.tf
+++ b/patterns/vpc-lattice/cross-cluster-pod-communication/cluster/versions.tf
@@ -4,11 +4,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.34"
+      version = ">= 5.34, < 6.0"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.9"
+      version = ">= 2.9, < 3.0"
     }
   }
 }

--- a/patterns/vpc-lattice/cross-cluster-pod-communication/environment/versions.tf
+++ b/patterns/vpc-lattice/cross-cluster-pod-communication/environment/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.34"
+      version = ">= 5.34, < 6.0"
     }
   }
 }

--- a/patterns/wireguard-with-cilium/main.tf
+++ b/patterns/wireguard-with-cilium/main.tf
@@ -4,11 +4,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.34"
+      version = ">= 5.34, < 6.0"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.9"
+      version = ">= 2.9, < 3.0"
     }
   }
 


### PR DESCRIPTION
# Description

- Pin AWS and Helm providers max supported version due to new major provider version breaking changes

- Requires https://github.com/aws-ia/terraform-aws-eks-blueprints-addons/pull/453

### Motivation and Context

- New major provider versions for AWS and Helm which introduce breaking changes. Pinning the required providers will maintain the current functionality prior to these new provider versions

### How was this change tested?

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR

### Additional Notes

<!-- Anything else we should know when reviewing? -->
