### PR TITLE
feat: Updated VPC configuration to disable DNS64 on the private subnets

### DIFF
--- a/patterns/ipv6-eks-cluster/main.tf
+++ b/patterns/ipv6-eks-cluster/main.tf
@@ -87,6 +87,7 @@ module "vpc" {
   public_subnet_assign_ipv6_address_on_creation  = true
   private_subnet_ipv6_prefixes                   = [3, 4, 5]
   private_subnet_assign_ipv6_address_on_creation = true
+  private_subnet_enable_dns64                    = false
 
   public_subnet_tags = {
     "kubernetes.io/role/elb" = 1


### PR DESCRIPTION
# Description

This change is to disable DNS64 on the private subnets. DNS64 is only needed on the subnets if you are running IPv6 only workloads in the subnet that need to communicate to IPv4 endpoints. Since the CNI plugin is installed (and recommended) on the EKS cluster, the pods have both an IPv4 and IPv6 address. Thus, when DNS64 is enabled on the subnet and a pod is looking to communicate with an only IPv4 endpoint (like a DynamoDB Gateway endpoint) a synthesized IPv6 address is returning thus causing the pod to use the IPv6 address (since it prefers it) which then causes the traffic to go to the NAT Gateway to do the NAT64 translation. This flow through the NAT Gateway, while it works, will unnecessarily drive up NAT Gateway usage.

### Motivation and Context

This issue was encountered by a customer and worked with EKS and Networking SMEs to resolve. The customer had noticed their NAT Gateway usage spiking unexpectedly and after reviewing their setup and many tests, we identified the above as the issue.

### How was this change tested?

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [N/A] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [?] Yes, I ran `pre-commit run -a` with this PR

### Additional Notes

Ran the TF plan and apply and validated that only the private subnets now have DNS64 disabled after the change.
