### PR TITLE
[ipv6-eks-cluster] update eks version to 1.33 and modules to the current latest version

### DIFF
--- a/patterns/ipv6-eks-cluster/main.tf
+++ b/patterns/ipv6-eks-cluster/main.tf
@@ -29,20 +29,22 @@ locals {
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 20.11"
+  version = "~> 21.0.7"
 
-  cluster_name                   = local.name
-  cluster_version                = "1.30"
-  cluster_endpoint_public_access = true
+  name                   = local.name
+  kubernetes_version     = "1.33"
+  endpoint_public_access = true
 
   # IPV6
-  cluster_ip_family          = "ipv6"
+  ip_family                  = "ipv6"
   create_cni_ipv6_iam_policy = true
 
-  cluster_addons = {
+  addons = {
     coredns    = {}
     kube-proxy = {}
-    vpc-cni    = {}
+    vpc-cni = {
+      before_compute = true
+    }
   }
 
   vpc_id     = module.vpc.vpc_id
@@ -67,7 +69,7 @@ module "eks" {
 
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "~> 5.0"
+  version = "~> 6.0.1"
 
   name = local.name
   cidr = local.vpc_cidr

--- a/patterns/ipv6-eks-cluster/versions.tf
+++ b/patterns/ipv6-eks-cluster/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.34, < 6.0"
+      version = ">= 6.0"
     }
   }
 


### PR DESCRIPTION
# Description


update eks version to 1.33 and modules to the current latest version

### How was this change tested?

- [X] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [N/A ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR

### Additional Notes

