### PR TITLE
feat: Upgrade Python deprecated runtime for privatelink-access

### DIFF
--- a/patterns/privatelink-access/lambdas/delete_eni.py
+++ b/patterns/privatelink-access/lambdas/delete_eni.py
@@ -42,6 +42,10 @@ def handler(event, context):
             unhealthyTargetIPAddress = targetHealthDescription["Target"]["Id"]
             unhealthyTargetIPAddresses.append(unhealthyTargetIPAddress)
 
+    if not unhealthyTargetIPAddresses:
+        logger.info("There are no unhealthy targets, quitting!")
+        return
+
     networkInterfaces = EC2_CLIENT.describe_network_interfaces(
         Filters=[
             {

--- a/patterns/privatelink-access/privatelink.tf
+++ b/patterns/privatelink-access/privatelink.tf
@@ -136,14 +136,18 @@ resource "aws_route53_record" "client" {
 # Lambda - Create ENI IPs to NLB Target Group
 ################################################################################
 
+locals {
+  lambda_runtime = "python3.13"
+}
+
 module "create_eni_lambda" {
   source  = "terraform-aws-modules/lambda/aws"
-  version = "~> 5.0"
+  version = "7.21.1"
 
   function_name = "${local.name}-add-eni-ips"
   description   = "Add ENI IPs to NLB target group when EKS API endpoint is created"
   handler       = "create_eni.handler"
-  runtime       = "python3.10"
+  runtime       = local.lambda_runtime
   publish       = true
   source_path   = "lambdas"
 
@@ -188,7 +192,7 @@ module "delete_eni_lambda" {
   function_name = "${local.name}-delete-eni-ips"
   description   = "Deletes ENI IPs from NLB target group when EKS API endpoint is deleted"
   handler       = "delete_eni.handler"
-  runtime       = "python3.10"
+  runtime       = local.lambda_runtime
   publish       = true
   source_path   = "lambdas"
 

--- a/patterns/privatelink-access/versions.tf
+++ b/patterns/privatelink-access/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.34, < 6.0"
+      version = ">= 5.79, < 6.0"
     }
     dns = {
       source  = "hashicorp/dns"


### PR DESCRIPTION
# Description
<!--
A brief description of the change being made with this pull request.
-->
This PR updates old Python runtime for Lambda functions provided with `privatelink-access` module.
The upgrade path is from `python3.10` to `python3.13`.


### Motivation and Context
AWS deprecates Python 3.10 runtime starting from **Oct 31, 2026.**
More details are on official page: https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html#runtimes-supported


### How was this change tested?

- [x] Yes, I have tested the PR using my local account setup
- [ ] Yes, I have updated the [docs](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR

### Additional Notes
<!-- Anything else we should know when reviewing? -->
Currently the latest available runtime is `python3.14`.
However, the module still uses old Terraform AWS Provider version `5.x`, which only allows to set `python3.13` as most recent.
The provider version at least `5.78` is required to set this runtime: https://github.com/hashicorp/terraform-provider-aws/blob/v5.78.0/CHANGELOG.md
Also, the `terraform-aws-modules/lambda/aws` module has been updated here to the last published version which still supports AWS Provider 5.x. That is `7.21.1` with the provider requirement of `5.79` at minimum. Upgrading lambda module further will cause broken provider version requirement, so it is fixed to that module version.

In addition, incorporated small fix from my previous PR #2153.